### PR TITLE
Add support to declare transaction version 1

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -108,6 +108,7 @@ jobs:
       - uses: axel-op/dart-package-analyzer@v3
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
+          relativePath: ${{ env.WORK_DIR }}
 
   publish:
     if: github.event.pull_request.head.repo.fork == false

--- a/packages/starknet/lib/src/account.dart
+++ b/packages/starknet/lib/src/account.dart
@@ -70,7 +70,18 @@ class Account {
 
   Future<DeclareTransactionResponse> declare({
     required CompiledContract compiledContract,
+    Felt? maxFee,
+    Felt? nonce,
   }) async {
+    nonce = nonce ?? Felt.fromInt(0);
+    maxFee = maxFee ?? defaultMaxFee;
+
+    final signature = signer.signDeclareTransaction(
+      compiledContract: compiledContract,
+      senderAddress: accountAddress,
+      chainId: chainId,
+    );
+
     return provider.addDeclareTransaction(
       DeclareTransactionRequest(
         declareTransaction: DeclareTransaction(
@@ -78,7 +89,7 @@ class Account {
           nonce: defaultNonce,
           contractClass: compiledContract.compress(),
           senderAddress: accountAddress,
-          signature: [],
+          signature: signature,
           type: 'DECLARE',
         ),
       ),

--- a/packages/starknet/lib/src/contract/model/compiled_contract.dart
+++ b/packages/starknet/lib/src/contract/model/compiled_contract.dart
@@ -27,8 +27,455 @@ class CompiledContract with _$CompiledContract {
       abi: abi,
     );
   }
+
+  /// Return program encoded as Python json.dumps
+  String encode() {
+    final new_program = Map.of(program);
+    new_program.remove("attributes");
+    final encoded = CompiledContractJsonEncoder().convert({
+      "abi": abi,
+      "program": new_program,
+    });
+    return encoded;
+  }
+
+  /// Compute hashes for externals, l1 handlers and constructors
+  /// https://docs.starknet.io/documentation/architecture_and_concepts/Contracts/contract-hash/
+  EntryPointsHashes entrypointsHashes() {
+    List<BigInt> buffer = [];
+    for (var entrypoint in entryPointsByType.external) {
+      buffer.add(entrypoint.selector.toBigInt());
+      buffer.add(BigInt.parse(entrypoint.offset));
+    }
+    final externals = computeHashOnElements(buffer);
+
+    buffer.clear();
+    for (var entrypoint in entryPointsByType.l1Handler) {
+      buffer.add(entrypoint.selector.toBigInt());
+      buffer.add(BigInt.parse(entrypoint.offset));
+    }
+    final l1handlers = computeHashOnElements(buffer);
+    buffer.clear();
+
+    for (var entrypoint in entryPointsByType.constructor) {
+      buffer.add(entrypoint.selector.toBigInt());
+      buffer.add(BigInt.parse(entrypoint.offset));
+    }
+    final constructors = computeHashOnElements(buffer);
+    return EntryPointsHashes(externals, l1handlers, constructors);
+  }
+
+  /// Compute hash for builtins
+  /// https://docs.starknet.io/documentation/architecture_and_concepts/Contracts/contract-hash/
+  BigInt builtinsHash() {
+    return computeHashOnElements((program["builtins"] as List)
+        .map((e) => Felt.fromString(e).toBigInt())
+        .toList());
+  }
+
+  /// Compute program hash
+  /// https://docs.starknet.io/documentation/architecture_and_concepts/Contracts/contract-hash/
+  BigInt programHash() {
+    final encoded = encode();
+    return starknetKeccak(ascii.encode(encoded)).toBigInt();
+  }
+
+  /// Compute bytecode hash
+  /// https://docs.starknet.io/documentation/architecture_and_concepts/Contracts/contract-hash/
+  BigInt byteCodeHash() {
+    return computeHashOnElements((program["data"] as List)
+        .map((e) => Felt.fromHexString(e).toBigInt())
+        .toList());
+  }
+
+  /// Compute contract class hash
+  /// https://docs.starknet.io/documentation/architecture_and_concepts/Contracts/contract-hash/
+  BigInt classHash() {
+    List<BigInt> elements = [];
+    elements.add(BigInt.from(0)); // FIXME: API VERSION
+    final hashes = entrypointsHashes();
+    elements.add(hashes.externals);
+    elements.add(hashes.l1handlers);
+    elements.add(hashes.constructors);
+    elements.add(builtinsHash());
+    elements.add(programHash());
+    elements.add(byteCodeHash());
+    final res = computeHashOnElements(elements);
+    return res;
+  }
+}
+
+// freezed/json_serializable add 'runtimeType' and 'stateMutability: null'
+Object? _contractJsonCleanup(dynamic object) {
+  if (object is ContractAbiEntry) {
+    var res = object.toJson();
+    res.remove("runtimeType");
+    if (object is FunctionAbiEntry) {
+      if (object.stateMutability == null) {
+        res.remove("stateMutability");
+      }
+    }
+    return res;
+  }
+  return object.toJson();
+}
+
+class EntryPointsHashes {
+  final BigInt externals;
+  final BigInt l1handlers;
+  final BigInt constructors;
+
+  EntryPointsHashes(this.externals, this.l1handlers, this.constructors);
 }
 
 String compressProgram(Map<String, Object?> program) {
   return base64.encode(gzip.encode(utf8.encode(jsonEncode(program))));
+}
+
+/// JSON encoder to mimic Python json dumps
+class CompiledContractJsonEncoder extends JsonEncoder {
+  @override
+  String convert(Object? object) =>
+      _JsonStringStringifier.stringify(object, _contractJsonCleanup, indent);
+}
+
+// 2023-02-03: since these symbols is not exported by dart sdk,
+// I have to duplicate the code here
+// ignore_for_file: constant_identifier_names
+// ignore_for_file: use_function_type_syntax_for_parameters
+// ignore_for_file: no_leading_underscores_for_local_identifiers
+// ignore_for_file: annotate_overrides
+
+// Implementation of encoder/stringifier.
+dynamic _defaultToEncodable(dynamic object) => object.toJson();
+
+abstract class _JsonStringifier {
+  // Character code constants.
+  static const int backspace = 0x08;
+  static const int tab = 0x09;
+  static const int newline = 0x0a;
+  static const int carriageReturn = 0x0d;
+  static const int formFeed = 0x0c;
+  static const int quote = 0x22;
+  static const int char_0 = 0x30;
+  static const int backslash = 0x5c;
+  static const int char_b = 0x62;
+  static const int char_d = 0x64;
+  static const int char_f = 0x66;
+  static const int char_n = 0x6e;
+  static const int char_r = 0x72;
+  static const int char_t = 0x74;
+  static const int char_u = 0x75;
+  static const int surrogateMin = 0xd800;
+  static const int surrogateMask = 0xfc00;
+  static const int surrogateLead = 0xd800;
+  static const int surrogateTrail = 0xdc00;
+
+  /// List of objects currently being traversed. Used to detect cycles.
+  final List _seen = [];
+
+  /// Function called for each un-encodable object encountered.
+  final Function(dynamic) _toEncodable;
+
+  _JsonStringifier(dynamic toEncodable(dynamic o)?)
+      : _toEncodable = toEncodable ?? _defaultToEncodable;
+
+  String? get _partialResult;
+
+  /// Append a string to the JSON output.
+  void writeString(String characters);
+
+  /// Append part of a string to the JSON output.
+  void writeStringSlice(String characters, int start, int end);
+
+  /// Append a single character, given by its code point, to the JSON output.
+  void writeCharCode(int charCode);
+
+  /// Write a number to the JSON output.
+  void writeNumber(num number);
+
+  // ('0' + x) or ('a' + x - 10)
+  static int hexDigit(int x) => x < 10 ? 48 + x : 87 + x;
+
+  /// Write, and suitably escape, a string's content as a JSON string literal.
+  void writeStringContent(String s) {
+    var offset = 0;
+    final length = s.length;
+    for (var i = 0; i < length; i++) {
+      var charCode = s.codeUnitAt(i);
+      if (charCode > backslash) {
+        if (charCode >= surrogateMin) {
+          // Possible surrogate. Check if it is unpaired.
+          if (((charCode & surrogateMask) == surrogateLead &&
+                  !(i + 1 < length &&
+                      (s.codeUnitAt(i + 1) & surrogateMask) ==
+                          surrogateTrail)) ||
+              ((charCode & surrogateMask) == surrogateTrail &&
+                  !(i - 1 >= 0 &&
+                      (s.codeUnitAt(i - 1) & surrogateMask) ==
+                          surrogateLead))) {
+            // Lone surrogate.
+            if (i > offset) writeStringSlice(s, offset, i);
+            offset = i + 1;
+            writeCharCode(backslash);
+            writeCharCode(char_u);
+            writeCharCode(char_d);
+            writeCharCode(hexDigit((charCode >> 8) & 0xf));
+            writeCharCode(hexDigit((charCode >> 4) & 0xf));
+            writeCharCode(hexDigit(charCode & 0xf));
+          }
+        }
+        continue;
+      }
+      if (charCode < 32) {
+        if (i > offset) writeStringSlice(s, offset, i);
+        offset = i + 1;
+        writeCharCode(backslash);
+        switch (charCode) {
+          case backspace:
+            writeCharCode(char_b);
+            break;
+          case tab:
+            writeCharCode(char_t);
+            break;
+          case newline:
+            writeCharCode(char_n);
+            break;
+          case formFeed:
+            writeCharCode(char_f);
+            break;
+          case carriageReturn:
+            writeCharCode(char_r);
+            break;
+          default:
+            writeCharCode(char_u);
+            writeCharCode(char_0);
+            writeCharCode(char_0);
+            writeCharCode(hexDigit((charCode >> 4) & 0xf));
+            writeCharCode(hexDigit(charCode & 0xf));
+            break;
+        }
+      } else if (charCode == quote || charCode == backslash) {
+        if (i > offset) writeStringSlice(s, offset, i);
+        offset = i + 1;
+        writeCharCode(backslash);
+        writeCharCode(charCode);
+      }
+    }
+    if (offset == 0) {
+      writeString(s);
+    } else if (offset < length) {
+      writeStringSlice(s, offset, length);
+    }
+  }
+
+  /// Check if an encountered object is already being traversed.
+  ///
+  /// Records the object if it isn't already seen. Should have a matching call to
+  /// [_removeSeen] when the object is no longer being traversed.
+  void _checkCycle(Object? object) {
+    for (var i = 0; i < _seen.length; i++) {
+      if (identical(object, _seen[i])) {
+        throw JsonCyclicError(object);
+      }
+    }
+    _seen.add(object);
+  }
+
+  /// Remove [object] from the list of currently traversed objects.
+  ///
+  /// Should be called in the opposite order of the matching [_checkCycle]
+  /// calls.
+  void _removeSeen(Object? object) {
+    assert(_seen.isNotEmpty);
+    assert(identical(_seen.last, object));
+    _seen.removeLast();
+  }
+
+  /// Write an object.
+  ///
+  /// If [object] isn't directly encodable, the [_toEncodable] function gets one
+  /// chance to return a replacement which is encodable.
+  void writeObject(Object? object) {
+    // Tries stringifying object directly. If it's not a simple value, List or
+    // Map, call toJson() to get a custom representation and try serializing
+    // that.
+    if (writeJsonValue(object)) return;
+    _checkCycle(object);
+    try {
+      var customJson = _toEncodable(object);
+      if (!writeJsonValue(customJson)) {
+        throw JsonUnsupportedObjectError(object, partialResult: _partialResult);
+      }
+      _removeSeen(object);
+    } catch (e) {
+      throw JsonUnsupportedObjectError(object,
+          cause: e, partialResult: _partialResult);
+    }
+  }
+
+  /// Serialize a [num], [String], [bool], [Null], [List] or [Map] value.
+  ///
+  /// Returns true if the value is one of these types, and false if not.
+  /// If a value is both a [List] and a [Map], it's serialized as a [List].
+  bool writeJsonValue(Object? object) {
+    if (object is num) {
+      if (!object.isFinite) return false;
+      writeNumber(object);
+      return true;
+    } else if (identical(object, true)) {
+      writeString('true');
+      return true;
+    } else if (identical(object, false)) {
+      writeString('false');
+      return true;
+    } else if (object == null) {
+      writeString('null');
+      return true;
+    } else if (object is String) {
+      writeString('"');
+      writeStringContent(object);
+      writeString('"');
+      return true;
+    } else if (object is List) {
+      _checkCycle(object);
+      writeList(object);
+      _removeSeen(object);
+      return true;
+    } else if (object is Map) {
+      _checkCycle(object);
+      // writeMap can fail if keys are not all strings.
+      var success = writeMap(object);
+      _removeSeen(object);
+      return success;
+    } else if (object is BigInt) {
+      // add BigInt since I'm using them as a workaround
+      // for JSON parsing using num (64 bits) to store number
+      writeStringContent(object.toString());
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  /// Serialize a [List].
+  void writeList(List<Object?> list) {
+    writeString('[');
+    if (list.isNotEmpty) {
+      writeObject(list[0]);
+      for (var i = 1; i < list.length; i++) {
+        writeString(', '); // add a space as in python json dumps
+        writeObject(list[i]);
+      }
+    }
+    writeString(']');
+  }
+
+  /// Serialize a [Map].
+  bool writeMap(Map<Object?, Object?> map) {
+    if (map.isEmpty) {
+      writeString("{}");
+      return true;
+    }
+    var keyValueList = List<Object?>.filled(map.length * 2, null);
+    var i = 0;
+    var allStringKeys = true;
+    Map.fromEntries(map.entries.toList()
+          ..sort((e1, e2) =>
+              (e1.key as String).naturalCompareTo(e2.key as String)))
+        .forEach((key, value) {
+      if (key is! String) {
+        allStringKeys = false;
+      }
+      keyValueList[i++] = key;
+      keyValueList[i++] = value;
+    });
+    if (!allStringKeys) return false;
+    writeString('{');
+    var separator = '"';
+    for (var i = 0; i < keyValueList.length; i += 2) {
+      writeString(separator);
+      separator = ', "'; // add a space as in python json dumps
+      writeStringContent(keyValueList[i] as String);
+      writeString('": '); // add a space as in python json dumps
+      writeObject(keyValueList[i + 1]);
+    }
+    writeString('}');
+    return true;
+  }
+}
+
+/// A specialization of [_JsonStringifier] that writes its JSON to a string.
+class _JsonStringStringifier extends _JsonStringifier {
+  final StringSink _sink;
+
+  _JsonStringStringifier(
+      this._sink, dynamic Function(dynamic object)? _toEncodable)
+      : super(_toEncodable);
+
+  /// Convert object to a string.
+  ///
+  /// The [toEncodable] function is used to convert non-encodable objects
+  /// to encodable ones.
+  ///
+  /// If [indent] is not `null`, the resulting JSON will be "pretty-printed"
+  /// with newlines and indentation. The `indent` string is added as indentation
+  /// for each indentation level. It should only contain valid JSON whitespace
+  /// characters (space, tab, carriage return or line feed).
+  static String stringify(
+      Object? object, dynamic toEncodable(dynamic object)?, String? indent) {
+    var output = StringBuffer();
+    printOn(object, output, toEncodable, indent);
+    return output.toString();
+  }
+
+  /// Convert object to a string, and write the result to the [output] sink.
+  ///
+  /// The result is written piecemally to the sink.
+  static void printOn(Object? object, StringSink output,
+      dynamic toEncodable(dynamic o)?, String? indent) {
+    _JsonStringifier stringifier;
+    stringifier = _JsonStringStringifier(output, toEncodable);
+    stringifier.writeObject(object);
+  }
+
+  String? get _partialResult => _sink is StringBuffer ? _sink.toString() : null;
+
+  @override
+  void writeNumber(num number) {
+    _sink.write(number);
+  }
+
+  @override
+  void writeString(String string) {
+    _sink.write(string);
+  }
+
+  @override
+  void writeStringSlice(String string, int start, int end) {
+    _sink.write(string.substring(start, end));
+  }
+
+  @override
+  void writeCharCode(int charCode) {
+    _sink.writeCharCode(charCode);
+  }
+}
+
+extension ContractCompare on String {
+  int naturalCompareTo(String other) {
+    // handle case where string is an integer (for hint)
+    int? me = int.tryParse(this);
+    int? you = int.tryParse(other);
+    if (me != null && you != null) {
+      if (me == you) {
+        return 0;
+      } else if (me > you) {
+        return 1;
+      } else {
+        return -1;
+      }
+    }
+    return compareTo(other);
+  }
 }

--- a/packages/starknet/lib/src/contract/model/contract_abi.dart
+++ b/packages/starknet/lib/src/contract/model/contract_abi.dart
@@ -10,7 +10,8 @@ class ContractAbiEntry with _$ContractAbiEntry {
     required String name,
     required List<TypedParameter> inputs,
     required List<TypedParameter> outputs,
-    @JsonKey(name: 'stateMutability') String? stateMutability,
+    @JsonKey(name: 'stateMutability', includeIfNull: false)
+        String? stateMutability,
   }) = FunctionAbiEntry;
 
   const factory ContractAbiEntry.event({

--- a/packages/starknet/lib/src/contract/model/contract_abi.freezed.dart
+++ b/packages/starknet/lib/src/contract/model/contract_abi.freezed.dart
@@ -42,7 +42,8 @@ mixin _$ContractAbiEntry {
             String name,
             List<TypedParameter> inputs,
             List<TypedParameter> outputs,
-            @JsonKey(name: 'stateMutability') String? stateMutability)
+            @JsonKey(name: 'stateMutability', includeIfNull: false)
+                String? stateMutability)
         function,
     required TResult Function(String type, String name,
             List<TypedParameter> keys, List<TypedParameter> data)
@@ -62,7 +63,8 @@ mixin _$ContractAbiEntry {
             String name,
             List<TypedParameter> inputs,
             List<TypedParameter> outputs,
-            @JsonKey(name: 'stateMutability') String? stateMutability)?
+            @JsonKey(name: 'stateMutability', includeIfNull: false)
+                String? stateMutability)?
         function,
     TResult? Function(String type, String name, List<TypedParameter> keys,
             List<TypedParameter> data)?
@@ -82,7 +84,8 @@ mixin _$ContractAbiEntry {
             String name,
             List<TypedParameter> inputs,
             List<TypedParameter> outputs,
-            @JsonKey(name: 'stateMutability') String? stateMutability)?
+            @JsonKey(name: 'stateMutability', includeIfNull: false)
+                String? stateMutability)?
         function,
     TResult Function(String type, String name, List<TypedParameter> keys,
             List<TypedParameter> data)?
@@ -178,7 +181,8 @@ abstract class _$$FunctionAbiEntryCopyWith<$Res>
       String name,
       List<TypedParameter> inputs,
       List<TypedParameter> outputs,
-      @JsonKey(name: 'stateMutability') String? stateMutability});
+      @JsonKey(name: 'stateMutability', includeIfNull: false)
+          String? stateMutability});
 }
 
 /// @nodoc
