### PR TITLE
Implement getNonce, syncing, protocolVersion, pendingTransactions, chainId methods

### DIFF
--- a/lib/src/model/json_rpc_api/chain_id.dart
+++ b/lib/src/model/json_rpc_api/chain_id.dart
@@ -1,0 +1,21 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'json_rpc_api_error.dart';
+
+part 'chain_id.freezed.dart';
+part 'chain_id.g.dart';
+
+@freezed
+class ChainId with _$ChainId {
+  const factory ChainId.result({
+    required String result,
+  }) = ChainIdResult;
+  const factory ChainId.error({
+    required JsonRpcApiError error,
+  }) = ChainIdError;
+
+  factory ChainId.fromJson(Map<String, Object?> json) =>
+      json.containsKey('error')
+          ? ChainIdError.fromJson(json)
+          : ChainIdResult.fromJson(json);
+}

--- a/lib/src/model/json_rpc_api/chain_id.freezed.dart
+++ b/lib/src/model/json_rpc_api/chain_id.freezed.dart
@@ -1,0 +1,398 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target
+
+part of 'chain_id.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+ChainId _$ChainIdFromJson(Map<String, dynamic> json) {
+  switch (json['runtimeType']) {
+    case 'result':
+      return ChainIdResult.fromJson(json);
+    case 'error':
+      return ChainIdError.fromJson(json);
+
+    default:
+      throw CheckedFromJsonException(json, 'runtimeType', 'ChainId',
+          'Invalid union type "${json['runtimeType']}"!');
+  }
+}
+
+/// @nodoc
+mixin _$ChainId {
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(String result) result,
+    required TResult Function(JsonRpcApiError error) error,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult Function(String result)? result,
+    TResult Function(JsonRpcApiError error)? error,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(String result)? result,
+    TResult Function(JsonRpcApiError error)? error,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(ChainIdResult value) result,
+    required TResult Function(ChainIdError value) error,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult Function(ChainIdResult value)? result,
+    TResult Function(ChainIdError value)? error,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(ChainIdResult value)? result,
+    TResult Function(ChainIdError value)? error,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ChainIdCopyWith<$Res> {
+  factory $ChainIdCopyWith(ChainId value, $Res Function(ChainId) then) =
+      _$ChainIdCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class _$ChainIdCopyWithImpl<$Res> implements $ChainIdCopyWith<$Res> {
+  _$ChainIdCopyWithImpl(this._value, this._then);
+
+  final ChainId _value;
+  // ignore: unused_field
+  final $Res Function(ChainId) _then;
+}
+
+/// @nodoc
+abstract class _$$ChainIdResultCopyWith<$Res> {
+  factory _$$ChainIdResultCopyWith(
+          _$ChainIdResult value, $Res Function(_$ChainIdResult) then) =
+      __$$ChainIdResultCopyWithImpl<$Res>;
+  $Res call({String result});
+}
+
+/// @nodoc
+class __$$ChainIdResultCopyWithImpl<$Res> extends _$ChainIdCopyWithImpl<$Res>
+    implements _$$ChainIdResultCopyWith<$Res> {
+  __$$ChainIdResultCopyWithImpl(
+      _$ChainIdResult _value, $Res Function(_$ChainIdResult) _then)
+      : super(_value, (v) => _then(v as _$ChainIdResult));
+
+  @override
+  _$ChainIdResult get _value => super._value as _$ChainIdResult;
+
+  @override
+  $Res call({
+    Object? result = freezed,
+  }) {
+    return _then(_$ChainIdResult(
+      result: result == freezed
+          ? _value.result
+          : result // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$ChainIdResult implements ChainIdResult {
+  const _$ChainIdResult({required this.result, final String? $type})
+      : $type = $type ?? 'result';
+
+  factory _$ChainIdResult.fromJson(Map<String, dynamic> json) =>
+      _$$ChainIdResultFromJson(json);
+
+  @override
+  final String result;
+
+  @JsonKey(name: 'runtimeType')
+  final String $type;
+
+  @override
+  String toString() {
+    return 'ChainId.result(result: $result)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ChainIdResult &&
+            const DeepCollectionEquality().equals(other.result, result));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, const DeepCollectionEquality().hash(result));
+
+  @JsonKey(ignore: true)
+  @override
+  _$$ChainIdResultCopyWith<_$ChainIdResult> get copyWith =>
+      __$$ChainIdResultCopyWithImpl<_$ChainIdResult>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(String result) result,
+    required TResult Function(JsonRpcApiError error) error,
+  }) {
+    return result(this.result);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult Function(String result)? result,
+    TResult Function(JsonRpcApiError error)? error,
+  }) {
+    return result?.call(this.result);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(String result)? result,
+    TResult Function(JsonRpcApiError error)? error,
+    required TResult orElse(),
+  }) {
+    if (result != null) {
+      return result(this.result);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(ChainIdResult value) result,
+    required TResult Function(ChainIdError value) error,
+  }) {
+    return result(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult Function(ChainIdResult value)? result,
+    TResult Function(ChainIdError value)? error,
+  }) {
+    return result?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(ChainIdResult value)? result,
+    TResult Function(ChainIdError value)? error,
+    required TResult orElse(),
+  }) {
+    if (result != null) {
+      return result(this);
+    }
+    return orElse();
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$ChainIdResultToJson(
+      this,
+    );
+  }
+}
+
+abstract class ChainIdResult implements ChainId {
+  const factory ChainIdResult({required final String result}) = _$ChainIdResult;
+
+  factory ChainIdResult.fromJson(Map<String, dynamic> json) =
+      _$ChainIdResult.fromJson;
+
+  String get result;
+  @JsonKey(ignore: true)
+  _$$ChainIdResultCopyWith<_$ChainIdResult> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$ChainIdErrorCopyWith<$Res> {
+  factory _$$ChainIdErrorCopyWith(
+          _$ChainIdError value, $Res Function(_$ChainIdError) then) =
+      __$$ChainIdErrorCopyWithImpl<$Res>;
+  $Res call({JsonRpcApiError error});
+
+  $JsonRpcApiErrorCopyWith<$Res> get error;
+}
+
+/// @nodoc
+class __$$ChainIdErrorCopyWithImpl<$Res> extends _$ChainIdCopyWithImpl<$Res>
+    implements _$$ChainIdErrorCopyWith<$Res> {
+  __$$ChainIdErrorCopyWithImpl(
+      _$ChainIdError _value, $Res Function(_$ChainIdError) _then)
+      : super(_value, (v) => _then(v as _$ChainIdError));
+
+  @override
+  _$ChainIdError get _value => super._value as _$ChainIdError;
+
+  @override
+  $Res call({
+    Object? error = freezed,
+  }) {
+    return _then(_$ChainIdError(
+      error: error == freezed
+          ? _value.error
+          : error // ignore: cast_nullable_to_non_nullable
+              as JsonRpcApiError,
+    ));
+  }
+
+  @override
+  $JsonRpcApiErrorCopyWith<$Res> get error {
+    return $JsonRpcApiErrorCopyWith<$Res>(_value.error, (value) {
+      return _then(_value.copyWith(error: value));
+    });
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$ChainIdError implements ChainIdError {
+  const _$ChainIdError({required this.error, final String? $type})
+      : $type = $type ?? 'error';
+
+  factory _$ChainIdError.fromJson(Map<String, dynamic> json) =>
+      _$$ChainIdErrorFromJson(json);
+
+  @override
+  final JsonRpcApiError error;
+
+  @JsonKey(name: 'runtimeType')
+  final String $type;
+
+  @override
+  String toString() {
+    return 'ChainId.error(error: $error)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ChainIdError &&
+            const DeepCollectionEquality().equals(other.error, error));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, const DeepCollectionEquality().hash(error));
+
+  @JsonKey(ignore: true)
+  @override
+  _$$ChainIdErrorCopyWith<_$ChainIdError> get copyWith =>
+      __$$ChainIdErrorCopyWithImpl<_$ChainIdError>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(String result) result,
+    required TResult Function(JsonRpcApiError error) error,
+  }) {
+    return error(this.error);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult Function(String result)? result,
+    TResult Function(JsonRpcApiError error)? error,
+  }) {
+    return error?.call(this.error);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(String result)? result,
+    TResult Function(JsonRpcApiError error)? error,
+    required TResult orElse(),
+  }) {
+    if (error != null) {
+      return error(this.error);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(ChainIdResult value) result,
+    required TResult Function(ChainIdError value) error,
+  }) {
+    return error(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult Function(ChainIdResult value)? result,
+    TResult Function(ChainIdError value)? error,
+  }) {
+    return error?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(ChainIdResult value)? result,
+    TResult Function(ChainIdError value)? error,
+    required TResult orElse(),
+  }) {
+    if (error != null) {
+      return error(this);
+    }
+    return orElse();
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$ChainIdErrorToJson(
+      this,
+    );
+  }
+}
+
+abstract class ChainIdError implements ChainId {
+  const factory ChainIdError({required final JsonRpcApiError error}) =
+      _$ChainIdError;
+
+  factory ChainIdError.fromJson(Map<String, dynamic> json) =
+      _$ChainIdError.fromJson;
+
+  JsonRpcApiError get error;
+  @JsonKey(ignore: true)
+  _$$ChainIdErrorCopyWith<_$ChainIdError> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/src/model/json_rpc_api/chain_id.g.dart
+++ b/lib/src/model/json_rpc_api/chain_id.g.dart
@@ -1,0 +1,31 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'chain_id.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$ChainIdResult _$$ChainIdResultFromJson(Map<String, dynamic> json) =>
+    _$ChainIdResult(
+      result: json['result'] as String,
+      $type: json['runtimeType'] as String?,
+    );
+
+Map<String, dynamic> _$$ChainIdResultToJson(_$ChainIdResult instance) =>
+    <String, dynamic>{
+      'result': instance.result,
+      'runtimeType': instance.$type,
+    };
+
+_$ChainIdError _$$ChainIdErrorFromJson(Map<String, dynamic> json) =>
+    _$ChainIdError(
+      error: JsonRpcApiError.fromJson(json['error'] as Map<String, dynamic>),
+      $type: json['runtimeType'] as String?,
+    );
+
+Map<String, dynamic> _$$ChainIdErrorToJson(_$ChainIdError instance) =>
+    <String, dynamic>{
+      'error': instance.error.toJson(),
+      'runtimeType': instance.$type,
+    };

--- a/lib/src/model/json_rpc_api/get_nonce.dart
+++ b/lib/src/model/json_rpc_api/get_nonce.dart
@@ -1,0 +1,22 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import '../../field_element.dart';
+import 'json_rpc_api_error.dart';
+
+part 'get_nonce.freezed.dart';
+part 'get_nonce.g.dart';
+
+@freezed
+class GetNonce with _$GetNonce {
+  const factory GetNonce.result({
+    required StarknetFieldElement result,
+  }) = GetNonceResult;
+  const factory GetNonce.error({
+    required JsonRpcApiError error,
+  }) = GetNonceError;
+
+  factory GetNonce.fromJson(Map<String, Object?> json) =>
+      json.containsKey('error')
+          ? GetNonceError.fromJson(json)
+          : GetNonceResult.fromJson(json);
+}

--- a/lib/src/model/json_rpc_api/get_nonce.freezed.dart
+++ b/lib/src/model/json_rpc_api/get_nonce.freezed.dart
@@ -1,0 +1,399 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target
+
+part of 'get_nonce.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+GetNonce _$GetNonceFromJson(Map<String, dynamic> json) {
+  switch (json['runtimeType']) {
+    case 'result':
+      return GetNonceResult.fromJson(json);
+    case 'error':
+      return GetNonceError.fromJson(json);
+
+    default:
+      throw CheckedFromJsonException(json, 'runtimeType', 'GetNonce',
+          'Invalid union type "${json['runtimeType']}"!');
+  }
+}
+
+/// @nodoc
+mixin _$GetNonce {
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(StarknetFieldElement result) result,
+    required TResult Function(JsonRpcApiError error) error,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult Function(StarknetFieldElement result)? result,
+    TResult Function(JsonRpcApiError error)? error,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(StarknetFieldElement result)? result,
+    TResult Function(JsonRpcApiError error)? error,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(GetNonceResult value) result,
+    required TResult Function(GetNonceError value) error,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult Function(GetNonceResult value)? result,
+    TResult Function(GetNonceError value)? error,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(GetNonceResult value)? result,
+    TResult Function(GetNonceError value)? error,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $GetNonceCopyWith<$Res> {
+  factory $GetNonceCopyWith(GetNonce value, $Res Function(GetNonce) then) =
+      _$GetNonceCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class _$GetNonceCopyWithImpl<$Res> implements $GetNonceCopyWith<$Res> {
+  _$GetNonceCopyWithImpl(this._value, this._then);
+
+  final GetNonce _value;
+  // ignore: unused_field
+  final $Res Function(GetNonce) _then;
+}
+
+/// @nodoc
+abstract class _$$GetNonceResultCopyWith<$Res> {
+  factory _$$GetNonceResultCopyWith(
+          _$GetNonceResult value, $Res Function(_$GetNonceResult) then) =
+      __$$GetNonceResultCopyWithImpl<$Res>;
+  $Res call({StarknetFieldElement result});
+}
+
+/// @nodoc
+class __$$GetNonceResultCopyWithImpl<$Res> extends _$GetNonceCopyWithImpl<$Res>
+    implements _$$GetNonceResultCopyWith<$Res> {
+  __$$GetNonceResultCopyWithImpl(
+      _$GetNonceResult _value, $Res Function(_$GetNonceResult) _then)
+      : super(_value, (v) => _then(v as _$GetNonceResult));
+
+  @override
+  _$GetNonceResult get _value => super._value as _$GetNonceResult;
+
+  @override
+  $Res call({
+    Object? result = freezed,
+  }) {
+    return _then(_$GetNonceResult(
+      result: result == freezed
+          ? _value.result
+          : result // ignore: cast_nullable_to_non_nullable
+              as StarknetFieldElement,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$GetNonceResult implements GetNonceResult {
+  const _$GetNonceResult({required this.result, final String? $type})
+      : $type = $type ?? 'result';
+
+  factory _$GetNonceResult.fromJson(Map<String, dynamic> json) =>
+      _$$GetNonceResultFromJson(json);
+
+  @override
+  final StarknetFieldElement result;
+
+  @JsonKey(name: 'runtimeType')
+  final String $type;
+
+  @override
+  String toString() {
+    return 'GetNonce.result(result: $result)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$GetNonceResult &&
+            const DeepCollectionEquality().equals(other.result, result));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, const DeepCollectionEquality().hash(result));
+
+  @JsonKey(ignore: true)
+  @override
+  _$$GetNonceResultCopyWith<_$GetNonceResult> get copyWith =>
+      __$$GetNonceResultCopyWithImpl<_$GetNonceResult>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(StarknetFieldElement result) result,
+    required TResult Function(JsonRpcApiError error) error,
+  }) {
+    return result(this.result);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult Function(StarknetFieldElement result)? result,
+    TResult Function(JsonRpcApiError error)? error,
+  }) {
+    return result?.call(this.result);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(StarknetFieldElement result)? result,
+    TResult Function(JsonRpcApiError error)? error,
+    required TResult orElse(),
+  }) {
+    if (result != null) {
+      return result(this.result);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(GetNonceResult value) result,
+    required TResult Function(GetNonceError value) error,
+  }) {
+    return result(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult Function(GetNonceResult value)? result,
+    TResult Function(GetNonceError value)? error,
+  }) {
+    return result?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(GetNonceResult value)? result,
+    TResult Function(GetNonceError value)? error,
+    required TResult orElse(),
+  }) {
+    if (result != null) {
+      return result(this);
+    }
+    return orElse();
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$GetNonceResultToJson(
+      this,
+    );
+  }
+}
+
+abstract class GetNonceResult implements GetNonce {
+  const factory GetNonceResult({required final StarknetFieldElement result}) =
+      _$GetNonceResult;
+
+  factory GetNonceResult.fromJson(Map<String, dynamic> json) =
+      _$GetNonceResult.fromJson;
+
+  StarknetFieldElement get result;
+  @JsonKey(ignore: true)
+  _$$GetNonceResultCopyWith<_$GetNonceResult> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$GetNonceErrorCopyWith<$Res> {
+  factory _$$GetNonceErrorCopyWith(
+          _$GetNonceError value, $Res Function(_$GetNonceError) then) =
+      __$$GetNonceErrorCopyWithImpl<$Res>;
+  $Res call({JsonRpcApiError error});
+
+  $JsonRpcApiErrorCopyWith<$Res> get error;
+}
+
+/// @nodoc
+class __$$GetNonceErrorCopyWithImpl<$Res> extends _$GetNonceCopyWithImpl<$Res>
+    implements _$$GetNonceErrorCopyWith<$Res> {
+  __$$GetNonceErrorCopyWithImpl(
+      _$GetNonceError _value, $Res Function(_$GetNonceError) _then)
+      : super(_value, (v) => _then(v as _$GetNonceError));
+
+  @override
+  _$GetNonceError get _value => super._value as _$GetNonceError;
+
+  @override
+  $Res call({
+    Object? error = freezed,
+  }) {
+    return _then(_$GetNonceError(
+      error: error == freezed
+          ? _value.error
+          : error // ignore: cast_nullable_to_non_nullable
+              as JsonRpcApiError,
+    ));
+  }
+
+  @override
+  $JsonRpcApiErrorCopyWith<$Res> get error {
+    return $JsonRpcApiErrorCopyWith<$Res>(_value.error, (value) {
+      return _then(_value.copyWith(error: value));
+    });
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$GetNonceError implements GetNonceError {
+  const _$GetNonceError({required this.error, final String? $type})
+      : $type = $type ?? 'error';
+
+  factory _$GetNonceError.fromJson(Map<String, dynamic> json) =>
+      _$$GetNonceErrorFromJson(json);
+
+  @override
+  final JsonRpcApiError error;
+
+  @JsonKey(name: 'runtimeType')
+  final String $type;
+
+  @override
+  String toString() {
+    return 'GetNonce.error(error: $error)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$GetNonceError &&
+            const DeepCollectionEquality().equals(other.error, error));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, const DeepCollectionEquality().hash(error));
+
+  @JsonKey(ignore: true)
+  @override
+  _$$GetNonceErrorCopyWith<_$GetNonceError> get copyWith =>
+      __$$GetNonceErrorCopyWithImpl<_$GetNonceError>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(StarknetFieldElement result) result,
+    required TResult Function(JsonRpcApiError error) error,
+  }) {
+    return error(this.error);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult Function(StarknetFieldElement result)? result,
+    TResult Function(JsonRpcApiError error)? error,
+  }) {
+    return error?.call(this.error);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(StarknetFieldElement result)? result,
+    TResult Function(JsonRpcApiError error)? error,
+    required TResult orElse(),
+  }) {
+    if (error != null) {
+      return error(this.error);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(GetNonceResult value) result,
+    required TResult Function(GetNonceError value) error,
+  }) {
+    return error(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult Function(GetNonceResult value)? result,
+    TResult Function(GetNonceError value)? error,
+  }) {
+    return error?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(GetNonceResult value)? result,
+    TResult Function(GetNonceError value)? error,
+    required TResult orElse(),
+  }) {
+    if (error != null) {
+      return error(this);
+    }
+    return orElse();
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$GetNonceErrorToJson(
+      this,
+    );
+  }
+}
+
+abstract class GetNonceError implements GetNonce {
+  const factory GetNonceError({required final JsonRpcApiError error}) =
+      _$GetNonceError;
+
+  factory GetNonceError.fromJson(Map<String, dynamic> json) =
+      _$GetNonceError.fromJson;
+
+  JsonRpcApiError get error;
+  @JsonKey(ignore: true)
+  _$$GetNonceErrorCopyWith<_$GetNonceError> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/src/model/json_rpc_api/get_nonce.g.dart
+++ b/lib/src/model/json_rpc_api/get_nonce.g.dart
@@ -1,0 +1,31 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'get_nonce.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$GetNonceResult _$$GetNonceResultFromJson(Map<String, dynamic> json) =>
+    _$GetNonceResult(
+      result: StarknetFieldElement.fromJson(json['result'] as String),
+      $type: json['runtimeType'] as String?,
+    );
+
+Map<String, dynamic> _$$GetNonceResultToJson(_$GetNonceResult instance) =>
+    <String, dynamic>{
+      'result': instance.result.toJson(),
+      'runtimeType': instance.$type,
+    };
+
+_$GetNonceError _$$GetNonceErrorFromJson(Map<String, dynamic> json) =>
+    _$GetNonceError(
+      error: JsonRpcApiError.fromJson(json['error'] as Map<String, dynamic>),
+      $type: json['runtimeType'] as String?,
+    );
+
+Map<String, dynamic> _$$GetNonceErrorToJson(_$GetNonceError instance) =>
+    <String, dynamic>{
+      'error': instance.error.toJson(),
+      'runtimeType': instance.$type,
+    };

--- a/lib/src/model/json_rpc_api/index.dart
+++ b/lib/src/model/json_rpc_api/index.dart
@@ -4,6 +4,7 @@ export 'call.dart';
 export 'chain_id.dart';
 export 'function_call.dart';
 export 'get_block_with_tx_hashes.dart';
+export 'get_nonce.dart';
 export 'get_storage.dart';
 export 'get_transaction.dart';
 export 'get_transaction_receipt.dart';

--- a/lib/src/model/json_rpc_api/index.dart
+++ b/lib/src/model/json_rpc_api/index.dart
@@ -1,9 +1,11 @@
 export 'block_id.dart';
 export 'block_number.dart';
 export 'call.dart';
+export 'chain_id.dart';
 export 'function_call.dart';
 export 'get_block_with_tx_hashes.dart';
 export 'get_storage.dart';
 export 'get_transaction.dart';
 export 'get_transaction_receipt.dart';
 export 'invoke_transaction.dart';
+export 'pending_transactions.dart';

--- a/lib/src/model/json_rpc_api/index.dart
+++ b/lib/src/model/json_rpc_api/index.dart
@@ -9,3 +9,4 @@ export 'get_transaction.dart';
 export 'get_transaction_receipt.dart';
 export 'invoke_transaction.dart';
 export 'pending_transactions.dart';
+export 'protocol_version.dart';

--- a/lib/src/model/json_rpc_api/index.dart
+++ b/lib/src/model/json_rpc_api/index.dart
@@ -10,3 +10,5 @@ export 'get_transaction_receipt.dart';
 export 'invoke_transaction.dart';
 export 'pending_transactions.dart';
 export 'protocol_version.dart';
+export 'sync_status.dart';
+export 'syncing.dart';

--- a/lib/src/model/json_rpc_api/pending_transactions.dart
+++ b/lib/src/model/json_rpc_api/pending_transactions.dart
@@ -1,0 +1,22 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:starknet/starknet.dart';
+
+import 'json_rpc_api_error.dart';
+
+part 'pending_transactions.freezed.dart';
+part 'pending_transactions.g.dart';
+
+@freezed
+class PendingTransactions with _$PendingTransactions {
+  const factory PendingTransactions.result({
+    required List<Txn> result,
+  }) = PendingTransactionsResult;
+  const factory PendingTransactions.error({
+    required JsonRpcApiError error,
+  }) = PendingTransactionsError;
+
+  factory PendingTransactions.fromJson(Map<String, Object?> json) =>
+      json.containsKey('error')
+          ? PendingTransactionsError.fromJson(json)
+          : PendingTransactionsResult.fromJson(json);
+}

--- a/lib/src/model/json_rpc_api/pending_transactions.freezed.dart
+++ b/lib/src/model/json_rpc_api/pending_transactions.freezed.dart
@@ -1,0 +1,415 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target
+
+part of 'pending_transactions.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+PendingTransactions _$PendingTransactionsFromJson(Map<String, dynamic> json) {
+  switch (json['runtimeType']) {
+    case 'result':
+      return PendingTransactionsResult.fromJson(json);
+    case 'error':
+      return PendingTransactionsError.fromJson(json);
+
+    default:
+      throw CheckedFromJsonException(json, 'runtimeType', 'PendingTransactions',
+          'Invalid union type "${json['runtimeType']}"!');
+  }
+}
+
+/// @nodoc
+mixin _$PendingTransactions {
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(List<Txn> result) result,
+    required TResult Function(JsonRpcApiError error) error,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult Function(List<Txn> result)? result,
+    TResult Function(JsonRpcApiError error)? error,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(List<Txn> result)? result,
+    TResult Function(JsonRpcApiError error)? error,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(PendingTransactionsResult value) result,
+    required TResult Function(PendingTransactionsError value) error,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult Function(PendingTransactionsResult value)? result,
+    TResult Function(PendingTransactionsError value)? error,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(PendingTransactionsResult value)? result,
+    TResult Function(PendingTransactionsError value)? error,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $PendingTransactionsCopyWith<$Res> {
+  factory $PendingTransactionsCopyWith(
+          PendingTransactions value, $Res Function(PendingTransactions) then) =
+      _$PendingTransactionsCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class _$PendingTransactionsCopyWithImpl<$Res>
+    implements $PendingTransactionsCopyWith<$Res> {
+  _$PendingTransactionsCopyWithImpl(this._value, this._then);
+
+  final PendingTransactions _value;
+  // ignore: unused_field
+  final $Res Function(PendingTransactions) _then;
+}
+
+/// @nodoc
+abstract class _$$PendingTransactionsResultCopyWith<$Res> {
+  factory _$$PendingTransactionsResultCopyWith(
+          _$PendingTransactionsResult value,
+          $Res Function(_$PendingTransactionsResult) then) =
+      __$$PendingTransactionsResultCopyWithImpl<$Res>;
+  $Res call({List<Txn> result});
+}
+
+/// @nodoc
+class __$$PendingTransactionsResultCopyWithImpl<$Res>
+    extends _$PendingTransactionsCopyWithImpl<$Res>
+    implements _$$PendingTransactionsResultCopyWith<$Res> {
+  __$$PendingTransactionsResultCopyWithImpl(_$PendingTransactionsResult _value,
+      $Res Function(_$PendingTransactionsResult) _then)
+      : super(_value, (v) => _then(v as _$PendingTransactionsResult));
+
+  @override
+  _$PendingTransactionsResult get _value =>
+      super._value as _$PendingTransactionsResult;
+
+  @override
+  $Res call({
+    Object? result = freezed,
+  }) {
+    return _then(_$PendingTransactionsResult(
+      result: result == freezed
+          ? _value._result
+          : result // ignore: cast_nullable_to_non_nullable
+              as List<Txn>,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$PendingTransactionsResult implements PendingTransactionsResult {
+  const _$PendingTransactionsResult(
+      {required final List<Txn> result, final String? $type})
+      : _result = result,
+        $type = $type ?? 'result';
+
+  factory _$PendingTransactionsResult.fromJson(Map<String, dynamic> json) =>
+      _$$PendingTransactionsResultFromJson(json);
+
+  final List<Txn> _result;
+  @override
+  List<Txn> get result {
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_result);
+  }
+
+  @JsonKey(name: 'runtimeType')
+  final String $type;
+
+  @override
+  String toString() {
+    return 'PendingTransactions.result(result: $result)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$PendingTransactionsResult &&
+            const DeepCollectionEquality().equals(other._result, _result));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, const DeepCollectionEquality().hash(_result));
+
+  @JsonKey(ignore: true)
+  @override
+  _$$PendingTransactionsResultCopyWith<_$PendingTransactionsResult>
+      get copyWith => __$$PendingTransactionsResultCopyWithImpl<
+          _$PendingTransactionsResult>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(List<Txn> result) result,
+    required TResult Function(JsonRpcApiError error) error,
+  }) {
+    return result(this.result);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult Function(List<Txn> result)? result,
+    TResult Function(JsonRpcApiError error)? error,
+  }) {
+    return result?.call(this.result);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(List<Txn> result)? result,
+    TResult Function(JsonRpcApiError error)? error,
+    required TResult orElse(),
+  }) {
+    if (result != null) {
+      return result(this.result);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(PendingTransactionsResult value) result,
+    required TResult Function(PendingTransactionsError value) error,
+  }) {
+    return result(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult Function(PendingTransactionsResult value)? result,
+    TResult Function(PendingTransactionsError value)? error,
+  }) {
+    return result?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(PendingTransactionsResult value)? result,
+    TResult Function(PendingTransactionsError value)? error,
+    required TResult orElse(),
+  }) {
+    if (result != null) {
+      return result(this);
+    }
+    return orElse();
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$PendingTransactionsResultToJson(
+      this,
+    );
+  }
+}
+
+abstract class PendingTransactionsResult implements PendingTransactions {
+  const factory PendingTransactionsResult({required final List<Txn> result}) =
+      _$PendingTransactionsResult;
+
+  factory PendingTransactionsResult.fromJson(Map<String, dynamic> json) =
+      _$PendingTransactionsResult.fromJson;
+
+  List<Txn> get result;
+  @JsonKey(ignore: true)
+  _$$PendingTransactionsResultCopyWith<_$PendingTransactionsResult>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$PendingTransactionsErrorCopyWith<$Res> {
+  factory _$$PendingTransactionsErrorCopyWith(_$PendingTransactionsError value,
+          $Res Function(_$PendingTransactionsError) then) =
+      __$$PendingTransactionsErrorCopyWithImpl<$Res>;
+  $Res call({JsonRpcApiError error});
+
+  $JsonRpcApiErrorCopyWith<$Res> get error;
+}
+
+/// @nodoc
+class __$$PendingTransactionsErrorCopyWithImpl<$Res>
+    extends _$PendingTransactionsCopyWithImpl<$Res>
+    implements _$$PendingTransactionsErrorCopyWith<$Res> {
+  __$$PendingTransactionsErrorCopyWithImpl(_$PendingTransactionsError _value,
+      $Res Function(_$PendingTransactionsError) _then)
+      : super(_value, (v) => _then(v as _$PendingTransactionsError));
+
+  @override
+  _$PendingTransactionsError get _value =>
+      super._value as _$PendingTransactionsError;
+
+  @override
+  $Res call({
+    Object? error = freezed,
+  }) {
+    return _then(_$PendingTransactionsError(
+      error: error == freezed
+          ? _value.error
+          : error // ignore: cast_nullable_to_non_nullable
+              as JsonRpcApiError,
+    ));
+  }
+
+  @override
+  $JsonRpcApiErrorCopyWith<$Res> get error {
+    return $JsonRpcApiErrorCopyWith<$Res>(_value.error, (value) {
+      return _then(_value.copyWith(error: value));
+    });
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$PendingTransactionsError implements PendingTransactionsError {
+  const _$PendingTransactionsError({required this.error, final String? $type})
+      : $type = $type ?? 'error';
+
+  factory _$PendingTransactionsError.fromJson(Map<String, dynamic> json) =>
+      _$$PendingTransactionsErrorFromJson(json);
+
+  @override
+  final JsonRpcApiError error;
+
+  @JsonKey(name: 'runtimeType')
+  final String $type;
+
+  @override
+  String toString() {
+    return 'PendingTransactions.error(error: $error)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$PendingTransactionsError &&
+            const DeepCollectionEquality().equals(other.error, error));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, const DeepCollectionEquality().hash(error));
+
+  @JsonKey(ignore: true)
+  @override
+  _$$PendingTransactionsErrorCopyWith<_$PendingTransactionsError>
+      get copyWith =>
+          __$$PendingTransactionsErrorCopyWithImpl<_$PendingTransactionsError>(
+              this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(List<Txn> result) result,
+    required TResult Function(JsonRpcApiError error) error,
+  }) {
+    return error(this.error);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult Function(List<Txn> result)? result,
+    TResult Function(JsonRpcApiError error)? error,
+  }) {
+    return error?.call(this.error);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(List<Txn> result)? result,
+    TResult Function(JsonRpcApiError error)? error,
+    required TResult orElse(),
+  }) {
+    if (error != null) {
+      return error(this.error);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(PendingTransactionsResult value) result,
+    required TResult Function(PendingTransactionsError value) error,
+  }) {
+    return error(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult Function(PendingTransactionsResult value)? result,
+    TResult Function(PendingTransactionsError value)? error,
+  }) {
+    return error?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(PendingTransactionsResult value)? result,
+    TResult Function(PendingTransactionsError value)? error,
+    required TResult orElse(),
+  }) {
+    if (error != null) {
+      return error(this);
+    }
+    return orElse();
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$PendingTransactionsErrorToJson(
+      this,
+    );
+  }
+}
+
+abstract class PendingTransactionsError implements PendingTransactions {
+  const factory PendingTransactionsError(
+      {required final JsonRpcApiError error}) = _$PendingTransactionsError;
+
+  factory PendingTransactionsError.fromJson(Map<String, dynamic> json) =
+      _$PendingTransactionsError.fromJson;
+
+  JsonRpcApiError get error;
+  @JsonKey(ignore: true)
+  _$$PendingTransactionsErrorCopyWith<_$PendingTransactionsError>
+      get copyWith => throw _privateConstructorUsedError;
+}

