### PR TITLE
fixup: use lowercase for getClass* member names

### DIFF
--- a/lib/src/provider/model/get_class.dart
+++ b/lib/src/provider/model/get_class.dart
@@ -18,7 +18,7 @@ class EntryPointsByType with _$EntryPointsByType {
   const factory EntryPointsByType({
     @JsonKey(name: 'CONSTRUCTOR') required List<EntryPoint> constructor,
     @JsonKey(name: 'EXTERNAL') required List<EntryPoint> external,
-    @JsonKey(name: 'L1_HANDLER') required List<EntryPoint> L1Handler,
+    @JsonKey(name: 'L1_HANDLER') required List<EntryPoint> l1Handler,
   }) = _EntryPointsByType;
 
   factory EntryPointsByType.fromJson(Map<String, Object?> json) =>

--- a/lib/src/provider/model/get_class.dart
+++ b/lib/src/provider/model/get_class.dart
@@ -16,9 +16,9 @@ class EntryPoint with _$EntryPoint {
 @freezed
 class EntryPointsByType with _$EntryPointsByType {
   const factory EntryPointsByType({
-    @JsonKey(name: 'CONSTRUCTOR') required List<EntryPoint> CONSTRUCTOR,
-    @JsonKey(name: 'EXTERNAL') required List<EntryPoint> EXTERNAL,
-    @JsonKey(name: 'L1_HANDLER') required List<EntryPoint> L1_HANDLER,
+    @JsonKey(name: 'CONSTRUCTOR') required List<EntryPoint> constructor,
+    @JsonKey(name: 'EXTERNAL') required List<EntryPoint> external,
+    @JsonKey(name: 'L1_HANDLER') required List<EntryPoint> L1Handler,
   }) = _EntryPointsByType;
 
   factory EntryPointsByType.fromJson(Map<String, Object?> json) =>

--- a/lib/src/provider/model/get_class.freezed.dart
+++ b/lib/src/provider/model/get_class.freezed.dart
@@ -177,7 +177,7 @@ mixin _$EntryPointsByType {
   @JsonKey(name: 'EXTERNAL')
   List<EntryPoint> get external => throw _privateConstructorUsedError;
   @JsonKey(name: 'L1_HANDLER')
-  List<EntryPoint> get L1Handler => throw _privateConstructorUsedError;
+  List<EntryPoint> get l1Handler => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
@@ -193,7 +193,7 @@ abstract class $EntryPointsByTypeCopyWith<$Res> {
   $Res call(
       {@JsonKey(name: 'CONSTRUCTOR') List<EntryPoint> constructor,
       @JsonKey(name: 'EXTERNAL') List<EntryPoint> external,
-      @JsonKey(name: 'L1_HANDLER') List<EntryPoint> L1Handler});
+      @JsonKey(name: 'L1_HANDLER') List<EntryPoint> l1Handler});
 }
 
 /// @nodoc
@@ -209,7 +209,7 @@ class _$EntryPointsByTypeCopyWithImpl<$Res>
   $Res call({
     Object? constructor = freezed,
     Object? external = freezed,
-    Object? L1Handler = freezed,
+    Object? l1Handler = freezed,
   }) {
     return _then(_value.copyWith(
       constructor: constructor == freezed
@@ -220,9 +220,9 @@ class _$EntryPointsByTypeCopyWithImpl<$Res>
           ? _value.external
           : external // ignore: cast_nullable_to_non_nullable
               as List<EntryPoint>,
-      L1Handler: L1Handler == freezed
-          ? _value.L1Handler
-          : L1Handler // ignore: cast_nullable_to_non_nullable
+      l1Handler: l1Handler == freezed
+          ? _value.l1Handler
+          : l1Handler // ignore: cast_nullable_to_non_nullable
               as List<EntryPoint>,
     ));
   }
@@ -238,7 +238,7 @@ abstract class _$$_EntryPointsByTypeCopyWith<$Res>
   $Res call(
       {@JsonKey(name: 'CONSTRUCTOR') List<EntryPoint> constructor,
       @JsonKey(name: 'EXTERNAL') List<EntryPoint> external,
-      @JsonKey(name: 'L1_HANDLER') List<EntryPoint> L1Handler});
+      @JsonKey(name: 'L1_HANDLER') List<EntryPoint> l1Handler});
 }
 
 /// @nodoc