@@ -231,7 +235,8 @@ class _$FunctionAbiEntry implements FunctionAbiEntry {
       required this.name,
       required final List<TypedParameter> inputs,
       required final List<TypedParameter> outputs,
-      @JsonKey(name: 'stateMutability') this.stateMutability,
+      @JsonKey(name: 'stateMutability', includeIfNull: false)
+          this.stateMutability,
       final String? $type})
       : _inputs = inputs,
         _outputs = outputs,
@@ -261,7 +266,7 @@ class _$FunctionAbiEntry implements FunctionAbiEntry {
   }
 
   @override
-  @JsonKey(name: 'stateMutability')
+  @JsonKey(name: 'stateMutability', includeIfNull: false)
   final String? stateMutability;
 
   @JsonKey(name: 'runtimeType')
@@ -309,7 +314,8 @@ class _$FunctionAbiEntry implements FunctionAbiEntry {
             String name,
             List<TypedParameter> inputs,
             List<TypedParameter> outputs,
-            @JsonKey(name: 'stateMutability') String? stateMutability)
+            @JsonKey(name: 'stateMutability', includeIfNull: false)
+                String? stateMutability)
         function,
     required TResult Function(String type, String name,
             List<TypedParameter> keys, List<TypedParameter> data)
@@ -332,7 +338,8 @@ class _$FunctionAbiEntry implements FunctionAbiEntry {
             String name,
             List<TypedParameter> inputs,
             List<TypedParameter> outputs,
-            @JsonKey(name: 'stateMutability') String? stateMutability)?
+            @JsonKey(name: 'stateMutability', includeIfNull: false)
+                String? stateMutability)?
         function,
     TResult? Function(String type, String name, List<TypedParameter> keys,
             List<TypedParameter> data)?
