### PR TITLE
Fix #101: Generated source code for 'MultipleOutputResult' fromCallData should not contains unused variable

### DIFF
--- a/.github/workflows/ci_builder.yaml
+++ b/.github/workflows/ci_builder.yaml
@@ -1,0 +1,46 @@
+name: CI builder
+
+on:
+  pull_request:
+
+env:
+  WORK_DIR: packages/starknet_builder
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: dart-lang/setup-dart@v1.0
+        with:
+          sdk: stable
+      - id: install
+        name: Install dependencies
+        run: dart pub get
+        working-directory: ${{ env.WORK_DIR }}
+      - name: Check formatting
+        run: dart format --output=none --set-exit-if-changed .
+        working-directory: ${{ env.WORK_DIR }}
+      - name: Analyze code
+        run: dart analyze --fatal-infos
+        if: always() && steps.install.outcome == 'success'
+        working-directory: ${{ env.WORK_DIR }}
+  
+  test:
+    defaults:
+      run:
+        working-directory: ${{ env.WORK_DIR }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: dart-lang/setup-dart@v1.0
+        with:
+          sdk: stable
+      - id: install
+        name: Install dependencies
+        run: dart pub get
+      - name: Run build_runner
+        run: dart run build_runner build --delete-conflicting-outputs
+      - name: Run tests
+        run: dart test
+

--- a/packages/starknet_builder/lib/src/examples/erc20_upgradeable.g.dart
+++ b/packages/starknet_builder/lib/src/examples/erc20_upgradeable.g.dart
@@ -245,16 +245,3 @@ class Erc20_upgradeable {
     return trxHash;
   }
 }
-
-extension on List<Felt> {
-  List<Felt> toCallData() {
-    return [
-      Felt.fromInt(this.length),
-      ...this,
-    ];
-  }
-
-  List<Felt> fromCallData() {
-    return this.sublist(1);
-  }
-}

