### PR TITLE
feat(rpc): update getNonce for JSON RPC 0.2.1

### DIFF
--- a/lib/src/contract/contract.dart
+++ b/lib/src/contract/contract.dart
@@ -27,20 +27,20 @@ class Contract {
   }
 
   /// Get Nonce from account contract
-  Future<Felt> getNonce() async {
+  Future<Felt> getNonce([BlockId blockId = BlockId.latest]) async {
     final response = await account.provider.call(
       request: FunctionCall(
         contractAddress: account.accountAddress,
         entryPointSelector: getSelectorByName("get_nonce"),
         calldata: [],
       ),
-      blockId: BlockId.blockTag("latest"),
+      blockId: blockId,
     );
     return (response.when(error: (error) async {
       if (error.code == 21 && error.message == "Invalid message selector") {
         // Fallback on provider getNonce
         final nonceResp =
-            await account.provider.getNonce(account.accountAddress);
+            await account.provider.getNonce(blockId, account.accountAddress);
         return (nonceResp.when(
           error: (error) {
             throw Exception(

--- a/lib/src/provider/model/block_id.dart
+++ b/lib/src/provider/model/block_id.dart
@@ -18,6 +18,8 @@ class BlockId with _$BlockId {
     String blockTag,
   ) = BlockIdTag;
 
+  static const BlockId latest = BlockId.blockTag('latest');
+
   factory BlockId.fromJson(Map<String, dynamic> json) =>
       _$BlockIdFromJson(json);
 

--- a/lib/src/provider/read_provider.dart
+++ b/lib/src/provider/read_provider.dart
@@ -80,6 +80,7 @@ abstract class ReadProvider {
   ///
   /// [Spec](https://github.com/starkware-libs/starknet-specs/blob/v0.1.0/api/starknet_api_openrpc.json#L628-L653)
   Future<GetNonce> getNonce(
+    BlockId blockId,
     Felt contractAddress,
   );
 
@@ -245,12 +246,13 @@ class JsonRpcReadProvider implements ReadProvider {
 
   @override
   Future<GetNonce> getNonce(
+    BlockId blockId,
     Felt contractAddress,
   ) {
     return callRpcEndpoint(
       nodeUri: nodeUri,
       method: 'starknet_getNonce',
-      params: [contractAddress],
+      params: [blockId, contractAddress],
     ).then(GetNonce.fromJson);
   }
 

--- a/test/provider/read_provider_test.dart
+++ b/test/provider/read_provider_test.dart
@@ -376,6 +376,7 @@ void main() {
     group('starknet_getNonce', () {
       test('returns latest nonce associated with the given address', () async {
         final response = await provider.getNonce(
+          BlockId.blockTag('latest'),
           Felt.fromHexString(
               '0x019245f0f49d23f2379d3e3f20d1f3f46207d1c4a1d09cac8dd50e8d528aabe1'),
         );
@@ -387,6 +388,7 @@ void main() {
 
       test('reading nonce from invalid contract', () async {
         final response = await provider.getNonce(
+          BlockId.blockTag('latest'),
           Felt.fromHexString(
               '0x000000000000000000000000000000000000000000000000000000000000000'),
         );


### PR DESCRIPTION
`staknet_getNonce` requires `block_id` parameter in JSON RPC 0.2.1