@@ -355,7 +362,8 @@ class _$FunctionAbiEntry implements FunctionAbiEntry {
             String name,
             List<TypedParameter> inputs,
             List<TypedParameter> outputs,
-            @JsonKey(name: 'stateMutability') String? stateMutability)?
+            @JsonKey(name: 'stateMutability', includeIfNull: false)
+                String? stateMutability)?
         function,
     TResult Function(String type, String name, List<TypedParameter> keys,
             List<TypedParameter> data)?
@@ -421,12 +429,12 @@ class _$FunctionAbiEntry implements FunctionAbiEntry {
 
 abstract class FunctionAbiEntry implements ContractAbiEntry {
   const factory FunctionAbiEntry(
-          {required final String type,
-          required final String name,
-          required final List<TypedParameter> inputs,
-          required final List<TypedParameter> outputs,
-          @JsonKey(name: 'stateMutability') final String? stateMutability}) =
-      _$FunctionAbiEntry;
+      {required final String type,
+      required final String name,
+      required final List<TypedParameter> inputs,
+      required final List<TypedParameter> outputs,
+      @JsonKey(name: 'stateMutability', includeIfNull: false)
+          final String? stateMutability}) = _$FunctionAbiEntry;
 
   factory FunctionAbiEntry.fromJson(Map<String, dynamic> json) =
       _$FunctionAbiEntry.fromJson;
@@ -437,7 +445,7 @@ abstract class FunctionAbiEntry implements ContractAbiEntry {
   String get name;
   List<TypedParameter> get inputs;
   List<TypedParameter> get outputs;
-  @JsonKey(name: 'stateMutability')
+  @JsonKey(name: 'stateMutability', includeIfNull: false)
   String? get stateMutability;
   @override
   @JsonKey(ignore: true)
@@ -575,7 +583,8 @@ class _$EventAbiEntry implements EventAbiEntry {
             String name,
             List<TypedParameter> inputs,
             List<TypedParameter> outputs,
-            @JsonKey(name: 'stateMutability') String? stateMutability)
+            @JsonKey(name: 'stateMutability', includeIfNull: false)
+                String? stateMutability)
         function,
     required TResult Function(String type, String name,
             List<TypedParameter> keys, List<TypedParameter> data)
@@ -598,7 +607,8 @@ class _$EventAbiEntry implements EventAbiEntry {
             String name,
             List<TypedParameter> inputs,
             List<TypedParameter> outputs,
-            @JsonKey(name: 'stateMutability') String? stateMutability)?
+            @JsonKey(name: 'stateMutability', includeIfNull: false)
+                String? stateMutability)?
         function,
     TResult? Function(String type, String name, List<TypedParameter> keys,
             List<TypedParameter> data)?