--- a/lib/src/model/json_rpc_api/pending_transactions.g.dart
+++ b/lib/src/model/json_rpc_api/pending_transactions.g.dart
@@ -1,0 +1,37 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'pending_transactions.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$PendingTransactionsResult _$$PendingTransactionsResultFromJson(
+        Map<String, dynamic> json) =>
+    _$PendingTransactionsResult(
+      result: (json['result'] as List<dynamic>)
+          .map((e) => Txn.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      $type: json['runtimeType'] as String?,
+    );
+
+Map<String, dynamic> _$$PendingTransactionsResultToJson(
+        _$PendingTransactionsResult instance) =>
+    <String, dynamic>{
+      'result': instance.result.map((e) => e.toJson()).toList(),
+      'runtimeType': instance.$type,
+    };
+
+_$PendingTransactionsError _$$PendingTransactionsErrorFromJson(
+        Map<String, dynamic> json) =>
+    _$PendingTransactionsError(
+      error: JsonRpcApiError.fromJson(json['error'] as Map<String, dynamic>),
+      $type: json['runtimeType'] as String?,
+    );
+
+Map<String, dynamic> _$$PendingTransactionsErrorToJson(
+        _$PendingTransactionsError instance) =>
+    <String, dynamic>{
+      'error': instance.error.toJson(),
+      'runtimeType': instance.$type,
+    };

--- a/lib/src/model/json_rpc_api/protocol_version.dart
+++ b/lib/src/model/json_rpc_api/protocol_version.dart
@@ -1,0 +1,21 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'json_rpc_api_error.dart';
+
+part 'protocol_version.freezed.dart';
+part 'protocol_version.g.dart';
+
+@freezed
+class ProtocolVersion with _$ProtocolVersion {
+  const factory ProtocolVersion.result({
+    required String protocolVersion,
+  }) = ProtocolVersionResult;
+  const factory ProtocolVersion.error({
+    required JsonRpcApiError error,
+  }) = ProtocolVersionError;
+
+  factory ProtocolVersion.fromJson(Map<String, Object?> json) =>
+      json.containsKey('error')
+          ? ProtocolVersionError.fromJson(json)
+          : ProtocolVersionResult.fromJson(json);
+}

--- a/lib/src/model/json_rpc_api/protocol_version.freezed.dart
+++ b/lib/src/model/json_rpc_api/protocol_version.freezed.dart
@@ -1,0 +1,407 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target
+
+part of 'protocol_version.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+ProtocolVersion _$ProtocolVersionFromJson(Map<String, dynamic> json) {
+  switch (json['runtimeType']) {
+    case 'result':
+      return ProtocolVersionResult.fromJson(json);
+    case 'error':
+      return ProtocolVersionError.fromJson(json);
+
+    default:
+      throw CheckedFromJsonException(json, 'runtimeType', 'ProtocolVersion',
+          'Invalid union type "${json['runtimeType']}"!');
+  }
+}
+
+/// @nodoc
+mixin _$ProtocolVersion {
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(String protocolVersion) result,
+    required TResult Function(JsonRpcApiError error) error,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult Function(String protocolVersion)? result,
+    TResult Function(JsonRpcApiError error)? error,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(String protocolVersion)? result,
+    TResult Function(JsonRpcApiError error)? error,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(ProtocolVersionResult value) result,
+    required TResult Function(ProtocolVersionError value) error,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult Function(ProtocolVersionResult value)? result,
+    TResult Function(ProtocolVersionError value)? error,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(ProtocolVersionResult value)? result,
+    TResult Function(ProtocolVersionError value)? error,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ProtocolVersionCopyWith<$Res> {
+  factory $ProtocolVersionCopyWith(
+          ProtocolVersion value, $Res Function(ProtocolVersion) then) =
+      _$ProtocolVersionCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class _$ProtocolVersionCopyWithImpl<$Res>
+    implements $ProtocolVersionCopyWith<$Res> {
+  _$ProtocolVersionCopyWithImpl(this._value, this._then);
+
+  final ProtocolVersion _value;
+  // ignore: unused_field
+  final $Res Function(ProtocolVersion) _then;
+}
+
+/// @nodoc
+abstract class _$$ProtocolVersionResultCopyWith<$Res> {
+  factory _$$ProtocolVersionResultCopyWith(_$ProtocolVersionResult value,
+          $Res Function(_$ProtocolVersionResult) then) =
+      __$$ProtocolVersionResultCopyWithImpl<$Res>;
+  $Res call({String protocolVersion});
+}
+
+/// @nodoc
+class __$$ProtocolVersionResultCopyWithImpl<$Res>
+    extends _$ProtocolVersionCopyWithImpl<$Res>
+    implements _$$ProtocolVersionResultCopyWith<$Res> {
+  __$$ProtocolVersionResultCopyWithImpl(_$ProtocolVersionResult _value,
+      $Res Function(_$ProtocolVersionResult) _then)
+      : super(_value, (v) => _then(v as _$ProtocolVersionResult));
+
+  @override
+  _$ProtocolVersionResult get _value => super._value as _$ProtocolVersionResult;
+
+  @override
+  $Res call({
+    Object? protocolVersion = freezed,
+  }) {
+    return _then(_$ProtocolVersionResult(
+      protocolVersion: protocolVersion == freezed
+          ? _value.protocolVersion
+          : protocolVersion // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$ProtocolVersionResult implements ProtocolVersionResult {
+  const _$ProtocolVersionResult(
+      {required this.protocolVersion, final String? $type})
+      : $type = $type ?? 'result';
+
+  factory _$ProtocolVersionResult.fromJson(Map<String, dynamic> json) =>
+      _$$ProtocolVersionResultFromJson(json);
+
+  @override
+  final String protocolVersion;
+
+  @JsonKey(name: 'runtimeType')
+  final String $type;
+
+  @override
+  String toString() {
+    return 'ProtocolVersion.result(protocolVersion: $protocolVersion)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ProtocolVersionResult &&
+            const DeepCollectionEquality()
+                .equals(other.protocolVersion, protocolVersion));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType, const DeepCollectionEquality().hash(protocolVersion));
+
+  @JsonKey(ignore: true)
+  @override
+  _$$ProtocolVersionResultCopyWith<_$ProtocolVersionResult> get copyWith =>
+      __$$ProtocolVersionResultCopyWithImpl<_$ProtocolVersionResult>(
+          this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(String protocolVersion) result,
+    required TResult Function(JsonRpcApiError error) error,
+  }) {
+    return result(protocolVersion);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult Function(String protocolVersion)? result,
+    TResult Function(JsonRpcApiError error)? error,
+  }) {
+    return result?.call(protocolVersion);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(String protocolVersion)? result,
+    TResult Function(JsonRpcApiError error)? error,
+    required TResult orElse(),
+  }) {
+    if (result != null) {
+      return result(protocolVersion);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(ProtocolVersionResult value) result,
+    required TResult Function(ProtocolVersionError value) error,
+  }) {
+    return result(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult Function(ProtocolVersionResult value)? result,
+    TResult Function(ProtocolVersionError value)? error,
+  }) {
+    return result?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(ProtocolVersionResult value)? result,
+    TResult Function(ProtocolVersionError value)? error,
+    required TResult orElse(),
+  }) {
+    if (result != null) {
+      return result(this);
+    }
+    return orElse();
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$ProtocolVersionResultToJson(
+      this,
+    );
+  }
+}
+
+abstract class ProtocolVersionResult implements ProtocolVersion {
+  const factory ProtocolVersionResult({required final String protocolVersion}) =
+      _$ProtocolVersionResult;
+
+  factory ProtocolVersionResult.fromJson(Map<String, dynamic> json) =
+      _$ProtocolVersionResult.fromJson;
+
+  String get protocolVersion;
+  @JsonKey(ignore: true)
+  _$$ProtocolVersionResultCopyWith<_$ProtocolVersionResult> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$ProtocolVersionErrorCopyWith<$Res> {
+  factory _$$ProtocolVersionErrorCopyWith(_$ProtocolVersionError value,
+          $Res Function(_$ProtocolVersionError) then) =
+      __$$ProtocolVersionErrorCopyWithImpl<$Res>;
+  $Res call({JsonRpcApiError error});
+
+  $JsonRpcApiErrorCopyWith<$Res> get error;
+}
+
+/// @nodoc
+class __$$ProtocolVersionErrorCopyWithImpl<$Res>
+    extends _$ProtocolVersionCopyWithImpl<$Res>
+    implements _$$ProtocolVersionErrorCopyWith<$Res> {
+  __$$ProtocolVersionErrorCopyWithImpl(_$ProtocolVersionError _value,
+      $Res Function(_$ProtocolVersionError) _then)
+      : super(_value, (v) => _then(v as _$ProtocolVersionError));
+
+  @override
+  _$ProtocolVersionError get _value => super._value as _$ProtocolVersionError;
+
+  @override
+  $Res call({
+    Object? error = freezed,
+  }) {
+    return _then(_$ProtocolVersionError(
+      error: error == freezed
+          ? _value.error
+          : error // ignore: cast_nullable_to_non_nullable
+              as JsonRpcApiError,
+    ));
+  }
+
+  @override
+  $JsonRpcApiErrorCopyWith<$Res> get error {
+    return $JsonRpcApiErrorCopyWith<$Res>(_value.error, (value) {
+      return _then(_value.copyWith(error: value));
+    });
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$ProtocolVersionError implements ProtocolVersionError {
+  const _$ProtocolVersionError({required this.error, final String? $type})
+      : $type = $type ?? 'error';
+
+  factory _$ProtocolVersionError.fromJson(Map<String, dynamic> json) =>
+      _$$ProtocolVersionErrorFromJson(json);
+
+  @override
+  final JsonRpcApiError error;
+
+  @JsonKey(name: 'runtimeType')
+  final String $type;
+
+  @override
+  String toString() {
+    return 'ProtocolVersion.error(error: $error)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ProtocolVersionError &&
+            const DeepCollectionEquality().equals(other.error, error));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, const DeepCollectionEquality().hash(error));
+
+  @JsonKey(ignore: true)
+  @override
+  _$$ProtocolVersionErrorCopyWith<_$ProtocolVersionError> get copyWith =>
+      __$$ProtocolVersionErrorCopyWithImpl<_$ProtocolVersionError>(
+          this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(String protocolVersion) result,
+    required TResult Function(JsonRpcApiError error) error,
+  }) {
+    return error(this.error);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult Function(String protocolVersion)? result,
+    TResult Function(JsonRpcApiError error)? error,
+  }) {
+    return error?.call(this.error);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(String protocolVersion)? result,
+    TResult Function(JsonRpcApiError error)? error,
+    required TResult orElse(),
+  }) {
+    if (error != null) {
+      return error(this.error);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(ProtocolVersionResult value) result,
+    required TResult Function(ProtocolVersionError value) error,
+  }) {
+    return error(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult Function(ProtocolVersionResult value)? result,
+    TResult Function(ProtocolVersionError value)? error,
+  }) {
+    return error?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(ProtocolVersionResult value)? result,
+    TResult Function(ProtocolVersionError value)? error,
+    required TResult orElse(),
+  }) {
+    if (error != null) {
+      return error(this);
+    }
+    return orElse();
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$ProtocolVersionErrorToJson(
+      this,
+    );
+  }
+}
+
+abstract class ProtocolVersionError implements ProtocolVersion {
+  const factory ProtocolVersionError({required final JsonRpcApiError error}) =
+      _$ProtocolVersionError;
+
+  factory ProtocolVersionError.fromJson(Map<String, dynamic> json) =
+      _$ProtocolVersionError.fromJson;
+
+  JsonRpcApiError get error;
+  @JsonKey(ignore: true)
+  _$$ProtocolVersionErrorCopyWith<_$ProtocolVersionError> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/src/model/json_rpc_api/protocol_version.g.dart
+++ b/lib/src/model/json_rpc_api/protocol_version.g.dart
@@ -1,0 +1,35 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'protocol_version.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$ProtocolVersionResult _$$ProtocolVersionResultFromJson(
+        Map<String, dynamic> json) =>
+    _$ProtocolVersionResult(
+      protocolVersion: json['protocol_version'] as String,
+      $type: json['runtimeType'] as String?,
+    );
+
+Map<String, dynamic> _$$ProtocolVersionResultToJson(
+        _$ProtocolVersionResult instance) =>
+    <String, dynamic>{
+      'protocol_version': instance.protocolVersion,
+      'runtimeType': instance.$type,
+    };
+
+_$ProtocolVersionError _$$ProtocolVersionErrorFromJson(
+        Map<String, dynamic> json) =>
+    _$ProtocolVersionError(
+      error: JsonRpcApiError.fromJson(json['error'] as Map<String, dynamic>),
+      $type: json['runtimeType'] as String?,
+    );
+
+Map<String, dynamic> _$$ProtocolVersionErrorToJson(
+        _$ProtocolVersionError instance) =>
+    <String, dynamic>{
+      'error': instance.error.toJson(),
+      'runtimeType': instance.$type,
+    };