@@ -256,7 +256,7 @@ class __$$_EntryPointsByTypeCopyWithImpl<$Res>
   $Res call({
     Object? constructor = freezed,
     Object? external = freezed,
-    Object? L1Handler = freezed,
+    Object? l1Handler = freezed,
   }) {
     return _then(_$_EntryPointsByType(
       constructor: constructor == freezed
@@ -267,9 +267,9 @@ class __$$_EntryPointsByTypeCopyWithImpl<$Res>
           ? _value._external
           : external // ignore: cast_nullable_to_non_nullable
               as List<EntryPoint>,
-      L1Handler: L1Handler == freezed
-          ? _value._L1Handler
-          : L1Handler // ignore: cast_nullable_to_non_nullable
+      l1Handler: l1Handler == freezed
+          ? _value._l1Handler
+          : l1Handler // ignore: cast_nullable_to_non_nullable
               as List<EntryPoint>,
     ));
   }
@@ -284,10 +284,10 @@ class _$_EntryPointsByType implements _EntryPointsByType {
       @JsonKey(name: 'EXTERNAL')
           required final List<EntryPoint> external,
       @JsonKey(name: 'L1_HANDLER')
-          required final List<EntryPoint> L1Handler})
+          required final List<EntryPoint> l1Handler})
       : _constructor = constructor,
         _external = external,
-        _L1Handler = L1Handler;
+        _l1Handler = l1Handler;
 
   factory _$_EntryPointsByType.fromJson(Map<String, dynamic> json) =>
       _$$_EntryPointsByTypeFromJson(json);
@@ -308,17 +308,17 @@ class _$_EntryPointsByType implements _EntryPointsByType {
     return EqualUnmodifiableListView(_external);
   }
 
-  final List<EntryPoint> _L1Handler;
+  final List<EntryPoint> _l1Handler;
   @override
   @JsonKey(name: 'L1_HANDLER')
-  List<EntryPoint> get L1Handler {
+  List<EntryPoint> get l1Handler {
     // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(_L1Handler);
+    return EqualUnmodifiableListView(_l1Handler);
   }
 
   @override
   String toString() {
-    return 'EntryPointsByType(constructor: $constructor, external: $external, L1Handler: $L1Handler)';
+    return 'EntryPointsByType(constructor: $constructor, external: $external, l1Handler: $l1Handler)';
   }
 
   @override
@@ -330,7 +330,7 @@ class _$_EntryPointsByType implements _EntryPointsByType {
                 .equals(other._constructor, _constructor) &&
             const DeepCollectionEquality().equals(other._external, _external) &&
             const DeepCollectionEquality()
-                .equals(other._L1Handler, _L1Handler));
+                .equals(other._l1Handler, _l1Handler));
   }
 
   @JsonKey(ignore: true)
@@ -339,7 +339,7 @@ class _$_EntryPointsByType implements _EntryPointsByType {
       runtimeType,
       const DeepCollectionEquality().hash(_constructor),
       const DeepCollectionEquality().hash(_external),
-      const DeepCollectionEquality().hash(_L1Handler));
+      const DeepCollectionEquality().hash(_l1Handler));
 
   @JsonKey(ignore: true)
   @override
@@ -362,7 +362,7 @@ abstract class _EntryPointsByType implements EntryPointsByType {
       @JsonKey(name: 'EXTERNAL')
           required final List<EntryPoint> external,
       @JsonKey(name: 'L1_HANDLER')
-          required final List<EntryPoint> L1Handler}) = _$_EntryPointsByType;
+          required final List<EntryPoint> l1Handler}) = _$_EntryPointsByType;
 
   factory _EntryPointsByType.fromJson(Map<String, dynamic> json) =
       _$_EntryPointsByType.fromJson;