@@ -621,7 +631,8 @@ class _$EventAbiEntry implements EventAbiEntry {
             String name,
             List<TypedParameter> inputs,
             List<TypedParameter> outputs,
-            @JsonKey(name: 'stateMutability') String? stateMutability)?
+            @JsonKey(name: 'stateMutability', includeIfNull: false)
+                String? stateMutability)?
         function,
     TResult Function(String type, String name, List<TypedParameter> keys,
             List<TypedParameter> data)?
@@ -822,7 +833,8 @@ class _$StructAbiEntry implements StructAbiEntry {
             String name,
             List<TypedParameter> inputs,
             List<TypedParameter> outputs,
-            @JsonKey(name: 'stateMutability') String? stateMutability)
+            @JsonKey(name: 'stateMutability', includeIfNull: false)
+                String? stateMutability)
         function,
     required TResult Function(String type, String name,
             List<TypedParameter> keys, List<TypedParameter> data)
@@ -845,7 +857,8 @@ class _$StructAbiEntry implements StructAbiEntry {
             String name,
             List<TypedParameter> inputs,
             List<TypedParameter> outputs,
-            @JsonKey(name: 'stateMutability') String? stateMutability)?
+            @JsonKey(name: 'stateMutability', includeIfNull: false)
+                String? stateMutability)?
         function,
     TResult? Function(String type, String name, List<TypedParameter> keys,
             List<TypedParameter> data)?
