### PR TITLE
Change StarkNet to Starknet

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,18 +1,18 @@
 # Contributor Guide
 
-**starknet.dart** is a dart package allowing any dart program (mainly Flutter apps) to communicate with the [StarkNet](https://starknet.io/docs/) blockchain.
+**starknet.dart** is a dart package allowing any dart program (mainly Flutter apps) to communicate with the [Starknet](https://starknet.io/docs/) blockchain.
 
-The [StarkNet nodes](https://github.com/eqlabs/pathfinder/blob/06ea631557937d4319aa539a2021e312ec757ac2/crates/pathfinder/src/rpc.rs) expose a JSON-RPC API (see the [specs](https://github.com/starkware-libs/starknet-specs)) that we can call to call Smart Contract methods or even get information on blocks and past transactions.
+The [Starknet nodes](https://github.com/eqlabs/pathfinder/blob/06ea631557937d4319aa539a2021e312ec757ac2/crates/pathfinder/src/rpc.rs) expose a JSON-RPC API (see the [specs](https://github.com/starkware-libs/starknet-specs)) that we can call to call Smart Contract methods or even get information on blocks and past transactions.
 
 The goal of the project is thus to build a bridge between dart applications and Starknet, while staying consistent with the common abstractions used in other blockchain SDKs (see [ethers.js](https://docs.ethers.io/v5/)).
 
 ## Why contributing to starknet.dart?
 
-StarkNet is a revolution in the web3 world: it allows to [scale Ethereum](https://docs.ethhub.io/ethereum-roadmap/layer-2-scaling/zk-rollups/) and offers the best UX one can dream of on a blockchain thanks to unique features like [account abstraction](https://www.argent.xyz/blog/wtf-is-account-abstraction/) or [session keys](https://github.com/dontpanicdao/starknet-burner).
+Starknet is a revolution in the web3 world: it allows to [scale Ethereum](https://docs.ethhub.io/ethereum-roadmap/layer-2-scaling/zk-rollups/) and offers the best UX one can dream of on a blockchain thanks to unique features like [account abstraction](https://www.argent.xyz/blog/wtf-is-account-abstraction/) or [session keys](https://github.com/dontpanicdao/starknet-burner).
 
 But web3 mainstream adoption won't happen unless decentralized applications go to mobile. That's why it's a priority to build the best possible Starknet SDK for Flutter, one of the most used cross-platform mobile framework.
 
-If you want to contribute to the web3 adoption and more specifically StarkNet one, then you probably **can't have more impact than working on this SDK** that will be used by the majority of Flutter dApps on StarkNet!
+If you want to contribute to the web3 adoption and more specifically Starknet one, then you probably **can't have more impact than working on this SDK** that will be used by the majority of Flutter dApps on Starknet!
 
 ## How to contribute
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # starknet.dart
 
-The goal of this SDK is to be able to interact with StarkNet smart contracts in a type-safe way.
+The goal of this SDK is to be able to interact with Starknet smart contracts in a type-safe way.
 
-You can also call the JSON-RPC endpoint exposed by the StarkNet full nodes (see the [specs](https://github.com/starkware-libs/starknet-specs)).
+You can also call the JSON-RPC endpoint exposed by the Starknet full nodes (see the [specs](https://github.com/starkware-libs/starknet-specs)).
 
 📚 [docs](https://pub.dev/packages/starknet)
 
@@ -10,11 +10,11 @@ You can also call the JSON-RPC endpoint exposed by the StarkNet full nodes (see 
 
 ## Motivation
 
-StarkNet is a revolution in the web3 world: it allows to [scale Ethereum](https://docs.ethhub.io/ethereum-roadmap/layer-2-scaling/zk-rollups/) and offers the best possible UX thanks to unique features like [account abstraction](https://www.argent.xyz/blog/wtf-is-account-abstraction/) or [session keys](https://github.com/dontpanicdao/starknet-burner).
+Starknet is a revolution in the web3 world: it allows to [scale Ethereum](https://docs.ethhub.io/ethereum-roadmap/layer-2-scaling/zk-rollups/) and offers the best possible UX thanks to unique features like [account abstraction](https://www.argent.xyz/blog/wtf-is-account-abstraction/) or [session keys](https://github.com/dontpanicdao/starknet-burner).
 
 But web3 mainstream adoption won't happen unless decentralized applications go to mobile.
 
-That's why it's a priority to **build the best possible Starknet SDK for dart applications**, thus unlocking the era of Flutter mobile apps on StarkNet.
+That's why it's a priority to **build the best possible Starknet SDK for dart applications**, thus unlocking the era of Flutter mobile apps on Starknet.
 
 ## Roadmap
 

--- a/contracts/lib/cairo_contracts/README.md
+++ b/contracts/lib/cairo_contracts/README.md
@@ -3,7 +3,7 @@
 [![Tests and linter](https://github.com/OpenZeppelin/cairo-contracts/actions/workflows/coverage.yml/badge.svg)](https://github.com/OpenZeppelin/cairo-contracts/actions/workflows/coverage.yml)
 [![codecov](https://codecov.io/github/OpenZeppelin/cairo-contracts/branch/main/graph/badge.svg?token=LFSZH8RPOL)](https://codecov.io/github/OpenZeppelin/cairo-contracts)
 
-**A library for secure smart contract development** written in Cairo for [StarkNet](https://starkware.co/product/starknet/), a decentralized ZK Rollup.
+**A library for secure smart contract development** written in Cairo for [Starknet](https://starkware.co/product/starknet/), a decentralized ZK Rollup.
 
 ## Usage
 
@@ -122,14 +122,14 @@ Check out the [full documentation site](https://docs.openzeppelin.com/contracts-
 
 ### Cairo
 
-- [StarkNet official documentation](https://www.cairo-lang.org/docs/hello_starknet/index.html#hello-starknet)
+- [Starknet official documentation](https://www.cairo-lang.org/docs/hello_starknet/index.html#hello-starknet)
 - [Cairo language documentation](https://www.cairo-lang.org/docs/hello_cairo/index.html#hello-cairo)
 - Perama's [Cairo by example](https://perama-v.github.io/cairo/by-example/)
 - [Cairo 101 workshops](https://www.youtube.com/playlist?list=PLcIyXLwiPilV5RBZj43AX1FY4FJMWHFTY)
 
 ### Nile
 
-- [Getting started with StarkNet using Nile](https://medium.com/coinmonks/starknet-tutorial-for-beginners-using-nile-6af9c2270c15)
+- [Getting started with Starknet using Nile](https://medium.com/coinmonks/starknet-tutorial-for-beginners-using-nile-6af9c2270c15)
 - [How to manage smart contract deployments with Nile](https://medium.com/@martriay/manage-your-starknet-deployments-with-nile-%EF%B8%8F-e849d40546dd)
 
 ## Development

--- a/contracts/lib/cairo_contracts/docs/modules/ROOT/pages/access.adoc
+++ b/contracts/lib/cairo_contracts/docs/modules/ROOT/pages/access.adoc
@@ -388,7 +388,7 @@ bytes32 public constant SOME_ROLE = keccak256("SOME_ROLE")
 These identifiers take up 32 bytes (256 bits).
 
 Cairo field elements store a maximum of 252 bits.
-Even further, a declared _constant_ field element in a StarkNet contract stores even less (see https://github.com/starkware-libs/cairo-lang/blob/release-v0.4.0b/src/starkware/cairo/lang/cairo_constants.py#L1[cairo_constants]).
+Even further, a declared _constant_ field element in a Starknet contract stores even less (see https://github.com/starkware-libs/cairo-lang/blob/release-v0.4.0b/src/starkware/cairo/lang/cairo_constants.py#L1[cairo_constants]).
 With this discrepancy, this library maintains an agnostic stance on how contracts should create identifiers.
 Some ideas to consider:
 

--- a/contracts/lib/cairo_contracts/docs/modules/ROOT/pages/accounts.adoc
+++ b/contracts/lib/cairo_contracts/docs/modules/ROOT/pages/accounts.adoc
@@ -2,13 +2,13 @@
 
 = Accounts
 
-Unlike Ethereum where accounts are directly derived from a private key, there's no native account concept on StarkNet.
+Unlike Ethereum where accounts are directly derived from a private key, there's no native account concept on Starknet.
 
 Instead, signature validation has to be done at the contract level.
 To relieve smart contract applications such as ERC20 tokens or exchanges from this responsibility, we make use of Account contracts to deal with transaction authentication.
 
-For a general overview of the account abstraction, see StarkWare's https://medium.com/starkware/starknet-alpha-0-10-0-923007290470[StarkNet Alpha 0.10].
-A more detailed discussion on the topic can be found in https://community.starknet.io/t/starknet-account-abstraction-model-part-1/781[StarkNet Account Abstraction Part 1].
+For a general overview of the account abstraction, see StarkWare's https://medium.com/starkware/starknet-alpha-0-10-0-923007290470[Starknet Alpha 0.10].
+A more detailed discussion on the topic can be found in https://community.starknet.io/t/starknet-account-abstraction-model-part-1/781[Starknet Account Abstraction Part 1].
 
 == Table of Contents
 
@@ -47,7 +47,7 @@ A more detailed discussion on the topic can be found in https://community.starkn
 
 The general workflow is:
 
-. Account contract is deployed to StarkNet.
+. Account contract is deployed to Starknet.
 . Signed transactions can now be sent to the Account contract which validates and executes them.
 
 In Python, this would look as follows:
@@ -125,7 +125,7 @@ Where:
 * `calldata_len` is the number of calldata parameters.
 * `calldata` is an array representing the function parameters.
 
-NOTE: The scheme of building multicall transactions within the `\\__execute__` method will change once StarkNet allows for pointers in struct arrays.
+NOTE: The scheme of building multicall transactions within the `\\__execute__` method will change once Starknet allows for pointers in struct arrays.
 In which case, multiple transactions can be passed to (as opposed to built within) `\\__execute__`.
 
 There's a fourth canonical entrypoint for accounts, the `\\__validate_deploy__` method. It is **only callable by the protocol** during the execution of a `DeployAccount` type of transaction, but not by any other contract. This entrypoint is for counterfactual deployments.
@@ -238,7 +238,7 @@ To simplify Account management, most of this is abstracted away with `MockSigner
 
 The `MockSigner` class in {test-signers}[signers.py] is used to perform transactions on a given Account, crafting the transaction and managing nonces.
 
-NOTE: StarkNet's testing framework does not currently support transaction invocations from account contracts. `MockSigner` therefore utilizes StarkNet's API gateway to manually execute the `InvokeFunction` for testing.
+NOTE: Starknet's testing framework does not currently support transaction invocations from account contracts. `MockSigner` therefore utilizes Starknet's API gateway to manually execute the `InvokeFunction` for testing.
 
 A `MockSigner` instance exposes the following methods:
 
@@ -582,7 +582,7 @@ Each preset differs on the signature type being used by the Account.
 
 === Account
 
-The https://github.com/OpenZeppelin/cairo-contracts/blob/release-v0.4.0b/src/openzeppelin/account/presets/Account.cairo[`Account`] preset uses StarkNet keys to validate transactions.
+The https://github.com/OpenZeppelin/cairo-contracts/blob/release-v0.4.0b/src/openzeppelin/account/presets/Account.cairo[`Account`] preset uses Starknet keys to validate transactions.
 
 === Eth Account
 
@@ -592,10 +592,10 @@ The https://github.com/OpenZeppelin/cairo-contracts/blob/release-v0.4.0b/src/ope
 
 Certain contracts like ERC721 require a means to differentiate between account contracts and non-account contracts.
 For a contract to declare itself as an account, it should implement https://eips.ethereum.org/EIPS/eip-165[ERC165] as proposed in https://github.com/OpenZeppelin/cairo-contracts/discussions/100[#100].
-To be in compliance with ERC165 specifications, the idea is to calculate the XOR of ``IAccount``'s EVM selectors (not StarkNet selectors).
+To be in compliance with ERC165 specifications, the idea is to calculate the XOR of ``IAccount``'s EVM selectors (not Starknet selectors).
 The resulting magic value of `IAccount` is 0x50b70dcb.
 
-Our ERC165 integration on StarkNet is inspired by OpenZeppelin's Solidity implementation of https://docs.openzeppelin.com/contracts/4.x/api/utils#ERC165Storage[ERC165Storage] which stores the interfaces that the implementing contract supports.
+Our ERC165 integration on Starknet is inspired by OpenZeppelin's Solidity implementation of https://docs.openzeppelin.com/contracts/4.x/api/utils#ERC165Storage[ERC165Storage] which stores the interfaces that the implementing contract supports.
 In the case of account contracts, querying `supportsInterface` of an account's address with the `IAccount` magic value should return `TRUE`.
 
 NOTE: For Account contracts, ERC165 support is static and does not require Account contracts to register.
@@ -604,7 +604,7 @@ NOTE: For Account contracts, ERC165 support is static and does not require Accou
 
 Account contracts can be extended by following the xref:extensibility.adoc#the_pattern[extensibility pattern].
 
-To implement custom account contracts, it's required by the StarkNet compiler that they include the three entrypoint functions `\\__validate__`, `\\__validate_declare__`, and `\\__execute__`.
+To implement custom account contracts, it's required by the Starknet compiler that they include the three entrypoint functions `\\__validate__`, `\\__validate_declare__`, and `\\__execute__`.
 
 `\\__validate__` and `\\__validate_declare__` should include the same signature validation method; whereas, `\\__execute__` should only handle the actual transaction. Incorporating a new validation scheme necessitates only that it's invoked by both `\\__validate__` and `\\__validate_declare__`.
 
@@ -612,7 +612,7 @@ This is why the Account library comes with different flavors of signature valida
 
 Account contract developers are encouraged to implement the https://github.com/OpenZeppelin/cairo-contracts/discussions/41[standard Account interface] and incorporate the custom logic thereafter.
 
-IMPORTANT: Due to current inconsistencies between the testing framework and the actual StarkNet network, extreme caution should be used when integrating new Account contracts.
+IMPORTANT: Due to current inconsistencies between the testing framework and the actual Starknet network, extreme caution should be used when integrating new Account contracts.
 Instances have occurred where account functionality tests pass and transactions execute correctly on the local node; yet, they fail on public networks.
 For this reason, it's highly encouraged that new account contracts are also deployed and tested on the public testnet.
 See https://github.com/OpenZeppelin/cairo-contracts/issues/386[issue #386] for more information.

--- a/contracts/lib/cairo_contracts/docs/modules/ROOT/pages/erc20.adoc
+++ b/contracts/lib/cairo_contracts/docs/modules/ROOT/pages/erc20.adoc
@@ -1,7 +1,7 @@
 = ERC20
 
 The ERC20 token standard is a specification for https://docs.openzeppelin.com/contracts/4.x/tokens#different-kinds-of-tokens[fungible tokens], a type of token where all the units are exactly equal to each other.
-The `ERC20.cairo` contract implements an approximation of https://eips.ethereum.org/EIPS/eip-20[EIP-20] in Cairo for StarkNet.
+The `ERC20.cairo` contract implements an approximation of https://eips.ethereum.org/EIPS/eip-20[EIP-20] in Cairo for Starknet.
 
 == Table of Contents
 
@@ -66,7 +66,7 @@ namespace IERC20 {
 
 === ERC20 compatibility
 
-Although StarkNet is not EVM compatible, this implementation aims to be as close as possible to the ERC20 standard, in the following ways:
+Although Starknet is not EVM compatible, this implementation aims to be as close as possible to the ERC20 standard, in the following ways:
 
 * It uses Cairo's `uint256` instead of `felt`.
 * It returns `TRUE` as success.
@@ -112,7 +112,7 @@ erc20 = await starknet.deploy(
 )
 ----
 
-As most StarkNet contracts, it expects to be called by another contract and it identifies it through `get_caller_address` (analogous to Solidity's `this.address`).
+As most Starknet contracts, it expects to be called by another contract and it identifies it through `get_caller_address` (analogous to Solidity's `this.address`).
 This is why we need an Account contract to interact with it.
 For example:
 

--- a/contracts/lib/cairo_contracts/docs/modules/ROOT/pages/erc721.adoc
+++ b/contracts/lib/cairo_contracts/docs/modules/ROOT/pages/erc721.adoc
@@ -1,7 +1,7 @@
 = ERC721
 
 The ERC721 token standard is a specification for https://docs.openzeppelin.com/contracts/4.x/tokens#different-kinds-of-tokens[non-fungible tokens], or more colloquially: NFTs.
-The `ERC721.cairo` contract implements an approximation of https://eips.ethereum.org/EIPS/eip-721[EIP-721] in Cairo for StarkNet.
+The `ERC721.cairo` contract implements an approximation of https://eips.ethereum.org/EIPS/eip-721[EIP-721] in Cairo for Starknet.
 
 == Table of Contents
 
@@ -88,7 +88,7 @@ namespace IERC721 {
 
 === ERC721 Compatibility
 
-Although StarkNet is not EVM compatible, this implementation aims to be as close as possible to the ERC721 standard in the following ways:
+Although Starknet is not EVM compatible, this implementation aims to be as close as possible to the ERC721 standard in the following ways:
 
 * It uses Cairo's `uint256` instead of `felt`.
 * It returns `TRUE` as success.
@@ -128,7 +128,7 @@ Use cases go from artwork, digital collectibles, physical property, and many mor
 
 To show a standard use case, we'll use the `ERC721Mintable` preset which allows for only the owner to `mint` and `burn` tokens.
 To create a token you need to first deploy both Account and ERC721 contracts respectively.
-As most StarkNet contracts, ERC721 expects to be called by another contract and it identifies it through `get_caller_address` (analogous to Solidity's `this.address`).
+As most Starknet contracts, ERC721 expects to be called by another contract and it identifies it through `get_caller_address` (analogous to Solidity's `this.address`).
 This is why we need an Account contract to interact with it.
 
 Considering that the ERC721 constructor method looks like this:
@@ -232,9 +232,9 @@ In order to be sure a contract can safely accept ERC721 tokens, said contract mu
 Methods such as `safeTransferFrom` and `safeMint` call the recipient contract's `onERC721Received` method.
 If the contract fails to return the correct magic value, the transaction fails.
 
-StarkNet contracts that support safe transfers, however, must also support xref:introspection.adoc#erc165[ERC165] and include `supportsInterface` as proposed in https://github.com/OpenZeppelin/cairo-contracts/discussions/100[#100].
+Starknet contracts that support safe transfers, however, must also support xref:introspection.adoc#erc165[ERC165] and include `supportsInterface` as proposed in https://github.com/OpenZeppelin/cairo-contracts/discussions/100[#100].
 `safeTransferFrom` requires a means of differentiating between account and non-account contracts.
-Currently, StarkNet does not support error handling from the contract level;
+Currently, Starknet does not support error handling from the contract level;
 therefore, the current ERC721 implementation requires that all contracts that support safe ERC721 transfers (both accounts and non-accounts) include the `supportsInterface` method.
 Further, `supportsInterface` should return `TRUE` if the recipient contract supports the `IERC721Receiver` magic value `0x150b7a02` (which invokes `onERC721Received`).
 If the recipient contract supports the `IAccount` magic value `0x50b70dcb`, `supportsInterface` should return `TRUE`.
@@ -256,7 +256,7 @@ namespace IERC721Receiver {
 
 === Supporting Interfaces
 
-In order to ensure EVM/StarkNet compatibility, this ERC721 implementation does not calculate interface identifiers.
+In order to ensure EVM/Starknet compatibility, this ERC721 implementation does not calculate interface identifiers.
 Instead, the interface IDs are hardcoded from their EVM calculations.
 On the EVM, the interface ID is calculated from the selector's first four bytes of the hash of the function's signature while Cairo selectors are 252 bytes long.
 Due to this difference, hardcoding EVM's already-calculated interface IDs is the most consistent approach to both follow the EIP165 standard and EVM compatibility.

--- a/contracts/lib/cairo_contracts/docs/modules/ROOT/pages/extensibility.adoc
+++ b/contracts/lib/cairo_contracts/docs/modules/ROOT/pages/extensibility.adoc
@@ -21,7 +21,7 @@ Therefore writing complex smart contracts is a delicate task.
 
 One of the best approaches to minimize introducing bugs is to reuse existing, battle-tested code, a.k.a.
 using libraries.
-But code reutilization in StarkNet's smart contracts is not easy:
+But code reutilization in Starknet's smart contracts is not easy:
 
 * Cairo has no explicit smart contract extension mechanisms such as inheritance or composability.
 * Using imports for modularity can result in clashes (more so given that arguments are not part of the selector), and lack of overrides or aliasing leaves no way to resolve them.

--- a/contracts/lib/cairo_contracts/docs/modules/ROOT/pages/index.adoc
+++ b/contracts/lib/cairo_contracts/docs/modules/ROOT/pages/index.adoc
@@ -1,6 +1,6 @@
 = Contracts for Cairo
 
-*A library for secure smart contract development* written in Cairo for https://starkware.co/product/starknet/[StarkNet], a decentralized ZK Rollup.
+*A library for secure smart contract development* written in Cairo for https://starkware.co/product/starknet/[Starknet], a decentralized ZK Rollup.
 
 == Usage
 

--- a/contracts/lib/cairo_contracts/docs/modules/ROOT/pages/introspection.adoc
+++ b/contracts/lib/cairo_contracts/docs/modules/ROOT/pages/introspection.adoc
@@ -33,7 +33,7 @@ using `IERC165_ID` instead of `0x01ffc9a7`.
 
 === Interface calculations
 
-In order to ensure EVM/StarkNet compatibility, interface identifiers are not calculated on StarkNet.
+In order to ensure EVM/Starknet compatibility, interface identifiers are not calculated on Starknet.
 Instead, the interface IDs are hardcoded from their EVM calculations.
 On the EVM, the interface ID is calculated from the selector's first four bytes of the hash of the function's signature while Cairo selectors are 252 bytes long.
 Due to this difference, hardcoding EVM's already-calculated interface IDs is the most consistent approach to both follow the EIP165 standard and EVM compatibility.

--- a/contracts/lib/cairo_contracts/docs/modules/ROOT/pages/proxies.adoc
+++ b/contracts/lib/cairo_contracts/docs/modules/ROOT/pages/proxies.adoc
@@ -76,9 +76,9 @@ Upgradeable contracts do not, therefore, require a separate library with refacto
 OpenZeppelin's alternative Upgrades library also implements https://docs.openzeppelin.com/upgrades-plugins/1.x/proxies#unstructured-storage-proxies[unstructured storage] for its upgradeable contracts.
 The basic idea behind unstructured storage is to pseudo-randomize the storage structure of the upgradeable contract so it's based on variable names instead of declaration order, which makes the chances of storage collision during an upgrade extremely unlikely.
 
-The StarkNet compiler, meanwhile, already creates pseudo-random storage addresses by hashing the storage variable names (and keys in mappings) by default.
-In other words, StarkNet already uses unstructured storage and does not need a second library to modify how storage is set.
-See StarkNet's https://starknet.io/documentation/contracts/#contracts_storage[Contracts Storage documentation] for more information.
+The Starknet compiler, meanwhile, already creates pseudo-random storage addresses by hashing the storage variable names (and keys in mappings) by default.
+In other words, Starknet already uses unstructured storage and does not need a second library to modify how storage is set.
+See Starknet's https://starknet.io/documentation/contracts/#contracts_storage[Contracts Storage documentation] for more information.
 
 [#proxies2]
 == Proxies
@@ -317,16 +317,16 @@ For a full deployment and upgrade implementation, please see:
 
 === Declaring contracts
 
-StarkNet contracts come in two forms: contract classes and contract instances.
+Starknet contracts come in two forms: contract classes and contract instances.
 Contract classes represent the uninstantiated, stateless code;
 whereas, contract instances are instantiated and include the state.
 Since the Proxy contract references the implementation contract by its class hash, declaring an implementation contract proves sufficient (as opposed to a full deployment).
-For more information on declaring classes, see https://starknet.io/docs/hello_starknet/intro.html#declare-contract[StarkNet's documentation].
+For more information on declaring classes, see https://starknet.io/docs/hello_starknet/intro.html#declare-contract[Starknet's documentation].
 
 === Testing method calls
 
-As with most StarkNet contracts, interacting with a proxy contract requires an xref:accounts.adoc#quickstart[account abstraction].
-Due to limitations in the StarkNet testing framework, however, `@view` methods also require an account abstraction. This is only a requirement when testing.
+As with most Starknet contracts, interacting with a proxy contract requires an xref:accounts.adoc#quickstart[account abstraction].
+Due to limitations in the Starknet testing framework, however, `@view` methods also require an account abstraction. This is only a requirement when testing.
 The differences in getter methods written in Python, for example, are as follows:
 
 [,python]

--- a/contracts/lib/cairo_contracts/docs/modules/ROOT/pages/utilities.adoc
+++ b/contracts/lib/cairo_contracts/docs/modules/ROOT/pages/utilities.adoc
@@ -145,14 +145,14 @@ print(z)
 
 == Assertions
 
-In order to abstract away some of the verbosity regarding test assertions on StarkNet transactions, this project includes the following helper methods:
+In order to abstract away some of the verbosity regarding test assertions on Starknet transactions, this project includes the following helper methods:
 
 === `assert_revert`
 
 An asynchronous wrapper method that executes a try-except pattern for transactions that should fail.
-Note that this wrapper does not check for a StarkNet error code.
+Note that this wrapper does not check for a Starknet error code.
 This allows for more flexibility in checking that a transaction simply failed.
-If you wanted to check for an exact error code, you could use StarkNet's https://github.com/starkware-libs/cairo-lang/blob/ed6cf8d6cec50a6ad95fa36d1eb4a7f48538019e/src/starkware/starknet/definitions/error_codes.py[error_codes module] and implement additional logic to the `assert_revert` method.
+If you wanted to check for an exact error code, you could use Starknet's https://github.com/starkware-libs/cairo-lang/blob/ed6cf8d6cec50a6ad95fa36d1eb4a7f48538019e/src/starkware/starknet/definitions/error_codes.py[error_codes module] and implement additional logic to the `assert_revert` method.
 
 To successfully use this wrapper, the transaction method should be wrapped with `assert_revert`;
 however, `await` should precede the wrapper itself like this:
@@ -284,7 +284,7 @@ def foo_factory(contract_classes, foo_init):
 
 == State
 
-The `State` class provides a wrapper for initializing the StarkNet state which acts as a helper for the `Account` class. This wrapper allows `Account` deployments to share the same initialized state without explicitly passing the instantiated StarkNet state to `Account`. Initializing the state should look like this:
+The `State` class provides a wrapper for initializing the Starknet state which acts as a helper for the `Account` class. This wrapper allows `Account` deployments to share the same initialized state without explicitly passing the instantiated Starknet state to `Account`. Initializing the state should look like this:
 
 [,python]
 ----
@@ -295,7 +295,7 @@ starknet = await State.init()
 
 == Account
 
-The `Account` class abstracts away most of the boilerplate for deploying accounts. Instantiating accounts with this class requires the StarkNet state to be instantiated first with the `State.init()` method like this:
+The `Account` class abstracts away most of the boilerplate for deploying accounts. Instantiating accounts with this class requires the Starknet state to be instantiated first with the `State.init()` method like this:
 
 [,python]
 ----


### PR DESCRIPTION
Changes the spelling of "StarkNet" from "StarkNet" to "Starknet" everywhere in the doc following the recommendations in [this SNIP](https://community.starknet.io/t/snip-naming-convention-starknet-not-starknet).

#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [x] Documentation
