### PR TITLE
Add `balance` and `send` methods to Account class

### DIFF
--- a/packages/starknet/lib/src/account.dart
+++ b/packages/starknet/lib/src/account.dart
@@ -107,10 +107,11 @@ class Account {
   Future<Uint256> balance() async =>
       ERC20(account: this, address: ethAddress).balanceOf(accountAddress);
 
-  Future<bool> send({required Felt recipient, required Uint256 amount}) async {
+  Future<String> send(
+      {required Felt recipient, required Uint256 amount}) async {
     final txHash = await ERC20(account: this, address: ethAddress)
         .transfer(recipient, amount);
-    return waitForAcceptance(transactionHash: txHash, provider: provider);
+    return txHash;
   }
 }
 

--- a/packages/starknet/lib/src/account.dart
+++ b/packages/starknet/lib/src/account.dart
@@ -103,6 +103,15 @@ class Account {
 
     return getDeployedContractAddress(txReceipt);
   }
+
+  Future<Uint256> balance() async =>
+      ERC20(account: this, address: ethAddress).balanceOf(accountAddress);
+
+  Future<bool> send({required Felt recipient, required Uint256 amount}) async {
+    final txHash = await ERC20(account: this, address: ethAddress)
+        .transfer(recipient, amount);
+    return waitForAcceptance(transactionHash: txHash, provider: provider);
+  }
 }
 
 Account getAccount({

--- a/packages/starknet/lib/src/static_config.dart
+++ b/packages/starknet/lib/src/static_config.dart
@@ -19,6 +19,10 @@ final defaultVersion = Felt.fromInt(0);
 final udcAddress = Felt.fromHexString(
     '0x041a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf');
 
+// address is the same for mainnet & testnet
+final ethAddress = Felt.fromHexString(
+    "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7");
+
 // Devnet
 
 final devnetUri = Uri.parse('http://localhost:5050/rpc');

--- a/packages/starknet/lib/src/types/uint256.dart
+++ b/packages/starknet/lib/src/types/uint256.dart
@@ -14,4 +14,11 @@ class Uint256 {
   String toString() {
     return toBigInt().toString();
   }
+
+  @override
+  bool operator ==(Object other) =>
+      other is Uint256 && high == other.high && low == other.low;
+
+  @override
+  int get hashCode => Object.hash(low, high);
 }

--- a/packages/starknet/test/account_test.dart
+++ b/packages/starknet/test/account_test.dart
@@ -36,5 +36,40 @@ void main() {
       });
       // }, tags: ['integration-devnet-040']);
     }, tags: ['to-be-fixed']);
+
+    group('fee token', () {
+      test('get balance', () async {
+        final balance = await account1.balance();
+        expect(
+            balance,
+            equals(Uint256(
+                low: Felt(BigInt.parse("1000000000000000000000")),
+                high: Felt.fromInt(0))));
+      });
+      test('send', () async {
+        final previousBalance = await account1.balance();
+        final success = await account0.send(
+            recipient: account1.accountAddress,
+            amount: Uint256(low: Felt.fromInt(100), high: Felt.fromInt(0)));
+        expect(success, equals(true));
+        final newBalance = await account1.balance();
+        final diffHigh =
+            newBalance.high.toBigInt() - previousBalance.high.toBigInt();
+        final diffLow =
+            newBalance.low.toBigInt() - previousBalance.low.toBigInt();
+        expect(diffHigh, equals(BigInt.from(0)));
+        expect(diffLow, equals(BigInt.from(100)));
+      });
+
+      test('send without enough amount', () async {
+        final previousBalance = await account1.balance();
+        final success = await account0.send(
+            recipient: account1.accountAddress,
+            amount: Uint256(low: Felt.fromInt(0), high: Felt.fromInt(100)));
+        expect(success, equals(false));
+        final newBalance = await account1.balance();
+        expect(newBalance, equals(previousBalance));
+      });
+    });
   });
 }

--- a/packages/starknet/test/account_test.dart
+++ b/packages/starknet/test/account_test.dart
@@ -48,9 +48,11 @@ void main() {
       });
       test('send', () async {
         final previousBalance = await account1.balance();
-        final success = await account0.send(
+        final txHash = await account0.send(
             recipient: account1.accountAddress,
             amount: Uint256(low: Felt.fromInt(100), high: Felt.fromInt(0)));
+        final success = await waitForAcceptance(
+            transactionHash: txHash, provider: account1.provider);
         expect(success, equals(true));
         final newBalance = await account1.balance();
         final diffHigh =
@@ -63,9 +65,11 @@ void main() {
 
       test('send without enough amount', () async {
         final previousBalance = await account1.balance();
-        final success = await account0.send(
+        final txHash = await account0.send(
             recipient: account1.accountAddress,
             amount: Uint256(low: Felt.fromInt(0), high: Felt.fromInt(100)));
+        final success = await waitForAcceptance(
+            transactionHash: txHash, provider: account1.provider);
         expect(success, equals(false));
         final newBalance = await account1.balance();
         expect(newBalance, equals(previousBalance));


### PR DESCRIPTION
This PR add `balance`` and `send` methods to Account class to ease fee token transfer between accounts.

Closes #111 