@@ -868,7 +881,8 @@ class _$StructAbiEntry implements StructAbiEntry {
             String name,
             List<TypedParameter> inputs,
             List<TypedParameter> outputs,
-            @JsonKey(name: 'stateMutability') String? stateMutability)?
+            @JsonKey(name: 'stateMutability', includeIfNull: false)
+                String? stateMutability)?
         function,
     TResult Function(String type, String name, List<TypedParameter> keys,
             List<TypedParameter> data)?
@@ -1085,7 +1099,8 @@ class _$ConstructorAbiEntry implements ConstructorAbiEntry {
             String name,
             List<TypedParameter> inputs,
             List<TypedParameter> outputs,
-            @JsonKey(name: 'stateMutability') String? stateMutability)
+            @JsonKey(name: 'stateMutability', includeIfNull: false)
+                String? stateMutability)
         function,
     required TResult Function(String type, String name,
             List<TypedParameter> keys, List<TypedParameter> data)
@@ -1108,7 +1123,8 @@ class _$ConstructorAbiEntry implements ConstructorAbiEntry {
             String name,
             List<TypedParameter> inputs,
             List<TypedParameter> outputs,
-            @JsonKey(name: 'stateMutability') String? stateMutability)?
+            @JsonKey(name: 'stateMutability', includeIfNull: false)
+                String? stateMutability)?
         function,
     TResult? Function(String type, String name, List<TypedParameter> keys,
             List<TypedParameter> data)?