--- a/packages/starknet_builder/lib/src/generator.dart
+++ b/packages/starknet_builder/lib/src/generator.dart
@@ -90,19 +90,15 @@ class _ContractAbiGenerator {
             calls.add(functionAbi);
           }
           if (false == needListFeltToCallData) {
-            for (var ii in functionAbi.inputsFiltered) {
-              if (ii.type == "felt*") {
-                needListFeltToCallData = true;
-                break;
-              }
+            if (functionAbi.inputsHas("felt*")) {
+              needListFeltToCallData = true;
+              break;
             }
           }
           if (false == needListFeltFromCallData) {
-            for (var oo in functionAbi.outputsFiltered) {
-              if (oo.type == "felt*") {
-                needListFeltFromCallData = true;
-                break;
-              }
+            if (functionAbi.outputsHas("felt*")) {
+              needListFeltFromCallData = true;
+              break;
             }
           }
           break;
@@ -273,12 +269,15 @@ class _ContractAbiGenerator {
                 ..body = Block((b) {
                   String offsetVar = "offset";
                   Reference offset = refer(offsetVar);
-                  String tmpSizeVar = "_tmpSize";
-                  Reference tmpSize = refer(tmpSizeVar);
                   b.addExpression(declareVar(offsetVar, type: refer('int'))
                       .assign(literalNum(0)));
-                  b.addExpression(declareVar(tmpSizeVar, type: refer('int'))
-                      .assign(literalNum(0)));
+                  String tmpSizeVar = "_tmpSize";
+                  Reference tmpSize = refer(tmpSizeVar);
+
+                  if (fun.outputsHas("felt*")) {
+                    b.addExpression(declareVar(tmpSizeVar, type: refer('int'))
+                        .assign(literalNum(0)));
+                  }
                   for (var output in fun.outputsFiltered) {
                     switch (output.type) {
                       case "felt":
@@ -572,6 +571,14 @@ extension on FunctionAbiEntry {
 
   List<TypedParameter> get outputsFiltered {
     return this.outputs.filterArray();
+  }
+
+  bool inputsHas(String type_) {
+    return this.inputsFiltered.where((e) => e.type == type_).isNotEmpty;
+  }
+
+  bool outputsHas(String type_) {
+    return this.outputsFiltered.where((e) => e.type == type_).isNotEmpty;
   }
 }
 

--- a/packages/starknet_builder/test/integration/issue_101_multiple_output.abi.json
+++ b/packages/starknet_builder/test/integration/issue_101_multiple_output.abi.json
@@ -1,0 +1,61 @@
+[
+    {
+        "members": [
+            {
+                "name": "amount",
+                "offset": 0,
+                "type": "Uint256"
+            },
+            {
+                "name": "id",
+                "offset": 2,
+                "type": "felt"
+            }
+        ],
+        "name": "MyAccount",
+        "size": 3,
+        "type": "struct"
+    },
+    {
+        "members": [
+            {
+                "name": "low",
+                "offset": 0,
+                "type": "felt"
+            },
+            {
+                "name": "high",
+                "offset": 1,
+                "type": "felt"
+            }
+        ],
+        "name": "Uint256",
+        "size": 2,
+        "type": "struct"
+    },
+    {
+        "inputs": [
+            {
+                "name": "id",
+                "type": "felt"
+            }
+        ],
+        "name": "multiple_outputs",
+        "outputs": [
+            {
+                "name": "account",
+                "type": "MyAccount"
+            },
+            {
+                "name": "total",
+                "type": "Uint256"
+            },
+            {
+                "name": "ref",
+                "type": "felt"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    }
+]

--- a/packages/starknet_builder/test/integration/issue_101_multiple_output.cairo
+++ b/packages/starknet_builder/test/integration/issue_101_multiple_output.cairo
@@ -1,0 +1,21 @@
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+from starkware.cairo.common.uint256 import Uint256
+
+struct MyAccount {
+    amount: Uint256,
+    id: felt,
+}
+
+@view
+func multiple_outputs{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}(id: felt) -> (
+    account: MyAccount, total: Uint256, ref: felt
+) {
+    let amount = Uint256(low=1, high=0);
+    let account = MyAccount(amount=amount, id=id);
+    let total = Uint256(low=1000, high=0);
+    let ref = id + 1;
+    return(account=account, total=total, ref=ref);
+}
+

--- a/packages/starknet_builder/test/integration/simple.abi.json
+++ b/packages/starknet_builder/test/integration/simple.abi.json
@@ -1,0 +1,14 @@
+[
+    {
+        "inputs": [],
+        "name": "answer",
+        "outputs": [
+            {
+                "name": "answer",
+                "type": "felt"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    }
+]

--- a/packages/starknet_builder/test/integration/simple.cairo
+++ b/packages/starknet_builder/test/integration/simple.cairo
@@ -1,0 +1,11 @@
+%lang starknet
+
+from starkware.cairo.common.cairo_builtins import HashBuiltin
+
+
+@view
+func answer{syscall_ptr: felt*, pedersen_ptr: HashBuiltin*, range_check_ptr}() -> (
+    answer: felt
+) {
+    return (answer=42);    
+}

--- a/packages/starknet_builder/test/issues_test.dart
+++ b/packages/starknet_builder/test/issues_test.dart
@@ -1,0 +1,34 @@
+import 'package:analyzer/dart/analysis/results.dart';
+import 'package:analyzer/diagnostic/diagnostic.dart';
+import 'package:build_test/build_test.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test(
+      "Issue #101: Generated source code for 'MultipleOutputResult' fromCallData should not contains unused variable",
+      () async {
+    final expectedFileName = "issue_101_multiple_output.g.dart";
+
+    final main = await resolveSources(
+      {
+        'starknet_builder|test/integration/$expectedFileName': useAssetReader,
+      },
+      (resolver) => resolver.libraries
+          .firstWhere((element) => element.source.toString().contains('issue')),
+    );
+    final errorResult = await main.session
+            .getErrors('/starknet_builder/test/integration/$expectedFileName')
+        as ErrorsResult;
+    final criticalErrors = errorResult.errors
+        .where((element) => element.severity == Severity.error)
+        .toList();
+    expect(criticalErrors, isEmpty,
+        reason: "Generated source code should compile without critical error");
+    final unusedLocalVariableErrors = errorResult.errors
+        .where((element) =>
+            element.errorCode.uniqueName == "HintCode.UNUSED_LOCAL_VARIABLE")
+        .toList();
+    expect(unusedLocalVariableErrors, isEmpty,
+        reason: "Generated source code shouldn't contains unused variable");
+  });
+}

--- a/packages/starknet_builder/test/simple_contract_test.dart
+++ b/packages/starknet_builder/test/simple_contract_test.dart
@@ -1,0 +1,57 @@
+import 'package:analyzer/dart/analysis/results.dart';
+import 'package:analyzer/diagnostic/diagnostic.dart';
+import 'package:analyzer/dart/element/element.dart';
+import 'package:build_test/build_test.dart';
+import 'package:test/test.dart';
+
+void main() {
+  final expectedClassName = "Simple";
+  final expectedFileName = "simple.g.dart";
+  late LibraryElement main;
+  late ClassElement? generatedClass;
+  late ErrorsResult errorResult;
+
+  setUp(() async {
+    main = await resolveSources(
+      {
+        'starknet_builder|test/integration/$expectedFileName': useAssetReader,
+      },
+      (resolver) => resolver.libraries.firstWhere(
+          (element) => element.source.toString().contains('simple')),
+    );
+    errorResult = await main.session
+            .getErrors('/starknet_builder/test/integration/$expectedFileName')
+        as ErrorsResult;
+    generatedClass = main.getClass(expectedClassName);
+  });
+  test("Generated source code should compile without critical error", () {
+    final criticalErrors = errorResult.errors
+        .where((element) => element.severity == Severity.error)
+        .toList();
+    expect(criticalErrors, isEmpty,
+        reason: "Generated source code should compile without critical error");
+  });
+  test(
+      "Generated class from simple contract should have only 1 method named 'answer'",
+      () {
+    expect(generatedClass, isNotNull,
+        reason:
+            "Generated source code should contains a class named '$expectedClassName'");
+    expect(generatedClass!.methods.length, equals(1),
+        reason: "Generated class should have only 1 method");
+    expect(generatedClass!.methods[0].name, equals("answer"),
+        reason: "Generated class shoud have 1 method named 'answer'");
+  });
+  test(
+      "#98: Generated source code from ABI should not add extension on List<Felt> if not needed",
+      () async {
+    if (!main.accessibleExtensions.isEmpty) {
+      for (var ee in main.accessibleExtensions) {
+        expect(ee.getDisplayString(withNullability: false),
+            isNot(endsWith("on List<Felt>")),
+            reason:
+                "Generated source code should not add extension on List<Felt> if not needed");
+      }
+    }
+  });
+}


### PR DESCRIPTION
Add check to avoid adding `_tmpSize` in `fromCallData` for a result class without felt array.

It depends on PR #99 and PR #100

Closes #101 