@@ -375,7 +375,7 @@ abstract class _EntryPointsByType implements EntryPointsByType {
   List<EntryPoint> get external;
   @override
   @JsonKey(name: 'L1_HANDLER')
-  List<EntryPoint> get L1Handler;
+  List<EntryPoint> get l1Handler;
   @override
   @JsonKey(ignore: true)
   _$$_EntryPointsByTypeCopyWith<_$_EntryPointsByType> get copyWith =>

--- a/lib/src/provider/model/get_class.freezed.dart
+++ b/lib/src/provider/model/get_class.freezed.dart
@@ -173,11 +173,11 @@ EntryPointsByType _$EntryPointsByTypeFromJson(Map<String, dynamic> json) {
 /// @nodoc
 mixin _$EntryPointsByType {
   @JsonKey(name: 'CONSTRUCTOR')
-  List<EntryPoint> get CONSTRUCTOR => throw _privateConstructorUsedError;
+  List<EntryPoint> get constructor => throw _privateConstructorUsedError;
   @JsonKey(name: 'EXTERNAL')
-  List<EntryPoint> get EXTERNAL => throw _privateConstructorUsedError;
+  List<EntryPoint> get external => throw _privateConstructorUsedError;
   @JsonKey(name: 'L1_HANDLER')
-  List<EntryPoint> get L1_HANDLER => throw _privateConstructorUsedError;
+  List<EntryPoint> get L1Handler => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
@@ -191,9 +191,9 @@ abstract class $EntryPointsByTypeCopyWith<$Res> {
           EntryPointsByType value, $Res Function(EntryPointsByType) then) =
       _$EntryPointsByTypeCopyWithImpl<$Res>;
   $Res call(
-      {@JsonKey(name: 'CONSTRUCTOR') List<EntryPoint> CONSTRUCTOR,
-      @JsonKey(name: 'EXTERNAL') List<EntryPoint> EXTERNAL,
-      @JsonKey(name: 'L1_HANDLER') List<EntryPoint> L1_HANDLER});
+      {@JsonKey(name: 'CONSTRUCTOR') List<EntryPoint> constructor,
+      @JsonKey(name: 'EXTERNAL') List<EntryPoint> external,
+      @JsonKey(name: 'L1_HANDLER') List<EntryPoint> L1Handler});
 }
 
 /// @nodoc
@@ -207,22 +207,22 @@ class _$EntryPointsByTypeCopyWithImpl<$Res>
 
   @override
   $Res call({
-    Object? CONSTRUCTOR = freezed,
-    Object? EXTERNAL = freezed,
-    Object? L1_HANDLER = freezed,
+    Object? constructor = freezed,
+    Object? external = freezed,
+    Object? L1Handler = freezed,
   }) {
     return _then(_value.copyWith(
-      CONSTRUCTOR: CONSTRUCTOR == freezed
-          ? _value.CONSTRUCTOR
-          : CONSTRUCTOR // ignore: cast_nullable_to_non_nullable
+      constructor: constructor == freezed
+          ? _value.constructor
+          : constructor // ignore: cast_nullable_to_non_nullable
               as List<EntryPoint>,
-      EXTERNAL: EXTERNAL == freezed
-          ? _value.EXTERNAL
-          : EXTERNAL // ignore: cast_nullable_to_non_nullable
+      external: external == freezed
+          ? _value.external
+          : external // ignore: cast_nullable_to_non_nullable
               as List<EntryPoint>,
-      L1_HANDLER: L1_HANDLER == freezed
-          ? _value.L1_HANDLER
-          : L1_HANDLER // ignore: cast_nullable_to_non_nullable
+      L1Handler: L1Handler == freezed
+          ? _value.L1Handler
+          : L1Handler // ignore: cast_nullable_to_non_nullable
               as List<EntryPoint>,
     ));
   }
@@ -236,9 +236,9 @@ abstract class _$$_EntryPointsByTypeCopyWith<$Res>
       __$$_EntryPointsByTypeCopyWithImpl<$Res>;
   @override
   $Res call(
-      {@JsonKey(name: 'CONSTRUCTOR') List<EntryPoint> CONSTRUCTOR,
-      @JsonKey(name: 'EXTERNAL') List<EntryPoint> EXTERNAL,
-      @JsonKey(name: 'L1_HANDLER') List<EntryPoint> L1_HANDLER});
+      {@JsonKey(name: 'CONSTRUCTOR') List<EntryPoint> constructor,
+      @JsonKey(name: 'EXTERNAL') List<EntryPoint> external,
+      @JsonKey(name: 'L1_HANDLER') List<EntryPoint> L1Handler});
 }
 
 /// @nodoc