@@ -1131,7 +1147,8 @@ class _$ConstructorAbiEntry implements ConstructorAbiEntry {
             String name,
             List<TypedParameter> inputs,
             List<TypedParameter> outputs,
-            @JsonKey(name: 'stateMutability') String? stateMutability)?
+            @JsonKey(name: 'stateMutability', includeIfNull: false)
+                String? stateMutability)?
         function,
     TResult Function(String type, String name, List<TypedParameter> keys,
             List<TypedParameter> data)?

--- a/packages/starknet/lib/src/contract/model/contract_abi.g.dart
+++ b/packages/starknet/lib/src/contract/model/contract_abi.g.dart
@@ -20,15 +20,24 @@ _$FunctionAbiEntry _$$FunctionAbiEntryFromJson(Map<String, dynamic> json) =>
       $type: json['runtimeType'] as String?,
     );
 
-Map<String, dynamic> _$$FunctionAbiEntryToJson(_$FunctionAbiEntry instance) =>
-    <String, dynamic>{
-      'type': instance.type,
-      'name': instance.name,
-      'inputs': instance.inputs.map((e) => e.toJson()).toList(),
-      'outputs': instance.outputs.map((e) => e.toJson()).toList(),
-      'stateMutability': instance.stateMutability,
-      'runtimeType': instance.$type,
-    };
+Map<String, dynamic> _$$FunctionAbiEntryToJson(_$FunctionAbiEntry instance) {
+  final val = <String, dynamic>{
+    'type': instance.type,
+    'name': instance.name,
+    'inputs': instance.inputs.map((e) => e.toJson()).toList(),
+    'outputs': instance.outputs.map((e) => e.toJson()).toList(),
+  };
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull('stateMutability', instance.stateMutability);
+  val['runtimeType'] = instance.$type;
+  return val;
+}
 
 _$EventAbiEntry _$$EventAbiEntryFromJson(Map<String, dynamic> json) =>
     _$EventAbiEntry(

--- a/packages/starknet/lib/src/contract/parse.dart
+++ b/packages/starknet/lib/src/contract/parse.dart
@@ -9,7 +9,18 @@ Future<CompiledContract> parseContract(String contractPath) async {
 }
 
 Future<dynamic> readJsonFile(String filePath) async {
+  final bigIntPattern = "BingInt|";
   var input = await File(filePath).readAsString();
-  var json = jsonDecode(input);
+  // Dart JSON decoder use double to represent number,
+  // but 64 bits is not enough for Felt
+  // so we prefix "number" by [bigIntPattern]
+  input = input.replaceAllMapped(
+      RegExp(r'^(\s*"value": )(-?[0-9]+)(\s*,?)', multiLine: true),
+      (match) => '${match[1]}"$bigIntPattern${match[2]}"${match[3]}');
+  var json = jsonDecode(input,
+      reviver: (key, value) =>
+          key == "value" && value is String && value.startsWith(bigIntPattern)
+              ? BigInt.parse(value.replaceAll(bigIntPattern, ""))
+              : value);
   return json;
 }

--- a/packages/starknet/lib/src/crypto/index.dart
+++ b/packages/starknet/lib/src/crypto/index.dart
@@ -11,7 +11,7 @@ export 'signature.dart';
 /// The transaction hash is a hash chain of the following information:
 ///   1. A prefix that depends on the transaction type.
 ///   2. The transaction's version.
-///   3. Contract address.
+///   3. Contract or sender address.
 ///   4. Entry point selector.
 ///   5. A hash chain of the calldata.
 ///   6. The transaction's maximum fee.
@@ -26,7 +26,7 @@ export 'signature.dart';
 BigInt calculateTransactionHashCommon({
   required BigInt txHashPrefix,
   int version = 0,
-  required BigInt contractAddress,
+  required BigInt address,
   required BigInt entryPointSelector,
   required List<BigInt> calldata,
   required BigInt maxFee,
@@ -37,7 +37,7 @@ BigInt calculateTransactionHashCommon({
   final List<BigInt> dataToHash = [
     txHashPrefix,
     BigInt.from(version),
-    contractAddress,
+    address,
     entryPointSelector,
     calldataHash,
     maxFee,

--- a/packages/starknet/lib/src/signer.dart
+++ b/packages/starknet/lib/src/signer.dart
@@ -5,6 +5,66 @@ class Signer {
 
   Signer({required this.privateKey});
 
+  List<Felt> signInvokeTransactionsV1(
+      {required List<FunctionCall> transactions,
+      required Felt senderAddress,
+      required Felt chainId,
+      Felt? nonce,
+      Felt? maxFee}) {
+    nonce = nonce ?? Felt.fromInt(0);
+    maxFee = maxFee ?? defaultMaxFee;
+    final calldata = functionCallsToCalldata(functionCalls: transactions);
+
+    final transactionHash = calculateTransactionHashCommon(
+      txHashPrefix: TransactionHashPrefix.invoke.toBigInt(),
+      address: senderAddress.toBigInt(),
+      version: 1,
+      entryPointSelector: BigInt.parse("0"),
+      calldata: toBigIntList(calldata),
+      maxFee: maxFee.toBigInt(),
+      chainId: chainId.toBigInt(),
+      additionalData: [nonce.toBigInt()],
+    );
+
+    final signature = starknet_sign(
+        privateKey: privateKey.toBigInt(),
+        messageHash: transactionHash,
+        seed: BigInt.from(32));
+
+    return [Felt(signature.r), Felt(signature.s)];
+  }
+
+  List<Felt> signInvokeTransactionsV0({
+    required List<FunctionCall> transactions,
+    required Felt contractAddress,
+    required Felt chainId,
+    Felt? nonce,
+    Felt? maxFee,
+    String entryPointSelectorName = "__execute__",
+  }) {
+    nonce = nonce ?? Felt.fromInt(0);
+    maxFee = maxFee ?? defaultMaxFee;
+    final calldata =
+        functionCallsToCalldata(functionCalls: transactions) + [nonce];
+
+    final transactionHash = calculateTransactionHashCommon(
+      txHashPrefix: TransactionHashPrefix.invoke.toBigInt(),
+      address: contractAddress.toBigInt(),
+      version: 0,
+      entryPointSelector: getSelectorByName(entryPointSelectorName).toBigInt(),
+      calldata: toBigIntList(calldata),
+      maxFee: maxFee.toBigInt(),
+      chainId: chainId.toBigInt(),
+    );
+
+    final signature = starknet_sign(
+        privateKey: privateKey.toBigInt(),
+        messageHash: transactionHash,
+        seed: BigInt.from(32));
+
+    return [Felt(signature.r), Felt(signature.s)];
+  }
+
   List<Felt> signTransactions({
     required List<FunctionCall> transactions,
     required Felt contractAddress,
@@ -14,29 +74,54 @@ class Signer {
     Felt? maxFee,
     String entryPointSelectorName = "__execute__",
   }) {
+    switch (version) {
+      case 0:
+        return signInvokeTransactionsV0(
+          transactions: transactions,
+          contractAddress: contractAddress,
+          chainId: chainId,
+          entryPointSelectorName: entryPointSelectorName,
+          nonce: nonce,
+          maxFee: maxFee,
+        );
+      case 1:
+        return signInvokeTransactionsV1(
+          transactions: transactions,
+          senderAddress: contractAddress,
+          chainId: chainId,
+          nonce: nonce,
+          maxFee: maxFee,
+        );
+      default:
+        throw Exception("Unsupported invoke transaction version: $version");
+    }
+  }
+
+  List<Felt> signDeclareTransaction(
+      {required CompiledContract compiledContract,
+      required Felt senderAddress,
+      required Felt chainId,
+      Felt? nonce,
+      Felt? maxFee}) {
     nonce = nonce ?? Felt.fromInt(0);
     maxFee = maxFee ?? defaultMaxFee;
-    final calldata = version == 0
-        ? functionCallsToCalldata(functionCalls: transactions) + [nonce]
-        : functionCallsToCalldata(functionCalls: transactions);
-
+    final classHash = compiledContract.classHash();
     final transactionHash = calculateTransactionHashCommon(
-      txHashPrefix: TransactionHashPrefix.invoke.toBigInt(),
-      contractAddress: contractAddress.toBigInt(),
-      version: version,
-      entryPointSelector: version == 0
-          ? getSelectorByName(entryPointSelectorName).toBigInt()
-          : BigInt.parse("0"),
-      calldata: toBigIntList(calldata),
+      txHashPrefix: TransactionHashPrefix.declare.toBigInt(),
+      version: 1,
+      address: senderAddress.toBigInt(),
+      entryPointSelector: BigInt.from(0),
+      calldata: [classHash],
       maxFee: maxFee.toBigInt(),
       chainId: chainId.toBigInt(),
-      additionalData: version == 0 ? [] : [nonce.toBigInt()],
+      additionalData: [nonce.toBigInt()],
     );
 
     final signature = starknet_sign(
-        privateKey: privateKey.toBigInt(),
-        messageHash: transactionHash,
-        seed: BigInt.from(32));
+      privateKey: privateKey.toBigInt(),
+      messageHash: transactionHash,
+      seed: BigInt.from(32),
+    );
 
     return [Felt(signature.r), Felt(signature.s)];
   }

--- a/packages/starknet/test/account_test.dart
+++ b/packages/starknet/test/account_test.dart
@@ -13,7 +13,7 @@ void main() {
             expect(
               result.classHash,
               equals(Felt.fromIntString(
-                  "3137515840355711948086108918138944421885262760143101541325567680247897769336")),
+                  "2629893875186532358210942156370932694899207790379996755057537765547495171435")), // 2023-02-06: class hash with 'runtimeType' included
             );
             return result.transactionHash;
           },
@@ -25,14 +25,14 @@ void main() {
       test('succeeds', () async {
         // Balance contract
         final classHash = Felt.fromHexString(
-            "0x31a7b73457f4edebcbb21a6c164bafc3415232de0257821e9521f8ae4bd0227");
+            "0x5d077995ffe1356cfd48aa5990ece8bf420dacab9b7d3e6941e0c53c208a56b"); // 2023-02-06: class hash with 'runtimeType' included
 
         final contractAddress = await account0
             .deploy(classHash: classHash, calldata: [Felt.fromInt(42)]);
         expect(
             contractAddress,
             equals(Felt.fromHexString(
-                '0x45bd3e6ed7b0f5804f4adbfd60033beb09684f3beb468bca08cc6ffc7e64b5b')));
+                '0x149867a6ce95f2d20ed96187abd430d7c2c48cdfb7dd541fb1337563ff8d9b9')));
       });
       // }, tags: ['integration-devnet-040']);
     }, tags: ['to-be-fixed']);

