### PR TITLE
Fix: generator should support ABI containing execute

### DIFF
--- a/packages/starknet_builder/.gitignore
+++ b/packages/starknet_builder/.gitignore
@@ -1,0 +1,1 @@
+test/integration/*.g.dart

--- a/packages/starknet_builder/lib/src/examples/balance.g.dart
+++ b/packages/starknet_builder/lib/src/examples/balance.g.dart
@@ -143,15 +143,20 @@ class MultipleOutputsWithArrayResult {
   }
 }
 
-class Balance extends Contract {
+class Balance {
   Balance({
-    required super.account,
-    required super.address,
-  });
+    required account,
+    required address,
+  }) : _contract = Contract(
+          account: account,
+          address: address,
+        );
+
+  final Contract _contract;
 
   Future<Felt> get_balance() async {
     final List<Felt> params = [];
-    final res = await call(
+    final res = await _contract.call(
       'get_balance',
       params,
     );
@@ -160,7 +165,7 @@ class Balance extends Contract {
 
   Future<Felt> get_answer() async {
     final List<Felt> params = [];
-    final res = await call(
+    final res = await _contract.call(
       'get_answer',
       params,
     );
@@ -175,7 +180,7 @@ class Balance extends Contract {
       a,
       b,
     ];
-    final res = await call(
+    final res = await _contract.call(
       'sum',
       params,
     );
@@ -184,7 +189,7 @@ class Balance extends Contract {
 
   Future<List<Felt>> copy_array(List<Felt> a) async {
     final List<Felt> params = [...a.toCallData()];
-    final res = await call(
+    final res = await _contract.call(
       'copy_array',
       params,
     );
@@ -193,7 +198,7 @@ class Balance extends Contract {
 
   Future<MultipleOutputsResult> multiple_outputs(Felt id) async {
     final List<Felt> params = [id];
-    final res = await call(
+    final res = await _contract.call(
       'multiple_outputs',
       params,
     );
@@ -208,7 +213,7 @@ class Balance extends Contract {
       ...a.toCallData(),
       id,
     ];
-    final res = await call(
+    final res = await _contract.call(
       'multiple_outputs_with_array',
       params,
     );
@@ -217,7 +222,7 @@ class Balance extends Contract {
 
   Future<String> increase_balance(Felt amount) async {
     final List<Felt> params = [amount];
-    final trx = await execute(
+    final trx = await _contract.execute(
       'increase_balance',
       params,
     );

--- a/packages/starknet_builder/lib/src/examples/erc20_upgradeable.g.dart
+++ b/packages/starknet_builder/lib/src/examples/erc20_upgradeable.g.dart
@@ -36,15 +36,20 @@ class Uint256 {
   }
 }
 
-class Erc20_upgradeable extends Contract {
+class Erc20_upgradeable {
   Erc20_upgradeable({
-    required super.account,
-    required super.address,
-  });
+    required account,
+    required address,
+  }) : _contract = Contract(
+          account: account,
+          address: address,
+        );
+
+  final Contract _contract;
 
   Future<Felt> name() async {
     final List<Felt> params = [];
-    final res = await call(
+    final res = await _contract.call(
       'name',
       params,
     );
@@ -53,7 +58,7 @@ class Erc20_upgradeable extends Contract {
 
   Future<Felt> symbol() async {
     final List<Felt> params = [];
-    final res = await call(
+    final res = await _contract.call(
       'symbol',
       params,
     );
@@ -62,7 +67,7 @@ class Erc20_upgradeable extends Contract {
 
   Future<Uint256> totalSupply() async {
     final List<Felt> params = [];
-    final res = await call(
+    final res = await _contract.call(
       'totalSupply',
       params,
     );
@@ -71,7 +76,7 @@ class Erc20_upgradeable extends Contract {
 
   Future<Felt> decimals() async {
     final List<Felt> params = [];
-    final res = await call(
+    final res = await _contract.call(
       'decimals',
       params,
     );
@@ -80,7 +85,7 @@ class Erc20_upgradeable extends Contract {
 
   Future<Uint256> balanceOf(Felt account) async {
     final List<Felt> params = [account];
-    final res = await call(
+    final res = await _contract.call(
       'balanceOf',
       params,
     );
@@ -95,7 +100,7 @@ class Erc20_upgradeable extends Contract {
       owner,
       spender,
     ];
-    final res = await call(
+    final res = await _contract.call(
       'allowance',
       params,
     );
@@ -118,7 +123,7 @@ class Erc20_upgradeable extends Contract {
       recipient,
       proxy_admin,
     ];
-    final trx = await execute(
+    final trx = await _contract.execute(
       'initializer',
       params,
     );
@@ -131,7 +136,7 @@ class Erc20_upgradeable extends Contract {
 
   Future<String> upgrade(Felt new_implementation) async {
     final List<Felt> params = [new_implementation];
-    final trx = await execute(
+    final trx = await _contract.execute(
       'upgrade',
       params,
     );
@@ -150,7 +155,7 @@ class Erc20_upgradeable extends Contract {
       recipient,
       ...amount.toCallData(),
     ];
-    final trx = await execute(
+    final trx = await _contract.execute(
       'transfer',
       params,
     );
@@ -171,7 +176,7 @@ class Erc20_upgradeable extends Contract {
       recipient,
       ...amount.toCallData(),
     ];
-    final trx = await execute(
+    final trx = await _contract.execute(
       'transferFrom',
       params,
     );
@@ -190,7 +195,7 @@ class Erc20_upgradeable extends Contract {
       spender,
       ...amount.toCallData(),
     ];
-    final trx = await execute(
+    final trx = await _contract.execute(
       'approve',
       params,
     );
@@ -209,7 +214,7 @@ class Erc20_upgradeable extends Contract {
       spender,
       ...added_value.toCallData(),
     ];
-    final trx = await execute(
+    final trx = await _contract.execute(
       'increaseAllowance',
       params,
     );
@@ -228,7 +233,7 @@ class Erc20_upgradeable extends Contract {
       spender,
       ...subtracted_value.toCallData(),
     ];
-    final trx = await execute(
+    final trx = await _contract.execute(
       'decreaseAllowance',
       params,
     );

--- a/packages/starknet_builder/pubspec.yaml
+++ b/packages/starknet_builder/pubspec.yaml
@@ -14,6 +14,8 @@ dependencies:
   starknet:
 
 dev_dependencies:
+  analyzer: ^5.4.0
   build_runner: ^2.1.11
+  build_test: ^2.1.6
   lints: ^2.0.0
   test: ^1.16.0

--- a/packages/starknet_builder/test/execute_test.dart
+++ b/packages/starknet_builder/test/execute_test.dart
@@ -1,0 +1,39 @@
+import 'package:analyzer/dart/analysis/results.dart';
+import 'package:analyzer/diagnostic/diagnostic.dart';
+
+import 'package:build_test/build_test.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test("Generator should support ABI containing 'execute'", () async {
+    final expectedClassName = "Execute";
+    final expectedFileName = "execute.g.dart";
+
+    final main = await resolveSources(
+      {
+        'starknet_builder|test/integration/$expectedFileName': useAssetReader,
+      },
+      (resolver) => resolver.libraries.firstWhere(
+          (element) => element.source.toString().contains('execute')),
+    );
+    final errorResult = await main.session
+            .getErrors('/starknet_builder/test/integration/$expectedFileName')
+        as ErrorsResult;
+    final criticalErrors = errorResult.errors
+        .where((element) => element.severity == Severity.error)
+        .toList();
+    expect(criticalErrors, isEmpty,
+        reason: "Generated source code should compile without critical error");
+
+    final generatedClass = main.getClass(expectedClassName);
+    expect(generatedClass, isNotNull,
+        reason:
+            "Generated source code should contains a class named '$expectedClassName'");
+    for (var methodName in ['execute']) {
+      expect(generatedClass!.methods.where((e) => e.name == methodName).length,
+          equals(1),
+          reason:
+              "Generated class should contains a method named '$methodName'");
+    }
+  });
+}

--- a/packages/starknet_builder/test/integration/execute.abi.json
+++ b/packages/starknet_builder/test/integration/execute.abi.json
@@ -1,0 +1,29 @@
+[
+    {
+        "inputs": [
+            {
+                "name": "a",
+                "type": "felt"
+            },
+            {
+                "name": "b",
+                "type": "felt"
+            }
+        ],
+        "name": "execute",
+        "outputs": [],
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "get",
+        "outputs": [
+            {
+                "name": "sum",
+                "type": "felt"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    }
+]

--- a/packages/starknet_builder/test/integration/execute.cairo
+++ b/packages/starknet_builder/test/integration/execute.cairo
@@ -1,0 +1,26 @@
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+
+
+@storage_var
+func sum() -> (res: felt) {
+}
+
+
+
+@external
+func execute{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(
+    a: felt, b: felt
+) {
+    sum.write(a + b);
+    return ();
+}
+
+@view
+func get{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (
+    sum: felt
+) {
+    let (sum_) = sum.read();
+    return (sum=sum_);
+}


### PR DESCRIPTION
With this PR, generated class from ABI doesn't inherit anymore from `Contract` class to avoid method name clash on `execute`

A test case have been added to ensure that generated class contains `execute` method.

Closes #95 