@@ -254,22 +254,22 @@ class __$$_EntryPointsByTypeCopyWithImpl<$Res>
 
   @override
   $Res call({
-    Object? CONSTRUCTOR = freezed,
-    Object? EXTERNAL = freezed,
-    Object? L1_HANDLER = freezed,
+    Object? constructor = freezed,
+    Object? external = freezed,
+    Object? L1Handler = freezed,
   }) {
     return _then(_$_EntryPointsByType(
-      CONSTRUCTOR: CONSTRUCTOR == freezed
-          ? _value._CONSTRUCTOR
-          : CONSTRUCTOR // ignore: cast_nullable_to_non_nullable
+      constructor: constructor == freezed
+          ? _value._constructor
+          : constructor // ignore: cast_nullable_to_non_nullable
               as List<EntryPoint>,
-      EXTERNAL: EXTERNAL == freezed
-          ? _value._EXTERNAL
-          : EXTERNAL // ignore: cast_nullable_to_non_nullable
+      external: external == freezed
+          ? _value._external
+          : external // ignore: cast_nullable_to_non_nullable
               as List<EntryPoint>,
-      L1_HANDLER: L1_HANDLER == freezed
-          ? _value._L1_HANDLER
-          : L1_HANDLER // ignore: cast_nullable_to_non_nullable
+      L1Handler: L1Handler == freezed
+          ? _value._L1Handler
+          : L1Handler // ignore: cast_nullable_to_non_nullable
               as List<EntryPoint>,
     ));
   }
@@ -280,45 +280,45 @@ class __$$_EntryPointsByTypeCopyWithImpl<$Res>
 class _$_EntryPointsByType implements _EntryPointsByType {
   const _$_EntryPointsByType(
       {@JsonKey(name: 'CONSTRUCTOR')
-          required final List<EntryPoint> CONSTRUCTOR,
+          required final List<EntryPoint> constructor,
       @JsonKey(name: 'EXTERNAL')
-          required final List<EntryPoint> EXTERNAL,
+          required final List<EntryPoint> external,
       @JsonKey(name: 'L1_HANDLER')
-          required final List<EntryPoint> L1_HANDLER})
-      : _CONSTRUCTOR = CONSTRUCTOR,
-        _EXTERNAL = EXTERNAL,
-        _L1_HANDLER = L1_HANDLER;
+          required final List<EntryPoint> L1Handler})
+      : _constructor = constructor,
+        _external = external,
+        _L1Handler = L1Handler;
 
   factory _$_EntryPointsByType.fromJson(Map<String, dynamic> json) =>
       _$$_EntryPointsByTypeFromJson(json);
 
-  final List<EntryPoint> _CONSTRUCTOR;
+  final List<EntryPoint> _constructor;
   @override
   @JsonKey(name: 'CONSTRUCTOR')