--- a/packages/starknet/test/contract/contract_test.dart
+++ b/packages/starknet/test/contract/contract_test.dart
@@ -1,0 +1,20 @@
+import 'dart:io';
+import 'package:starknet/starknet.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Contract', () {
+    group('Compiled contract', () {
+      test('Compute class hash', () async {
+        final contractPath =
+            '${Directory.current.path}/../../contracts/build/balance.json';
+        final compiledContract = await parseContract(contractPath);
+        final classHash = compiledContract.classHash();
+        expect(
+            classHash,
+            equals(BigInt.parse(
+                "2629893875186532358210942156370932694899207790379996755057537765547495171435")));
+      });
+    });
+  }, tags: ['unit']);
+}

--- a/packages/starknet/test/crypto/calculate_transaction_hash_common.dart
+++ b/packages/starknet/test/crypto/calculate_transaction_hash_common.dart
@@ -10,7 +10,7 @@ void main() {
           calculateTransactionHashCommon(
               txHashPrefix: TransactionHashPrefix.invoke.toBigInt(),
               // Note: the address is larger than a field element, so we must use BigInt
-              contractAddress: BigInt.parse(
+              address: BigInt.parse(
                   '2007067565103695475819120104515800035851923905855118399071773059478896040938'),
               entryPointSelector: getSelectorByName('__execute__').toBigInt(),
               calldata: toBigIntList(functionCallsToCalldata(functionCalls: [

--- a/packages/starknet/test/signer_test.dart
+++ b/packages/starknet/test/signer_test.dart
@@ -4,7 +4,7 @@ import 'package:test/test.dart';
 void main() {
   group('Signer', () {
     group('signTransactions', () {
-      test('returns the right signature', () {
+      test('returns the right signature for invoke transaction version 0', () {
         final signature = Signer(privateKey: Felt.fromInt(1234)).signTransactions(
             transactions: [
               FunctionCall(

--- a/packages/starknet_example/lib/src/udc.g.dart
+++ b/packages/starknet_example/lib/src/udc.g.dart
@@ -1,13 +1,17 @@
 // Generated code, do not modify. Run `build_runner build` to re-generate!
-// ignore_for_file: unused_element
 
 import 'package:starknet/starknet.dart';
 
-class Udc extends Contract {
+class Udc {
   Udc({
-    required super.account,
-    required super.address,
-  });
+    required account,
+    required address,
+  }) : _contract = Contract(
+          account: account,
+          address: address,
+        );
+
+  final Contract _contract;
 
   Future<String> deployContract(
     Felt classHash,
@@ -21,7 +25,7 @@ class Udc extends Contract {
       unique,
       ...calldata.toCallData(),
     ];
-    final trx = await execute(
+    final trx = await _contract.execute(
       'deployContract',
       params,
     );
@@ -39,9 +43,5 @@ extension on List<Felt> {
       Felt.fromInt(this.length),
       ...this,
     ];
-  }
-
-  List<Felt> fromCallData() {
-    return this.sublist(1);
   }
 }

--- a/scripts/python/commands/interact.py
+++ b/scripts/python/commands/interact.py
@@ -42,7 +42,7 @@ def main():
 
 def _get_balance_contract(
     env: str,
-    address="0x795595609782473a2836b4bf554431c84593935fddd9d15b4ba552063d82f21",
+    address="0x149867a6ce95f2d20ed96187abd430d7c2c48cdfb7dd541fb1337563ff8d9b9",
     contract_name="balance"
 ):
     config = get_config(env)


### PR DESCRIPTION
This PR add support to declare transaction version 1.

By default dart JSON decoder is using num (64 bits) to represent number, but in cairo compiled program we have felt which are 252 bits: I have added a custom JSON encoder/decoder to be able to use BigInt to represent numbers.

Custom JSON encoder is also used to mimic python JSON dumps (space after ':' and ',', key sorted) which is the format expected to compute [contract class hash](https://docs.starknet.io/documentation/architecture_and_concepts/Contracts/contract-hash/)

**/!\ Code has been duplicated from dart sdk since symbols are not exported /!\\**

Please note that I didn't find a way to avoid `freezed` with `json_serializable` adding a field name `runtimeType` in JSON output, so computed class hash **will be different that the one computed by python SDK** from the same cairo compiled program.

Closes #92 
Closes #108 