--- a/lib/src/model/json_rpc_api/sync_status.dart
+++ b/lib/src/model/json_rpc_api/sync_status.dart
@@ -1,0 +1,20 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:starknet/starknet.dart';
+
+part 'sync_status.freezed.dart';
+part 'sync_status.g.dart';
+
+@freezed
+class SyncStatus with _$SyncStatus {
+  const factory SyncStatus({
+    required StarknetFieldElement startingBlockHash,
+    required String startingBlockNum,
+    required StarknetFieldElement currentBlockHash,
+    required String currentBlockNum,
+    required StarknetFieldElement highestBlockHash,
+    required String highestBlockNum,
+  }) = _SyncStatus;
+
+  factory SyncStatus.fromJson(Map<String, Object?> json) =>
+      _$SyncStatusFromJson(json);
+}

--- a/lib/src/model/json_rpc_api/sync_status.freezed.dart
+++ b/lib/src/model/json_rpc_api/sync_status.freezed.dart
@@ -1,0 +1,266 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target
+
+part of 'sync_status.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+SyncStatus _$SyncStatusFromJson(Map<String, dynamic> json) {
+  return _SyncStatus.fromJson(json);
+}
+
+/// @nodoc
+mixin _$SyncStatus {
+  StarknetFieldElement get startingBlockHash =>
+      throw _privateConstructorUsedError;
+  String get startingBlockNum => throw _privateConstructorUsedError;
+  StarknetFieldElement get currentBlockHash =>
+      throw _privateConstructorUsedError;
+  String get currentBlockNum => throw _privateConstructorUsedError;
+  StarknetFieldElement get highestBlockHash =>
+      throw _privateConstructorUsedError;
+  String get highestBlockNum => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $SyncStatusCopyWith<SyncStatus> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $SyncStatusCopyWith<$Res> {
+  factory $SyncStatusCopyWith(
+          SyncStatus value, $Res Function(SyncStatus) then) =
+      _$SyncStatusCopyWithImpl<$Res>;
+  $Res call(
+      {StarknetFieldElement startingBlockHash,
+      String startingBlockNum,
+      StarknetFieldElement currentBlockHash,
+      String currentBlockNum,
+      StarknetFieldElement highestBlockHash,
+      String highestBlockNum});
+}
+
+/// @nodoc
+class _$SyncStatusCopyWithImpl<$Res> implements $SyncStatusCopyWith<$Res> {
+  _$SyncStatusCopyWithImpl(this._value, this._then);
+
+  final SyncStatus _value;
+  // ignore: unused_field
+  final $Res Function(SyncStatus) _then;
+
+  @override
+  $Res call({
+    Object? startingBlockHash = freezed,
+    Object? startingBlockNum = freezed,
+    Object? currentBlockHash = freezed,
+    Object? currentBlockNum = freezed,
+    Object? highestBlockHash = freezed,
+    Object? highestBlockNum = freezed,
+  }) {
+    return _then(_value.copyWith(
+      startingBlockHash: startingBlockHash == freezed
+          ? _value.startingBlockHash
+          : startingBlockHash // ignore: cast_nullable_to_non_nullable
+              as StarknetFieldElement,
+      startingBlockNum: startingBlockNum == freezed
+          ? _value.startingBlockNum
+          : startingBlockNum // ignore: cast_nullable_to_non_nullable
+              as String,
+      currentBlockHash: currentBlockHash == freezed
+          ? _value.currentBlockHash
+          : currentBlockHash // ignore: cast_nullable_to_non_nullable
+              as StarknetFieldElement,
+      currentBlockNum: currentBlockNum == freezed
+          ? _value.currentBlockNum
+          : currentBlockNum // ignore: cast_nullable_to_non_nullable
+              as String,
+      highestBlockHash: highestBlockHash == freezed
+          ? _value.highestBlockHash
+          : highestBlockHash // ignore: cast_nullable_to_non_nullable
+              as StarknetFieldElement,
+      highestBlockNum: highestBlockNum == freezed
+          ? _value.highestBlockNum
+          : highestBlockNum // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+abstract class _$$_SyncStatusCopyWith<$Res>
+    implements $SyncStatusCopyWith<$Res> {
+  factory _$$_SyncStatusCopyWith(
+          _$_SyncStatus value, $Res Function(_$_SyncStatus) then) =
+      __$$_SyncStatusCopyWithImpl<$Res>;
+  @override
+  $Res call(
+      {StarknetFieldElement startingBlockHash,
+      String startingBlockNum,
+      StarknetFieldElement currentBlockHash,
+      String currentBlockNum,
+      StarknetFieldElement highestBlockHash,
+      String highestBlockNum});
+}
+
+/// @nodoc
+class __$$_SyncStatusCopyWithImpl<$Res> extends _$SyncStatusCopyWithImpl<$Res>
+    implements _$$_SyncStatusCopyWith<$Res> {
+  __$$_SyncStatusCopyWithImpl(
+      _$_SyncStatus _value, $Res Function(_$_SyncStatus) _then)
+      : super(_value, (v) => _then(v as _$_SyncStatus));
+
+  @override
+  _$_SyncStatus get _value => super._value as _$_SyncStatus;
+
+  @override
+  $Res call({
+    Object? startingBlockHash = freezed,
+    Object? startingBlockNum = freezed,
+    Object? currentBlockHash = freezed,
+    Object? currentBlockNum = freezed,
+    Object? highestBlockHash = freezed,
+    Object? highestBlockNum = freezed,
+  }) {
+    return _then(_$_SyncStatus(
+      startingBlockHash: startingBlockHash == freezed
+          ? _value.startingBlockHash
+          : startingBlockHash // ignore: cast_nullable_to_non_nullable
+              as StarknetFieldElement,
+      startingBlockNum: startingBlockNum == freezed
+          ? _value.startingBlockNum
+          : startingBlockNum // ignore: cast_nullable_to_non_nullable
+              as String,
+      currentBlockHash: currentBlockHash == freezed
+          ? _value.currentBlockHash
+          : currentBlockHash // ignore: cast_nullable_to_non_nullable
+              as StarknetFieldElement,
+      currentBlockNum: currentBlockNum == freezed
+          ? _value.currentBlockNum
+          : currentBlockNum // ignore: cast_nullable_to_non_nullable
+              as String,
+      highestBlockHash: highestBlockHash == freezed
+          ? _value.highestBlockHash
+          : highestBlockHash // ignore: cast_nullable_to_non_nullable
+              as StarknetFieldElement,
+      highestBlockNum: highestBlockNum == freezed
+          ? _value.highestBlockNum
+          : highestBlockNum // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$_SyncStatus implements _SyncStatus {
+  const _$_SyncStatus(
+      {required this.startingBlockHash,
+      required this.startingBlockNum,
+      required this.currentBlockHash,
+      required this.currentBlockNum,
+      required this.highestBlockHash,
+      required this.highestBlockNum});
+
+  factory _$_SyncStatus.fromJson(Map<String, dynamic> json) =>
+      _$$_SyncStatusFromJson(json);
+
+  @override
+  final StarknetFieldElement startingBlockHash;
+  @override
+  final String startingBlockNum;
+  @override
+  final StarknetFieldElement currentBlockHash;
+  @override
+  final String currentBlockNum;
+  @override
+  final StarknetFieldElement highestBlockHash;
+  @override
+  final String highestBlockNum;
+
+  @override
+  String toString() {
+    return 'SyncStatus(startingBlockHash: $startingBlockHash, startingBlockNum: $startingBlockNum, currentBlockHash: $currentBlockHash, currentBlockNum: $currentBlockNum, highestBlockHash: $highestBlockHash, highestBlockNum: $highestBlockNum)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_SyncStatus &&
+            const DeepCollectionEquality()
+                .equals(other.startingBlockHash, startingBlockHash) &&
+            const DeepCollectionEquality()
+                .equals(other.startingBlockNum, startingBlockNum) &&
+            const DeepCollectionEquality()
+                .equals(other.currentBlockHash, currentBlockHash) &&
+            const DeepCollectionEquality()
+                .equals(other.currentBlockNum, currentBlockNum) &&
+            const DeepCollectionEquality()
+                .equals(other.highestBlockHash, highestBlockHash) &&
+            const DeepCollectionEquality()
+                .equals(other.highestBlockNum, highestBlockNum));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(startingBlockHash),
+      const DeepCollectionEquality().hash(startingBlockNum),
+      const DeepCollectionEquality().hash(currentBlockHash),
+      const DeepCollectionEquality().hash(currentBlockNum),
+      const DeepCollectionEquality().hash(highestBlockHash),
+      const DeepCollectionEquality().hash(highestBlockNum));
+
+  @JsonKey(ignore: true)
+  @override
+  _$$_SyncStatusCopyWith<_$_SyncStatus> get copyWith =>
+      __$$_SyncStatusCopyWithImpl<_$_SyncStatus>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$_SyncStatusToJson(
+      this,
+    );
+  }
+}
+
+abstract class _SyncStatus implements SyncStatus {
+  const factory _SyncStatus(
+      {required final StarknetFieldElement startingBlockHash,
+      required final String startingBlockNum,
+      required final StarknetFieldElement currentBlockHash,
+      required final String currentBlockNum,
+      required final StarknetFieldElement highestBlockHash,
+      required final String highestBlockNum}) = _$_SyncStatus;
+
+  factory _SyncStatus.fromJson(Map<String, dynamic> json) =
+      _$_SyncStatus.fromJson;
+
+  @override
+  StarknetFieldElement get startingBlockHash;
+  @override
+  String get startingBlockNum;
+  @override
+  StarknetFieldElement get currentBlockHash;
+  @override
+  String get currentBlockNum;
+  @override
+  StarknetFieldElement get highestBlockHash;
+  @override
+  String get highestBlockNum;
+  @override
+  @JsonKey(ignore: true)
+  _$$_SyncStatusCopyWith<_$_SyncStatus> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/src/model/json_rpc_api/sync_status.g.dart
+++ b/lib/src/model/json_rpc_api/sync_status.g.dart
@@ -1,0 +1,30 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'sync_status.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$_SyncStatus _$$_SyncStatusFromJson(Map<String, dynamic> json) =>
+    _$_SyncStatus(
+      startingBlockHash:
+          StarknetFieldElement.fromJson(json['starting_block_hash'] as String),
+      startingBlockNum: json['starting_block_num'] as String,
+      currentBlockHash:
+          StarknetFieldElement.fromJson(json['current_block_hash'] as String),
+      currentBlockNum: json['current_block_num'] as String,
+      highestBlockHash:
+          StarknetFieldElement.fromJson(json['highest_block_hash'] as String),
+      highestBlockNum: json['highest_block_num'] as String,
+    );
+
+Map<String, dynamic> _$$_SyncStatusToJson(_$_SyncStatus instance) =>
+    <String, dynamic>{
+      'starting_block_hash': instance.startingBlockHash.toJson(),
+      'starting_block_num': instance.startingBlockNum,
+      'current_block_hash': instance.currentBlockHash.toJson(),
+      'current_block_num': instance.currentBlockNum,
+      'highest_block_hash': instance.highestBlockHash.toJson(),
+      'highest_block_num': instance.highestBlockNum,
+    };

--- a/lib/src/model/json_rpc_api/syncing.dart
+++ b/lib/src/model/json_rpc_api/syncing.dart
@@ -1,0 +1,27 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:starknet/src/model/json_rpc_api/sync_status.dart';
+
+import 'json_rpc_api_error.dart';
+
+part 'syncing.freezed.dart';
+part 'syncing.g.dart';
+
+@freezed
+class Syncing with _$Syncing {
+  const factory Syncing.synchronized({
+    required SyncStatus result,
+  }) = Synchronized;
+  const factory Syncing.notSynchronized({
+    required bool result,
+  }) = NotSynchronized;
+  const factory Syncing.error({
+    required JsonRpcApiError error,
+  }) = SyncingError;
+
+  factory Syncing.fromJson(Map<String, Object?> json) =>
+      json.containsKey('error')
+          ? SyncingError.fromJson(json)
+          : json['result'] is bool
+              ? NotSynchronized.fromJson(json)
+              : Synchronized.fromJson(json);
+}

--- a/lib/src/model/json_rpc_api/syncing.freezed.dart
+++ b/lib/src/model/json_rpc_api/syncing.freezed.dart
@@ -1,0 +1,586 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target
+
+part of 'syncing.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+Syncing _$SyncingFromJson(Map<String, dynamic> json) {
+  switch (json['runtimeType']) {
+    case 'synchronized':
+      return Synchronized.fromJson(json);
+    case 'notSynchronized':
+      return NotSynchronized.fromJson(json);
+    case 'error':
+      return SyncingError.fromJson(json);
+
+    default:
+      throw CheckedFromJsonException(json, 'runtimeType', 'Syncing',
+          'Invalid union type "${json['runtimeType']}"!');
+  }
+}
+
+/// @nodoc
+mixin _$Syncing {
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(SyncStatus result) synchronized,
+    required TResult Function(bool result) notSynchronized,
+    required TResult Function(JsonRpcApiError error) error,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult Function(SyncStatus result)? synchronized,
+    TResult Function(bool result)? notSynchronized,
+    TResult Function(JsonRpcApiError error)? error,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(SyncStatus result)? synchronized,
+    TResult Function(bool result)? notSynchronized,
+    TResult Function(JsonRpcApiError error)? error,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(Synchronized value) synchronized,
+    required TResult Function(NotSynchronized value) notSynchronized,
+    required TResult Function(SyncingError value) error,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult Function(Synchronized value)? synchronized,
+    TResult Function(NotSynchronized value)? notSynchronized,
+    TResult Function(SyncingError value)? error,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(Synchronized value)? synchronized,
+    TResult Function(NotSynchronized value)? notSynchronized,
+    TResult Function(SyncingError value)? error,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $SyncingCopyWith<$Res> {
+  factory $SyncingCopyWith(Syncing value, $Res Function(Syncing) then) =
+      _$SyncingCopyWithImpl<$Res>;
+}
+
+/// @nodoc
+class _$SyncingCopyWithImpl<$Res> implements $SyncingCopyWith<$Res> {
+  _$SyncingCopyWithImpl(this._value, this._then);
+
+  final Syncing _value;
+  // ignore: unused_field
+  final $Res Function(Syncing) _then;
+}
+
+/// @nodoc
+abstract class _$$SynchronizedCopyWith<$Res> {
+  factory _$$SynchronizedCopyWith(
+          _$Synchronized value, $Res Function(_$Synchronized) then) =
+      __$$SynchronizedCopyWithImpl<$Res>;
+  $Res call({SyncStatus result});
+
+  $SyncStatusCopyWith<$Res> get result;
+}
+
+/// @nodoc
+class __$$SynchronizedCopyWithImpl<$Res> extends _$SyncingCopyWithImpl<$Res>
+    implements _$$SynchronizedCopyWith<$Res> {
+  __$$SynchronizedCopyWithImpl(
+      _$Synchronized _value, $Res Function(_$Synchronized) _then)
+      : super(_value, (v) => _then(v as _$Synchronized));
+
+  @override
+  _$Synchronized get _value => super._value as _$Synchronized;
+
+  @override
+  $Res call({
+    Object? result = freezed,
+  }) {
+    return _then(_$Synchronized(
+      result: result == freezed
+          ? _value.result
+          : result // ignore: cast_nullable_to_non_nullable
+              as SyncStatus,
+    ));
+  }
+
+  @override
+  $SyncStatusCopyWith<$Res> get result {
+    return $SyncStatusCopyWith<$Res>(_value.result, (value) {
+      return _then(_value.copyWith(result: value));
+    });
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$Synchronized implements Synchronized {
+  const _$Synchronized({required this.result, final String? $type})
+      : $type = $type ?? 'synchronized';
+
+  factory _$Synchronized.fromJson(Map<String, dynamic> json) =>
+      _$$SynchronizedFromJson(json);
+
+  @override
+  final SyncStatus result;
+
+  @JsonKey(name: 'runtimeType')
+  final String $type;
+
+  @override
+  String toString() {
+    return 'Syncing.synchronized(result: $result)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$Synchronized &&
+            const DeepCollectionEquality().equals(other.result, result));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, const DeepCollectionEquality().hash(result));
+
+  @JsonKey(ignore: true)
+  @override
+  _$$SynchronizedCopyWith<_$Synchronized> get copyWith =>
+      __$$SynchronizedCopyWithImpl<_$Synchronized>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(SyncStatus result) synchronized,
+    required TResult Function(bool result) notSynchronized,
+    required TResult Function(JsonRpcApiError error) error,
+  }) {
+    return synchronized(result);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult Function(SyncStatus result)? synchronized,
+    TResult Function(bool result)? notSynchronized,
+    TResult Function(JsonRpcApiError error)? error,
+  }) {
+    return synchronized?.call(result);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(SyncStatus result)? synchronized,
+    TResult Function(bool result)? notSynchronized,
+    TResult Function(JsonRpcApiError error)? error,
+    required TResult orElse(),
+  }) {
+    if (synchronized != null) {
+      return synchronized(result);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(Synchronized value) synchronized,
+    required TResult Function(NotSynchronized value) notSynchronized,
+    required TResult Function(SyncingError value) error,
+  }) {
+    return synchronized(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult Function(Synchronized value)? synchronized,
+    TResult Function(NotSynchronized value)? notSynchronized,
+    TResult Function(SyncingError value)? error,
+  }) {
+    return synchronized?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(Synchronized value)? synchronized,
+    TResult Function(NotSynchronized value)? notSynchronized,
+    TResult Function(SyncingError value)? error,
+    required TResult orElse(),
+  }) {
+    if (synchronized != null) {
+      return synchronized(this);
+    }
+    return orElse();
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$SynchronizedToJson(
+      this,
+    );
+  }
+}
+
+abstract class Synchronized implements Syncing {
+  const factory Synchronized({required final SyncStatus result}) =
+      _$Synchronized;
+
+  factory Synchronized.fromJson(Map<String, dynamic> json) =
+      _$Synchronized.fromJson;
+
+  SyncStatus get result;
+  @JsonKey(ignore: true)
+  _$$SynchronizedCopyWith<_$Synchronized> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$NotSynchronizedCopyWith<$Res> {
+  factory _$$NotSynchronizedCopyWith(
+          _$NotSynchronized value, $Res Function(_$NotSynchronized) then) =
+      __$$NotSynchronizedCopyWithImpl<$Res>;
+  $Res call({bool result});
+}
+
+/// @nodoc
+class __$$NotSynchronizedCopyWithImpl<$Res> extends _$SyncingCopyWithImpl<$Res>
+    implements _$$NotSynchronizedCopyWith<$Res> {
+  __$$NotSynchronizedCopyWithImpl(
+      _$NotSynchronized _value, $Res Function(_$NotSynchronized) _then)
+      : super(_value, (v) => _then(v as _$NotSynchronized));
+
+  @override
+  _$NotSynchronized get _value => super._value as _$NotSynchronized;
+
+  @override
+  $Res call({
+    Object? result = freezed,
+  }) {
+    return _then(_$NotSynchronized(
+      result: result == freezed
+          ? _value.result
+          : result // ignore: cast_nullable_to_non_nullable
+              as bool,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$NotSynchronized implements NotSynchronized {
+  const _$NotSynchronized({required this.result, final String? $type})
+      : $type = $type ?? 'notSynchronized';
+
+  factory _$NotSynchronized.fromJson(Map<String, dynamic> json) =>
+      _$$NotSynchronizedFromJson(json);
+
+  @override
+  final bool result;
+
+  @JsonKey(name: 'runtimeType')
+  final String $type;
+
+  @override
+  String toString() {
+    return 'Syncing.notSynchronized(result: $result)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$NotSynchronized &&
+            const DeepCollectionEquality().equals(other.result, result));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, const DeepCollectionEquality().hash(result));
+
+  @JsonKey(ignore: true)
+  @override
+  _$$NotSynchronizedCopyWith<_$NotSynchronized> get copyWith =>
+      __$$NotSynchronizedCopyWithImpl<_$NotSynchronized>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(SyncStatus result) synchronized,
+    required TResult Function(bool result) notSynchronized,
+    required TResult Function(JsonRpcApiError error) error,
+  }) {
+    return notSynchronized(result);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult Function(SyncStatus result)? synchronized,
+    TResult Function(bool result)? notSynchronized,
+    TResult Function(JsonRpcApiError error)? error,
+  }) {
+    return notSynchronized?.call(result);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(SyncStatus result)? synchronized,
+    TResult Function(bool result)? notSynchronized,
+    TResult Function(JsonRpcApiError error)? error,
+    required TResult orElse(),
+  }) {
+    if (notSynchronized != null) {
+      return notSynchronized(result);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(Synchronized value) synchronized,
+    required TResult Function(NotSynchronized value) notSynchronized,
+    required TResult Function(SyncingError value) error,
+  }) {
+    return notSynchronized(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult Function(Synchronized value)? synchronized,
+    TResult Function(NotSynchronized value)? notSynchronized,
+    TResult Function(SyncingError value)? error,
+  }) {
+    return notSynchronized?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(Synchronized value)? synchronized,
+    TResult Function(NotSynchronized value)? notSynchronized,
+    TResult Function(SyncingError value)? error,
+    required TResult orElse(),
+  }) {
+    if (notSynchronized != null) {
+      return notSynchronized(this);
+    }
+    return orElse();
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$NotSynchronizedToJson(
+      this,
+    );
+  }
+}
+
+abstract class NotSynchronized implements Syncing {
+  const factory NotSynchronized({required final bool result}) =
+      _$NotSynchronized;
+
+  factory NotSynchronized.fromJson(Map<String, dynamic> json) =
+      _$NotSynchronized.fromJson;
+
+  bool get result;
+  @JsonKey(ignore: true)
+  _$$NotSynchronizedCopyWith<_$NotSynchronized> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$SyncingErrorCopyWith<$Res> {
+  factory _$$SyncingErrorCopyWith(
+          _$SyncingError value, $Res Function(_$SyncingError) then) =
+      __$$SyncingErrorCopyWithImpl<$Res>;
+  $Res call({JsonRpcApiError error});
+
+  $JsonRpcApiErrorCopyWith<$Res> get error;
+}
+
+/// @nodoc
+class __$$SyncingErrorCopyWithImpl<$Res> extends _$SyncingCopyWithImpl<$Res>
+    implements _$$SyncingErrorCopyWith<$Res> {
+  __$$SyncingErrorCopyWithImpl(
+      _$SyncingError _value, $Res Function(_$SyncingError) _then)
+      : super(_value, (v) => _then(v as _$SyncingError));
+
+  @override
+  _$SyncingError get _value => super._value as _$SyncingError;
+
+  @override
+  $Res call({
+    Object? error = freezed,
+  }) {
+    return _then(_$SyncingError(
+      error: error == freezed
+          ? _value.error
+          : error // ignore: cast_nullable_to_non_nullable
+              as JsonRpcApiError,
+    ));
+  }
+
+  @override
+  $JsonRpcApiErrorCopyWith<$Res> get error {
+    return $JsonRpcApiErrorCopyWith<$Res>(_value.error, (value) {
+      return _then(_value.copyWith(error: value));
+    });
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$SyncingError implements SyncingError {
+  const _$SyncingError({required this.error, final String? $type})
+      : $type = $type ?? 'error';
+
+  factory _$SyncingError.fromJson(Map<String, dynamic> json) =>
+      _$$SyncingErrorFromJson(json);
+
+  @override
+  final JsonRpcApiError error;
+
+  @JsonKey(name: 'runtimeType')
+  final String $type;
+
+  @override
+  String toString() {
+    return 'Syncing.error(error: $error)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$SyncingError &&
+            const DeepCollectionEquality().equals(other.error, error));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, const DeepCollectionEquality().hash(error));
+
+  @JsonKey(ignore: true)
+  @override
+  _$$SyncingErrorCopyWith<_$SyncingError> get copyWith =>
+      __$$SyncingErrorCopyWithImpl<_$SyncingError>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(SyncStatus result) synchronized,
+    required TResult Function(bool result) notSynchronized,
+    required TResult Function(JsonRpcApiError error) error,
+  }) {
+    return error(this.error);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult Function(SyncStatus result)? synchronized,
+    TResult Function(bool result)? notSynchronized,
+    TResult Function(JsonRpcApiError error)? error,
+  }) {
+    return error?.call(this.error);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(SyncStatus result)? synchronized,
+    TResult Function(bool result)? notSynchronized,
+    TResult Function(JsonRpcApiError error)? error,
+    required TResult orElse(),
+  }) {
+    if (error != null) {
+      return error(this.error);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(Synchronized value) synchronized,
+    required TResult Function(NotSynchronized value) notSynchronized,
+    required TResult Function(SyncingError value) error,
+  }) {
+    return error(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult Function(Synchronized value)? synchronized,
+    TResult Function(NotSynchronized value)? notSynchronized,
+    TResult Function(SyncingError value)? error,
+  }) {
+    return error?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(Synchronized value)? synchronized,
+    TResult Function(NotSynchronized value)? notSynchronized,
+    TResult Function(SyncingError value)? error,
+    required TResult orElse(),
+  }) {
+    if (error != null) {
+      return error(this);
+    }
+    return orElse();
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$SyncingErrorToJson(
+      this,
+    );
+  }
+}
+
+abstract class SyncingError implements Syncing {
+  const factory SyncingError({required final JsonRpcApiError error}) =
+      _$SyncingError;
+
+  factory SyncingError.fromJson(Map<String, dynamic> json) =
+      _$SyncingError.fromJson;
+
+  JsonRpcApiError get error;
+  @JsonKey(ignore: true)
+  _$$SyncingErrorCopyWith<_$SyncingError> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/src/model/json_rpc_api/syncing.g.dart
+++ b/lib/src/model/json_rpc_api/syncing.g.dart
@@ -1,0 +1,43 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'syncing.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$Synchronized _$$SynchronizedFromJson(Map<String, dynamic> json) =>
+    _$Synchronized(
+      result: SyncStatus.fromJson(json['result'] as Map<String, dynamic>),
+      $type: json['runtimeType'] as String?,
+    );
+
+Map<String, dynamic> _$$SynchronizedToJson(_$Synchronized instance) =>
+    <String, dynamic>{
+      'result': instance.result.toJson(),
+      'runtimeType': instance.$type,
+    };
+
+_$NotSynchronized _$$NotSynchronizedFromJson(Map<String, dynamic> json) =>
+    _$NotSynchronized(
+      result: json['result'] as bool,
+      $type: json['runtimeType'] as String?,
+    );
+
+Map<String, dynamic> _$$NotSynchronizedToJson(_$NotSynchronized instance) =>
+    <String, dynamic>{
+      'result': instance.result,
+      'runtimeType': instance.$type,
+    };
+
+_$SyncingError _$$SyncingErrorFromJson(Map<String, dynamic> json) =>
+    _$SyncingError(
+      error: JsonRpcApiError.fromJson(json['error'] as Map<String, dynamic>),
+      $type: json['runtimeType'] as String?,
+    );
+
+Map<String, dynamic> _$$SyncingErrorToJson(_$SyncingError instance) =>
+    <String, dynamic>{
+      'error': instance.error.toJson(),
+      'runtimeType': instance.$type,
+    };

--- a/lib/src/provider.dart
+++ b/lib/src/provider.dart
@@ -58,10 +58,15 @@ abstract class Provider {
   /// [Spec](https://github.com/starkware-libs/starknet-specs/blob/30e5bafcda60c31b5fb4021b4f5ddcfc18d2ff7d/api/starknet_api_openrpc.json#L536-L548)
   Future<ProtocolVersion> protocolVersion();
 
-  /// Gets the current starknet protocol version identifier, as supported by this sequencer.
+  /// Returns an object about the sync status, or false if the node is not synching
   ///
   /// [Spec](https://github.com/starkware-libs/starknet-specs/blob/30e5bafcda60c31b5fb4021b4f5ddcfc18d2ff7d/api/starknet_api_openrpc.json#L549-L569)
   Future<Syncing> syncing();
+
+  /// Gets the latest nonce associated with the given address.
+  ///
+  /// [Spec](https://github.com/starkware-libs/starknet-specs/blob/30e5bafcda60c31b5fb4021b4f5ddcfc18d2ff7d/api/starknet_api_openrpc.json#L628-L653)
+  Future<GetNonce> getNonce();
 }
 
 class JsonRpcProvider implements Provider {
@@ -170,6 +175,15 @@ class JsonRpcProvider implements Provider {
       method: 'starknet_syncing',
       params: [],
     ).then(Syncing.fromJson);
+  }
+
+  @override
+  Future<GetNonce> getNonce() {
+    return callRpcEndpoint(
+      nodeUri: nodeUri,
+      method: 'starknet_getNonce',
+      params: [],
+    ).then(GetNonce.fromJson);
   }
 
   static final devnet = JsonRpcProvider(nodeUri: devnetUri);

--- a/lib/src/provider.dart
+++ b/lib/src/provider.dart
@@ -1,7 +1,3 @@
-import 'package:starknet/src/model/json_rpc_api/block_id.dart';
-import 'package:starknet/src/model/json_rpc_api/chain_id.dart';
-import 'package:starknet/src/model/json_rpc_api/get_transaction.dart';
-import 'package:starknet/src/model/json_rpc_api/get_transaction_receipt.dart';
 import 'package:starknet/starknet.dart';
 
 abstract class Provider {
@@ -51,6 +47,11 @@ abstract class Provider {
   ///
   /// [Spec](https://github.com/starkware-libs/starknet-specs/blob/30e5bafcda60c31b5fb4021b4f5ddcfc18d2ff7d/api/starknet_api_openrpc.json#L509-L520)
   Future<ChainId> chainId();
+
+  /// Gets the transactions in the transaction pool, recognized by the sequencer.
+  ///
+  /// [Spec](https://github.com/starkware-libs/starknet-specs/blob/30e5bafcda60c31b5fb4021b4f5ddcfc18d2ff7d/api/starknet_api_openrpc.json#L521-L535)
+  Future<PendingTransactions> pendingTransactions();
 }
 
 class JsonRpcProvider implements Provider {
@@ -132,6 +133,15 @@ class JsonRpcProvider implements Provider {
       method: 'starknet_chainId',
       params: [],
     ).then(ChainId.fromJson);
+  }
+
+  @override
+  Future<PendingTransactions> pendingTransactions() {
+    return callRpcEndpoint(
+      nodeUri: nodeUri,
+      method: 'starknet_pendingTransactions',
+      params: [],
+    ).then(PendingTransactions.fromJson);
   }
 
   static final devnet = JsonRpcProvider(nodeUri: devnetUri);

--- a/lib/src/provider.dart
+++ b/lib/src/provider.dart
@@ -1,4 +1,5 @@
 import 'package:starknet/src/model/json_rpc_api/block_id.dart';
+import 'package:starknet/src/model/json_rpc_api/chain_id.dart';
 import 'package:starknet/src/model/json_rpc_api/get_transaction.dart';
 import 'package:starknet/src/model/json_rpc_api/get_transaction_receipt.dart';
 import 'package:starknet/starknet.dart';
@@ -45,6 +46,11 @@ abstract class Provider {
   /// [Spec](https://github.com/starkware-libs/starknet-specs/blob/30e5bafcda60c31b5fb4021b4f5ddcfc18d2ff7d/api/starknet_api_openrpc.json#L214-L239)
   Future<GetTransactionReceipt> getTransactionReceipt(
       StarknetFieldElement txnHash);
+
+  /// Gets the currently configured StarkNet chain id.
+  ///
+  /// [Spec](https://github.com/starkware-libs/starknet-specs/blob/30e5bafcda60c31b5fb4021b4f5ddcfc18d2ff7d/api/starknet_api_openrpc.json#L509-L520)
+  Future<ChainId> chainId();
 }
 
 class JsonRpcProvider implements Provider {
@@ -117,6 +123,15 @@ class JsonRpcProvider implements Provider {
       method: 'starknet_getTransactionReceipt',
       params: [transactionHash],
     ).then(GetTransactionReceipt.fromJson);
+  }
+
+  @override
+  Future<ChainId> chainId() {
+    return callRpcEndpoint(
+      nodeUri: nodeUri,
+      method: 'starknet_chainId',
+      params: [],
+    ).then(ChainId.fromJson);
   }
 
   static final devnet = JsonRpcProvider(nodeUri: devnetUri);

--- a/lib/src/provider.dart
+++ b/lib/src/provider.dart
@@ -57,6 +57,11 @@ abstract class Provider {
   ///
   /// [Spec](https://github.com/starkware-libs/starknet-specs/blob/30e5bafcda60c31b5fb4021b4f5ddcfc18d2ff7d/api/starknet_api_openrpc.json#L536-L548)
   Future<ProtocolVersion> protocolVersion();
+
+  /// Gets the current starknet protocol version identifier, as supported by this sequencer.
+  ///
+  /// [Spec](https://github.com/starkware-libs/starknet-specs/blob/30e5bafcda60c31b5fb4021b4f5ddcfc18d2ff7d/api/starknet_api_openrpc.json#L549-L569)
+  Future<Syncing> syncing();
 }
 
 class JsonRpcProvider implements Provider {
@@ -156,6 +161,15 @@ class JsonRpcProvider implements Provider {
       method: 'starknet_protocolVersion',
       params: [],
     ).then(ProtocolVersion.fromJson);
+  }
+
+  @override
+  Future<Syncing> syncing() {
+    return callRpcEndpoint(
+      nodeUri: nodeUri,
+      method: 'starknet_syncing',
+      params: [],
+    ).then(Syncing.fromJson);
   }
 
   static final devnet = JsonRpcProvider(nodeUri: devnetUri);

--- a/lib/src/provider.dart
+++ b/lib/src/provider.dart
@@ -52,6 +52,11 @@ abstract class Provider {
   ///
   /// [Spec](https://github.com/starkware-libs/starknet-specs/blob/30e5bafcda60c31b5fb4021b4f5ddcfc18d2ff7d/api/starknet_api_openrpc.json#L521-L535)
   Future<PendingTransactions> pendingTransactions();
+
+  /// Gets the current starknet protocol version identifier, as supported by this sequencer.
+  ///
+  /// [Spec](https://github.com/starkware-libs/starknet-specs/blob/30e5bafcda60c31b5fb4021b4f5ddcfc18d2ff7d/api/starknet_api_openrpc.json#L536-L548)
+  Future<ProtocolVersion> protocolVersion();
 }
 
 class JsonRpcProvider implements Provider {
@@ -142,6 +147,15 @@ class JsonRpcProvider implements Provider {
       method: 'starknet_pendingTransactions',
       params: [],
     ).then(PendingTransactions.fromJson);
+  }
+
+  @override
+  Future<ProtocolVersion> protocolVersion() {
+    return callRpcEndpoint(
+      nodeUri: nodeUri,
+      method: 'starknet_protocolVersion',
+      params: [],
+    ).then(ProtocolVersion.fromJson);
   }
 
   static final devnet = JsonRpcProvider(nodeUri: devnetUri);

--- a/lib/src/provider.dart
+++ b/lib/src/provider.dart
@@ -63,10 +63,13 @@ abstract class Provider {
   /// [Spec](https://github.com/starkware-libs/starknet-specs/blob/30e5bafcda60c31b5fb4021b4f5ddcfc18d2ff7d/api/starknet_api_openrpc.json#L549-L569)
   Future<Syncing> syncing();
 
-  /// Gets the latest nonce associated with the given address.
+  /// Gets the nonce associated with the given address in the given block
   ///
-  /// [Spec](https://github.com/starkware-libs/starknet-specs/blob/30e5bafcda60c31b5fb4021b4f5ddcfc18d2ff7d/api/starknet_api_openrpc.json#L628-L653)
-  Future<GetNonce> getNonce();
+  /// [Spec](https://github.com/starkware-libs/starknet-specs/blob/5cafa4cbaf5e4596bf309dfbde1bd0c4fa2ce1ce/api/starknet_api_openrpc.json#L628-L664)
+  Future<GetNonce> getNonce(
+    BlockId blockId,
+    StarknetFieldElement contractAddress,
+  );
 }
 
 class JsonRpcProvider implements Provider {
@@ -178,11 +181,14 @@ class JsonRpcProvider implements Provider {
   }
 
   @override
-  Future<GetNonce> getNonce() {
+  Future<GetNonce> getNonce(
+    BlockId blockId,
+    StarknetFieldElement contractAddress,
+  ) {
     return callRpcEndpoint(
       nodeUri: nodeUri,
       method: 'starknet_getNonce',
-      params: [],
+      params: [blockId, contractAddress],
     ).then(GetNonce.fromJson);
   }
 

--- a/test/provider_test.dart
+++ b/test/provider_test.dart
@@ -251,7 +251,13 @@ void main() {
 
     group('starknet_getNonce', () {
       test('returns unimplemented method error for getNonce', () async {
-        final response = await provider.getNonce();
+        final response = await provider.getNonce(
+          BlockId.blockHash(
+              blockHash: StarknetFieldElement.fromHexString(
+                  '0x3e506ab93bb22e483c5ddeee5db90a815cced1189805630673bbf86dbce1d79')),
+          StarknetFieldElement.fromHexString(
+              '0x7cda35873823b661b560e5eb5fa901d2190512ea2006b7d504082ace819094f'),
+        );
 
         response.when(
             error: (error) {

--- a/test/provider_test.dart
+++ b/test/provider_test.dart
@@ -179,6 +179,21 @@ void main() {
       });
     });
 
+    group('syncing', () {
+      test('returns the state of synchronized node', () async {
+        final response = await provider.syncing();
+
+        response.when(
+            error: (error) => fail("Shouldn't fail"),
+            synchronized: (SyncStatus result) {
+              expect(result.currentBlockHash, isNotNull);
+            },
+            notSynchronized: (bool result) {
+              expect(result, isFalse);
+            });
+      });
+    });
+
     // Tests for unimplemented methods
 
     group('starknet_getTransactionByBlockIdAndIndex', () {

--- a/test/provider_test.dart
+++ b/test/provider_test.dart
@@ -110,7 +110,7 @@ void main() {
         );
 
         response.when(
-            error: (error) => fail("Should fail"),
+            error: (error) => fail("Shouldn't fail"),
             result: (result) {
               expect(
                   result.txnHash,
@@ -141,7 +141,7 @@ void main() {
         );
 
         response.when(
-            error: (error) => fail("Should fail"),
+            error: (error) => fail("Shouldn't fail"),
             result: (result) {
               expect(
                   result.txnHash,
@@ -163,7 +163,19 @@ void main() {
 
         response.when(
             error: (error) => expect(error.code, 25),
-            result: (result) => fail('Should fail'));
+            result: (result) => fail("Shouldn't fail"));
+      });
+    });
+
+    group('chainId', () {
+      test('returns the current StarkNet chain id', () async {
+        final response = await provider.chainId();
+
+        response.when(
+            error: (error) => fail("Shouldn't fail"),
+            result: (result) {
+              expect(result, isNotEmpty);
+            });
       });
     });
 

--- a/test/provider_test.dart
+++ b/test/provider_test.dart
@@ -202,5 +202,22 @@ void main() {
             });
       });
     });
+
+    group('starknet_pendingTransactions', () {
+      test('returns unimplemented method error for pendingTransactions',
+          () async {
+        final response = await provider.pendingTransactions();
+
+        response.when(
+            error: (error) {
+              expect(error.code, equals(-32601));
+              expect(
+                  error.message,
+                  contains(
+                      'method \'starknet_pendingTransactions\' not found'));
+            },
+            result: (_) => fail('Expected to return an unimplemented error'));
+      });
+    });
   });
 }

--- a/test/provider_test.dart
+++ b/test/provider_test.dart
@@ -248,5 +248,19 @@ void main() {
             result: (_) => fail('Expected to return an unimplemented error'));
       });
     });