-  List<EntryPoint> get CONSTRUCTOR {
+  List<EntryPoint> get constructor {
     // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(_CONSTRUCTOR);
+    return EqualUnmodifiableListView(_constructor);
   }
 
-  final List<EntryPoint> _EXTERNAL;
+  final List<EntryPoint> _external;
   @override
   @JsonKey(name: 'EXTERNAL')
-  List<EntryPoint> get EXTERNAL {
+  List<EntryPoint> get external {
     // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(_EXTERNAL);
+    return EqualUnmodifiableListView(_external);
   }
 
-  final List<EntryPoint> _L1_HANDLER;
+  final List<EntryPoint> _L1Handler;
   @override
   @JsonKey(name: 'L1_HANDLER')
-  List<EntryPoint> get L1_HANDLER {
+  List<EntryPoint> get L1Handler {
     // ignore: implicit_dynamic_type
-    return EqualUnmodifiableListView(_L1_HANDLER);
+    return EqualUnmodifiableListView(_L1Handler);
   }
 
   @override
   String toString() {
-    return 'EntryPointsByType(CONSTRUCTOR: $CONSTRUCTOR, EXTERNAL: $EXTERNAL, L1_HANDLER: $L1_HANDLER)';
+    return 'EntryPointsByType(constructor: $constructor, external: $external, L1Handler: $L1Handler)';
   }
 
   @override
@@ -327,19 +327,19 @@ class _$_EntryPointsByType implements _EntryPointsByType {
         (other.runtimeType == runtimeType &&
             other is _$_EntryPointsByType &&
             const DeepCollectionEquality()
-                .equals(other._CONSTRUCTOR, _CONSTRUCTOR) &&
-            const DeepCollectionEquality().equals(other._EXTERNAL, _EXTERNAL) &&
+                .equals(other._constructor, _constructor) &&
+            const DeepCollectionEquality().equals(other._external, _external) &&
             const DeepCollectionEquality()
-                .equals(other._L1_HANDLER, _L1_HANDLER));
+                .equals(other._L1Handler, _L1Handler));
   }
 
   @JsonKey(ignore: true)
   @override
   int get hashCode => Object.hash(
       runtimeType,
-      const DeepCollectionEquality().hash(_CONSTRUCTOR),
-      const DeepCollectionEquality().hash(_EXTERNAL),
-      const DeepCollectionEquality().hash(_L1_HANDLER));
+      const DeepCollectionEquality().hash(_constructor),
+      const DeepCollectionEquality().hash(_external),
+      const DeepCollectionEquality().hash(_L1Handler));
 
   @JsonKey(ignore: true)
   @override
@@ -358,24 +358,24 @@ class _$_EntryPointsByType implements _EntryPointsByType {
 abstract class _EntryPointsByType implements EntryPointsByType {
   const factory _EntryPointsByType(
       {@JsonKey(name: 'CONSTRUCTOR')
-          required final List<EntryPoint> CONSTRUCTOR,
+          required final List<EntryPoint> constructor,
       @JsonKey(name: 'EXTERNAL')
-          required final List<EntryPoint> EXTERNAL,
+          required final List<EntryPoint> external,
       @JsonKey(name: 'L1_HANDLER')
-          required final List<EntryPoint> L1_HANDLER}) = _$_EntryPointsByType;
+          required final List<EntryPoint> L1Handler}) = _$_EntryPointsByType;
 
   factory _EntryPointsByType.fromJson(Map<String, dynamic> json) =
       _$_EntryPointsByType.fromJson;
 
   @override
   @JsonKey(name: 'CONSTRUCTOR')
-  List<EntryPoint> get CONSTRUCTOR;
+  List<EntryPoint> get constructor;
   @override
   @JsonKey(name: 'EXTERNAL')
-  List<EntryPoint> get EXTERNAL;
+  List<EntryPoint> get external;
   @override
   @JsonKey(name: 'L1_HANDLER')
-  List<EntryPoint> get L1_HANDLER;
+  List<EntryPoint> get L1Handler;
   @override
   @JsonKey(ignore: true)
   _$$_EntryPointsByTypeCopyWith<_$_EntryPointsByType> get copyWith =>

--- a/lib/src/provider/model/get_class.g.dart
+++ b/lib/src/provider/model/get_class.g.dart
@@ -26,7 +26,7 @@ _$_EntryPointsByType _$$_EntryPointsByTypeFromJson(Map<String, dynamic> json) =>
       external: (json['EXTERNAL'] as List<dynamic>)
           .map((e) => EntryPoint.fromJson(e as Map<String, dynamic>))
           .toList(),
-      L1Handler: (json['L1_HANDLER'] as List<dynamic>)
+      l1Handler: (json['L1_HANDLER'] as List<dynamic>)
           .map((e) => EntryPoint.fromJson(e as Map<String, dynamic>))
           .toList(),
     );
@@ -36,7 +36,7 @@ Map<String, dynamic> _$$_EntryPointsByTypeToJson(
     <String, dynamic>{
       'CONSTRUCTOR': instance.constructor.map((e) => e.toJson()).toList(),
       'EXTERNAL': instance.external.map((e) => e.toJson()).toList(),
-      'L1_HANDLER': instance.L1Handler.map((e) => e.toJson()).toList(),
+      'L1_HANDLER': instance.l1Handler.map((e) => e.toJson()).toList(),
     };
 
 _$_ContractClass _$$_ContractClassFromJson(Map<String, dynamic> json) =>

--- a/lib/src/provider/model/get_class.g.dart
+++ b/lib/src/provider/model/get_class.g.dart
@@ -20,13 +20,13 @@ Map<String, dynamic> _$$_EntryPointToJson(_$_EntryPoint instance) =>
 
 _$_EntryPointsByType _$$_EntryPointsByTypeFromJson(Map<String, dynamic> json) =>
     _$_EntryPointsByType(
-      CONSTRUCTOR: (json['CONSTRUCTOR'] as List<dynamic>)
+      constructor: (json['CONSTRUCTOR'] as List<dynamic>)
           .map((e) => EntryPoint.fromJson(e as Map<String, dynamic>))
           .toList(),
-      EXTERNAL: (json['EXTERNAL'] as List<dynamic>)
+      external: (json['EXTERNAL'] as List<dynamic>)
           .map((e) => EntryPoint.fromJson(e as Map<String, dynamic>))
           .toList(),
-      L1_HANDLER: (json['L1_HANDLER'] as List<dynamic>)
+      L1Handler: (json['L1_HANDLER'] as List<dynamic>)
           .map((e) => EntryPoint.fromJson(e as Map<String, dynamic>))
           .toList(),
     );
@@ -34,9 +34,9 @@ _$_EntryPointsByType _$$_EntryPointsByTypeFromJson(Map<String, dynamic> json) =>
 Map<String, dynamic> _$$_EntryPointsByTypeToJson(
         _$_EntryPointsByType instance) =>
     <String, dynamic>{
-      'CONSTRUCTOR': instance.CONSTRUCTOR.map((e) => e.toJson()).toList(),
-      'EXTERNAL': instance.EXTERNAL.map((e) => e.toJson()).toList(),
-      'L1_HANDLER': instance.L1_HANDLER.map((e) => e.toJson()).toList(),
+      'CONSTRUCTOR': instance.constructor.map((e) => e.toJson()).toList(),
+      'EXTERNAL': instance.external.map((e) => e.toJson()).toList(),
+      'L1_HANDLER': instance.L1Handler.map((e) => e.toJson()).toList(),
     };
 
 _$_ContractClass _$$_ContractClassFromJson(Map<String, dynamic> json) =>

--- a/test/provider/read_provider_test.dart
+++ b/test/provider/read_provider_test.dart
@@ -329,11 +329,11 @@ void main() {
             error: (error) => fail("Shouldn't fail"),
             result: (result) {
               final entry_points = result.entryPointsByType;
-              expect(entry_points.CONSTRUCTOR.length, 0);
-              expect(entry_points.L1_HANDLER.length, 0);
-              expect(entry_points.EXTERNAL.length, 2);
-              expect(entry_points.EXTERNAL[0].offset, "0x3a");
-              expect(entry_points.EXTERNAL[1].offset, "0x5b");
+              expect(entry_points.constructor.length, 0);
+              expect(entry_points.L1Handler.length, 0);
+              expect(entry_points.external.length, 2);
+              expect(entry_points.external[0].offset, "0x3a");
+              expect(entry_points.external[1].offset, "0x5b");
             });
       });
 
@@ -349,11 +349,11 @@ void main() {
           expect(error.code, equals(-32602));
         }, result: (result) {
           final entry_points = result.entryPointsByType;
-          expect(entry_points.CONSTRUCTOR.length, 0);
-          expect(entry_points.L1_HANDLER.length, 0);
-          expect(entry_points.EXTERNAL.length, 2);
-          expect(entry_points.EXTERNAL[0].offset, "0x3a");
-          expect(entry_points.EXTERNAL[1].offset, "0x5b");
+          expect(entry_points.constructor.length, 0);
+          expect(entry_points.L1Handler.length, 0);
+          expect(entry_points.external.length, 2);
+          expect(entry_points.external[0].offset, "0x3a");
+          expect(entry_points.external[1].offset, "0x5b");
         });
       });
     });

--- a/test/provider/read_provider_test.dart
+++ b/test/provider/read_provider_test.dart
@@ -330,7 +330,7 @@ void main() {
             result: (result) {
               final entry_points = result.entryPointsByType;
               expect(entry_points.constructor.length, 0);
-              expect(entry_points.L1Handler.length, 0);
+              expect(entry_points.l1Handler.length, 0);
               expect(entry_points.external.length, 2);
               expect(entry_points.external[0].offset, "0x3a");
               expect(entry_points.external[1].offset, "0x5b");
@@ -350,7 +350,7 @@ void main() {
         }, result: (result) {
           final entry_points = result.entryPointsByType;
           expect(entry_points.constructor.length, 0);
-          expect(entry_points.L1Handler.length, 0);
+          expect(entry_points.l1Handler.length, 0);
           expect(entry_points.external.length, 2);
           expect(entry_points.external[0].offset, "0x3a");
           expect(entry_points.external[1].offset, "0x5b");


### PR DESCRIPTION
This PR will use lowercase for EntryPointsByType members instead of uppercase
JSON mapping is done using @JsonKey