+
+    group('starknet_getNonce', () {
+      test('returns unimplemented method error for getNonce', () async {
+        final response = await provider.getNonce();
+
+        response.when(
+            error: (error) {
+              expect(error.code, equals(-32601));
+              expect(error.message,
+                  contains('method \'starknet_getNonce\' not found'));
+            },
+            result: (_) => fail('Expected to return an unimplemented error'));
+      });
+    });
   });
 }

--- a/test/provider_test.dart
+++ b/test/provider_test.dart
@@ -219,5 +219,19 @@ void main() {
             result: (_) => fail('Expected to return an unimplemented error'));
       });
     });
+
+    group('starknet_protocolVersion', () {
+      test('returns unimplemented method error for protocolVersion', () async {
+        final response = await provider.protocolVersion();
+
+        response.when(
+            error: (error) {
+              expect(error.code, equals(-32601));
+              expect(error.message,
+                  contains('method \'starknet_protocolVersion\' not found'));
+            },
+            result: (_) => fail('Expected to return an unimplemented error'));
+      });
+    });
   });
 }


### PR DESCRIPTION
Closes #17 
Implement boilerplate code for `starknet_getNonce`, `starknet_syncing`, `starknet_protocolVersion`, `starknet_pendingTransactions` and `starknet_chainId` methods and tests.

List of unimplemented methods:
1. starknet_pendingTransactions
2. starknet_protocolVersion
3. starknet_getNonce