### PR TITLE
Add support to deploy account transaction version 1

### DIFF
--- a/packages/starknet/lib/src/account.dart
+++ b/packages/starknet/lib/src/account.dart
@@ -160,6 +160,43 @@ class Account {
         .transfer(recipient, amount);
     return txHash;
   }
+
+  static Future<DeployAccountTransactionResponse> deployAccount({
+    required Signer signer,
+    required Provider provider,
+    required List<Felt> constructorCalldata,
+    Felt? classHash,
+    Felt? contractAddressSalt,
+    Felt? maxFee,
+    Felt? nonce,
+  }) async {
+    final chainId = (await provider.chainId()).when(
+      result: (result) => Felt.fromHexString(result),
+      error: (error) => StarknetChainId.testNet,
+    );
+
+    classHash = classHash ?? openZeppelinAccountClassHash;
+    maxFee = maxFee ?? defaultMaxFee;
+    nonce = nonce ?? defaultNonce;
+    contractAddressSalt = contractAddressSalt ?? Felt.fromInt(42);
+
+    final signature = signer.signDeployAccountTransactionV1(
+      contractAddressSalt: contractAddressSalt,
+      classHash: classHash,
+      constructorCalldata: constructorCalldata,
+      chainId: chainId,
+    );
+
+    return provider.addDeployAccountTransaction(DeployAccountTransactionRequest(
+        deployAccountTransaction: DeployAccountTransactionV1(
+      classHash: classHash,
+      signature: signature,
+      maxFee: maxFee,
+      nonce: nonce,
+      contractAddressSalt: contractAddressSalt,
+      constructorCalldata: constructorCalldata,
+    )));
+  }
 }
 
 Account getAccount({

--- a/packages/starknet/lib/src/contract/contract.dart
+++ b/packages/starknet/lib/src/contract/contract.dart
@@ -4,6 +4,25 @@ class Contract {
   final Account account;
   final Felt address;
 
+  // see https://docs.starknet.io/documentation/architecture_and_concepts/Contracts/contract-address/
+  static Felt computeAddress({
+    required Felt classHash,
+    required List<Felt> callData,
+    required Felt salt,
+  }) {
+    final deployerAddress = BigInt.from(0); // always zero
+    List<BigInt> elements = [];
+    elements.add(Felt.fromString("STARKNET_CONTRACT_ADDRESS").toBigInt());
+    // caller address is always zero
+    elements.add(deployerAddress);
+    elements.add(salt.toBigInt());
+    elements.add(classHash.toBigInt());
+    elements
+        .add(computeHashOnElements(callData.map((e) => e.toBigInt()).toList()));
+    final address = computeHashOnElements(elements);
+    return Felt(address);
+  }
+
   Contract({required this.account, required this.address});
 
   Future<List<Felt>> call(String selector, List<Felt> calldata) async {

--- a/packages/starknet/lib/src/contract/contract.dart
+++ b/packages/starknet/lib/src/contract/contract.dart
@@ -4,10 +4,12 @@ class Contract {
   final Account account;
   final Felt address;
 
-  // see https://docs.starknet.io/documentation/architecture_and_concepts/Contracts/contract-address/
+  /// Compute contract address for given [classHash], [callData], [salt]
+  ///
+  /// https://docs.starknet.io/documentation/architecture_and_concepts/Contracts/contract-address/
   static Felt computeAddress({
     required Felt classHash,
-    required List<Felt> callData,
+    required List<Felt> calldata,
     required Felt salt,
   }) {
     final deployerAddress = BigInt.from(0); // always zero
@@ -18,13 +20,14 @@ class Contract {
     elements.add(salt.toBigInt());
     elements.add(classHash.toBigInt());
     elements
-        .add(computeHashOnElements(callData.map((e) => e.toBigInt()).toList()));
+        .add(computeHashOnElements(calldata.map((e) => e.toBigInt()).toList()));
     final address = computeHashOnElements(elements);
     return Felt(address);
   }
 
   Contract({required this.account, required this.address});
 
+  /// Call contract given [selector] with [calldata]
   Future<List<Felt>> call(String selector, List<Felt> calldata) async {
     final response = await account.provider.call(
       request: FunctionCall(
@@ -80,6 +83,7 @@ class Contract {
     })));
   }
 
+  /// Execute contract given [selector] with [calldata]
   Future<InvokeTransactionResponse> execute(
       String selector, List<Felt> calldata) async {
     final Felt nonce = await getNonce();

--- a/packages/starknet/lib/src/contract/contract.dart
+++ b/packages/starknet/lib/src/contract/contract.dart
@@ -47,46 +47,9 @@ class Contract {
     ));
   }
 
-  /// Get Nonce from account contract
-  Future<Felt> getNonce([BlockId blockId = BlockId.latest]) async {
-    final response = await account.provider.call(
-      request: FunctionCall(
-        contractAddress: account.accountAddress,
-        entryPointSelector: getSelectorByName("get_nonce"),
-        calldata: [],
-      ),
-      blockId: blockId,
-    );
-    return (response.when(error: (error) async {
-      if (error.code == 21 && error.message == "Invalid message selector") {
-        // Fallback on provider getNonce
-        final nonceResp = await account.provider.getNonce(
-          blockId: blockId,
-          contractAddress: account.accountAddress,
-        );
-
-        return (nonceResp.when(
-          error: (error) {
-            throw Exception(
-                "Error provider getNonce (${error.code}): ${error.message}");
-          },
-          result: ((result) {
-            return result;
-          }),
-        ));
-      } else {
-        throw Exception(
-            "Error call get_nonce (${error.code}): ${error.message}");
-      }
-    }, result: ((result) {
-      return result[0];
-    })));
-  }
-
   /// Execute contract given [selector] with [calldata]
   Future<InvokeTransactionResponse> execute(
       String selector, List<Felt> calldata) async {
-    final Felt nonce = await getNonce();
     final Felt maxFee = defaultMaxFee;
 
     final trx = await account.execute(
@@ -97,7 +60,6 @@ class Contract {
           calldata: calldata,
         ),
       ],
-      nonce: nonce,
       maxFee: maxFee,
     );
     return trx;

--- a/packages/starknet/lib/src/provider/model/deploy_account_transaction.dart
+++ b/packages/starknet/lib/src/provider/model/deploy_account_transaction.dart
@@ -1,0 +1,72 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:starknet/starknet.dart';
+
+part 'deploy_account_transaction.freezed.dart';
+part 'deploy_account_transaction.g.dart';
+
+abstract class DeployAccountTransaction {
+  factory DeployAccountTransaction.fromJson(Map<String, Object?> json) =>
+      json['version'] == '0x01'
+          ? DeployAccountTransaction.fromJson(json)
+          : throw Exception("Unsupported version ${json['version']}");
+
+  Map<String, dynamic> toJson();
+}
+
+@freezed
+class DeployAccountTransactionV1
+    with _$DeployAccountTransactionV1
+    implements DeployAccountTransaction {
+  const factory DeployAccountTransactionV1({
+    required List<Felt> signature,
+    required Felt maxFee,
+    required Felt nonce,
+    required Felt contractAddressSalt,
+    required List<Felt> constructorCalldata,
+    required Felt classHash,
+    @Default('0x01') String version,
+    @Default('DEPLOY_ACCOUNT') String type,
+  }) = _DeployAccountTransactionV1;
+
+  factory DeployAccountTransactionV1.fromJson(Map<String, Object?> json) =>
+      _$DeployAccountTransactionV1FromJson(json);
+}
+
+@freezed
+class DeployAccountTransactionRequest with _$DeployAccountTransactionRequest {
+  const factory DeployAccountTransactionRequest({
+    required DeployAccountTransaction deployAccountTransaction,
+  }) = _DeployAccountTransactionRequest;
+
+  factory DeployAccountTransactionRequest.fromJson(Map<String, Object?> json) =>
+      _$DeployAccountTransactionRequestFromJson(json);
+}
+
+@freezed
+class DeployAccountTransactionResponse with _$DeployAccountTransactionResponse {
+  const factory DeployAccountTransactionResponse.result({
+    required DeployAccountTransactionResponseResult result,
+  }) = DeployAccountTransactionResult;
+  const factory DeployAccountTransactionResponse.error({
+    required JsonRpcApiError error,
+  }) = DeployAccountTransactionError;
+
+  factory DeployAccountTransactionResponse.fromJson(
+          Map<String, Object?> json) =>
+      json.containsKey('error')
+          ? DeployAccountTransactionError.fromJson(json)
+          : DeployAccountTransactionResult.fromJson(json);
+}
+
+@freezed
+class DeployAccountTransactionResponseResult
+    with _$DeployAccountTransactionResponseResult {
+  const factory DeployAccountTransactionResponseResult({
+    required Felt transactionHash,
+    required Felt contractAddress,
+  }) = _DeployAccountTransactionResponseResult;
+
+  factory DeployAccountTransactionResponseResult.fromJson(
+          Map<String, Object?> json) =>
+      _$DeployAccountTransactionResponseResultFromJson(json);
+}

--- a/packages/starknet/lib/src/provider/model/deploy_account_transaction.freezed.dart
+++ b/packages/starknet/lib/src/provider/model/deploy_account_transaction.freezed.dart
@@ -1,0 +1,1087 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'deploy_account_transaction.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
+
+DeployAccountTransactionV1 _$DeployAccountTransactionV1FromJson(
+    Map<String, dynamic> json) {
+  return _DeployAccountTransactionV1.fromJson(json);
+}
+
+/// @nodoc
+mixin _$DeployAccountTransactionV1 {
+  List<Felt> get signature => throw _privateConstructorUsedError;
+  Felt get maxFee => throw _privateConstructorUsedError;
+  Felt get nonce => throw _privateConstructorUsedError;
+  Felt get contractAddressSalt => throw _privateConstructorUsedError;
+  List<Felt> get constructorCalldata => throw _privateConstructorUsedError;
+  Felt get classHash => throw _privateConstructorUsedError;
+  String get version => throw _privateConstructorUsedError;
+  String get type => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $DeployAccountTransactionV1CopyWith<DeployAccountTransactionV1>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $DeployAccountTransactionV1CopyWith<$Res> {
+  factory $DeployAccountTransactionV1CopyWith(DeployAccountTransactionV1 value,
+          $Res Function(DeployAccountTransactionV1) then) =
+      _$DeployAccountTransactionV1CopyWithImpl<$Res,
+          DeployAccountTransactionV1>;
+  @useResult
+  $Res call(
+      {List<Felt> signature,
+      Felt maxFee,
+      Felt nonce,
+      Felt contractAddressSalt,
+      List<Felt> constructorCalldata,
+      Felt classHash,
+      String version,
+      String type});
+}
+
+/// @nodoc
+class _$DeployAccountTransactionV1CopyWithImpl<$Res,
+        $Val extends DeployAccountTransactionV1>
+    implements $DeployAccountTransactionV1CopyWith<$Res> {
+  _$DeployAccountTransactionV1CopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? signature = null,
+    Object? maxFee = null,
+    Object? nonce = null,
+    Object? contractAddressSalt = null,
+    Object? constructorCalldata = null,
+    Object? classHash = null,
+    Object? version = null,
+    Object? type = null,
+  }) {
+    return _then(_value.copyWith(
+      signature: null == signature
+          ? _value.signature
+          : signature // ignore: cast_nullable_to_non_nullable
+              as List<Felt>,
+      maxFee: null == maxFee
+          ? _value.maxFee
+          : maxFee // ignore: cast_nullable_to_non_nullable
+              as Felt,
+      nonce: null == nonce
+          ? _value.nonce
+          : nonce // ignore: cast_nullable_to_non_nullable
+              as Felt,
+      contractAddressSalt: null == contractAddressSalt
+          ? _value.contractAddressSalt
+          : contractAddressSalt // ignore: cast_nullable_to_non_nullable
+              as Felt,
+      constructorCalldata: null == constructorCalldata
+          ? _value.constructorCalldata
+          : constructorCalldata // ignore: cast_nullable_to_non_nullable
+              as List<Felt>,
+      classHash: null == classHash
+          ? _value.classHash
+          : classHash // ignore: cast_nullable_to_non_nullable
+              as Felt,
+      version: null == version
+          ? _value.version
+          : version // ignore: cast_nullable_to_non_nullable
+              as String,
+      type: null == type
+          ? _value.type
+          : type // ignore: cast_nullable_to_non_nullable
+              as String,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$_DeployAccountTransactionV1CopyWith<$Res>
+    implements $DeployAccountTransactionV1CopyWith<$Res> {
+  factory _$$_DeployAccountTransactionV1CopyWith(
+          _$_DeployAccountTransactionV1 value,
+          $Res Function(_$_DeployAccountTransactionV1) then) =
+      __$$_DeployAccountTransactionV1CopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {List<Felt> signature,
+      Felt maxFee,
+      Felt nonce,
+      Felt contractAddressSalt,
+      List<Felt> constructorCalldata,
+      Felt classHash,
+      String version,
+      String type});
+}
+
+/// @nodoc
+class __$$_DeployAccountTransactionV1CopyWithImpl<$Res>
+    extends _$DeployAccountTransactionV1CopyWithImpl<$Res,
+        _$_DeployAccountTransactionV1>
+    implements _$$_DeployAccountTransactionV1CopyWith<$Res> {
+  __$$_DeployAccountTransactionV1CopyWithImpl(
+      _$_DeployAccountTransactionV1 _value,
+      $Res Function(_$_DeployAccountTransactionV1) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? signature = null,
+    Object? maxFee = null,
+    Object? nonce = null,
+    Object? contractAddressSalt = null,
+    Object? constructorCalldata = null,
+    Object? classHash = null,
+    Object? version = null,
+    Object? type = null,
+  }) {
+    return _then(_$_DeployAccountTransactionV1(
+      signature: null == signature
+          ? _value._signature
+          : signature // ignore: cast_nullable_to_non_nullable
+              as List<Felt>,
+      maxFee: null == maxFee
+          ? _value.maxFee
+          : maxFee // ignore: cast_nullable_to_non_nullable
+              as Felt,
+      nonce: null == nonce
+          ? _value.nonce
+          : nonce // ignore: cast_nullable_to_non_nullable
+              as Felt,
+      contractAddressSalt: null == contractAddressSalt
+          ? _value.contractAddressSalt
+          : contractAddressSalt // ignore: cast_nullable_to_non_nullable
+              as Felt,
+      constructorCalldata: null == constructorCalldata
+          ? _value._constructorCalldata
+          : constructorCalldata // ignore: cast_nullable_to_non_nullable
+              as List<Felt>,
+      classHash: null == classHash
+          ? _value.classHash
+          : classHash // ignore: cast_nullable_to_non_nullable
+              as Felt,
+      version: null == version
+          ? _value.version
+          : version // ignore: cast_nullable_to_non_nullable
+              as String,
+      type: null == type
+          ? _value.type
+          : type // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$_DeployAccountTransactionV1 implements _DeployAccountTransactionV1 {
+  const _$_DeployAccountTransactionV1(
+      {required final List<Felt> signature,
+      required this.maxFee,
+      required this.nonce,
+      required this.contractAddressSalt,
+      required final List<Felt> constructorCalldata,
+      required this.classHash,
+      this.version = '0x01',
+      this.type = 'DEPOY_ACCOUNT'})
+      : _signature = signature,
+        _constructorCalldata = constructorCalldata;
+
+  factory _$_DeployAccountTransactionV1.fromJson(Map<String, dynamic> json) =>
+      _$$_DeployAccountTransactionV1FromJson(json);
+
+  final List<Felt> _signature;
+  @override
+  List<Felt> get signature {
+    if (_signature is EqualUnmodifiableListView) return _signature;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_signature);
+  }
+
+  @override
+  final Felt maxFee;
+  @override
+  final Felt nonce;
+  @override
+  final Felt contractAddressSalt;
+  final List<Felt> _constructorCalldata;
+  @override
+  List<Felt> get constructorCalldata {
+    if (_constructorCalldata is EqualUnmodifiableListView)
+      return _constructorCalldata;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_constructorCalldata);
+  }
+
+  @override
+  final Felt classHash;
+  @override
+  @JsonKey()
+  final String version;
+  @override
+  @JsonKey()
+  final String type;
+
+  @override
+  String toString() {
+    return 'DeployAccountTransactionV1(signature: $signature, maxFee: $maxFee, nonce: $nonce, contractAddressSalt: $contractAddressSalt, constructorCalldata: $constructorCalldata, classHash: $classHash, version: $version, type: $type)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_DeployAccountTransactionV1 &&
+            const DeepCollectionEquality()
+                .equals(other._signature, _signature) &&
+            (identical(other.maxFee, maxFee) || other.maxFee == maxFee) &&
+            (identical(other.nonce, nonce) || other.nonce == nonce) &&
+            (identical(other.contractAddressSalt, contractAddressSalt) ||
+                other.contractAddressSalt == contractAddressSalt) &&
+            const DeepCollectionEquality()
+                .equals(other._constructorCalldata, _constructorCalldata) &&
+            (identical(other.classHash, classHash) ||
+                other.classHash == classHash) &&
+            (identical(other.version, version) || other.version == version) &&
+            (identical(other.type, type) || other.type == type));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(_signature),
+      maxFee,
+      nonce,
+      contractAddressSalt,
+      const DeepCollectionEquality().hash(_constructorCalldata),
+      classHash,
+      version,
+      type);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$_DeployAccountTransactionV1CopyWith<_$_DeployAccountTransactionV1>
+      get copyWith => __$$_DeployAccountTransactionV1CopyWithImpl<
+          _$_DeployAccountTransactionV1>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$_DeployAccountTransactionV1ToJson(
+      this,
+    );
+  }
+}
+
+abstract class _DeployAccountTransactionV1
+    implements DeployAccountTransactionV1 {
+  const factory _DeployAccountTransactionV1(
+      {required final List<Felt> signature,
+      required final Felt maxFee,
+      required final Felt nonce,
+      required final Felt contractAddressSalt,
+      required final List<Felt> constructorCalldata,
+      required final Felt classHash,
+      final String version,
+      final String type}) = _$_DeployAccountTransactionV1;
+
+  factory _DeployAccountTransactionV1.fromJson(Map<String, dynamic> json) =
+      _$_DeployAccountTransactionV1.fromJson;
+
+  @override
+  List<Felt> get signature;
+  @override
+  Felt get maxFee;
+  @override
+  Felt get nonce;
+  @override
+  Felt get contractAddressSalt;
+  @override
+  List<Felt> get constructorCalldata;
+  @override
+  Felt get classHash;
+  @override
+  String get version;
+  @override
+  String get type;
+  @override
+  @JsonKey(ignore: true)
+  _$$_DeployAccountTransactionV1CopyWith<_$_DeployAccountTransactionV1>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+DeployAccountTransactionRequest _$DeployAccountTransactionRequestFromJson(
+    Map<String, dynamic> json) {
+  return _DeployAccountTransactionRequest.fromJson(json);
+}
+
+/// @nodoc
+mixin _$DeployAccountTransactionRequest {
+  DeployAccountTransaction get deployAccountTransaction =>
+      throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $DeployAccountTransactionRequestCopyWith<DeployAccountTransactionRequest>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $DeployAccountTransactionRequestCopyWith<$Res> {
+  factory $DeployAccountTransactionRequestCopyWith(
+          DeployAccountTransactionRequest value,
+          $Res Function(DeployAccountTransactionRequest) then) =
+      _$DeployAccountTransactionRequestCopyWithImpl<$Res,
+          DeployAccountTransactionRequest>;
+  @useResult
+  $Res call({DeployAccountTransaction deployAccountTransaction});
+}
+
+/// @nodoc
+class _$DeployAccountTransactionRequestCopyWithImpl<$Res,
+        $Val extends DeployAccountTransactionRequest>
+    implements $DeployAccountTransactionRequestCopyWith<$Res> {
+  _$DeployAccountTransactionRequestCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? deployAccountTransaction = null,
+  }) {
+    return _then(_value.copyWith(
+      deployAccountTransaction: null == deployAccountTransaction
+          ? _value.deployAccountTransaction
+          : deployAccountTransaction // ignore: cast_nullable_to_non_nullable
+              as DeployAccountTransaction,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$_DeployAccountTransactionRequestCopyWith<$Res>
+    implements $DeployAccountTransactionRequestCopyWith<$Res> {
+  factory _$$_DeployAccountTransactionRequestCopyWith(
+          _$_DeployAccountTransactionRequest value,
+          $Res Function(_$_DeployAccountTransactionRequest) then) =
+      __$$_DeployAccountTransactionRequestCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({DeployAccountTransaction deployAccountTransaction});
+}
+
+/// @nodoc
+class __$$_DeployAccountTransactionRequestCopyWithImpl<$Res>
+    extends _$DeployAccountTransactionRequestCopyWithImpl<$Res,
+        _$_DeployAccountTransactionRequest>
+    implements _$$_DeployAccountTransactionRequestCopyWith<$Res> {
+  __$$_DeployAccountTransactionRequestCopyWithImpl(
+      _$_DeployAccountTransactionRequest _value,
+      $Res Function(_$_DeployAccountTransactionRequest) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? deployAccountTransaction = null,
+  }) {
+    return _then(_$_DeployAccountTransactionRequest(
+      deployAccountTransaction: null == deployAccountTransaction
+          ? _value.deployAccountTransaction
+          : deployAccountTransaction // ignore: cast_nullable_to_non_nullable
+              as DeployAccountTransaction,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$_DeployAccountTransactionRequest
+    implements _DeployAccountTransactionRequest {
+  const _$_DeployAccountTransactionRequest(
+      {required this.deployAccountTransaction});
+
+  factory _$_DeployAccountTransactionRequest.fromJson(
+          Map<String, dynamic> json) =>
+      _$$_DeployAccountTransactionRequestFromJson(json);
+
+  @override
+  final DeployAccountTransaction deployAccountTransaction;
+
+  @override
+  String toString() {
+    return 'DeployAccountTransactionRequest(deployAccountTransaction: $deployAccountTransaction)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_DeployAccountTransactionRequest &&
+            (identical(
+                    other.deployAccountTransaction, deployAccountTransaction) ||
+                other.deployAccountTransaction == deployAccountTransaction));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, deployAccountTransaction);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$_DeployAccountTransactionRequestCopyWith<
+          _$_DeployAccountTransactionRequest>
+      get copyWith => __$$_DeployAccountTransactionRequestCopyWithImpl<
+          _$_DeployAccountTransactionRequest>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$_DeployAccountTransactionRequestToJson(
+      this,
+    );
+  }
+}
+
+abstract class _DeployAccountTransactionRequest
+    implements DeployAccountTransactionRequest {
+  const factory _DeployAccountTransactionRequest(
+          {required final DeployAccountTransaction deployAccountTransaction}) =
+      _$_DeployAccountTransactionRequest;
+
+  factory _DeployAccountTransactionRequest.fromJson(Map<String, dynamic> json) =
+      _$_DeployAccountTransactionRequest.fromJson;
+
+  @override
+  DeployAccountTransaction get deployAccountTransaction;
+  @override
+  @JsonKey(ignore: true)
+  _$$_DeployAccountTransactionRequestCopyWith<
+          _$_DeployAccountTransactionRequest>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+DeployAccountTransactionResponse _$DeployAccountTransactionResponseFromJson(
+    Map<String, dynamic> json) {
+  switch (json['runtimeType']) {
+    case 'result':
+      return DeployAccountTransactionResult.fromJson(json);
+    case 'error':
+      return DeployAccountTransactionError.fromJson(json);
+
+    default:
+      throw CheckedFromJsonException(
+          json,
+          'runtimeType',
+          'DeployAccountTransactionResponse',
+          'Invalid union type "${json['runtimeType']}"!');
+  }
+}
+
+/// @nodoc
+mixin _$DeployAccountTransactionResponse {
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(DeployAccountTransactionResponseResult result)
+        result,
+    required TResult Function(JsonRpcApiError error) error,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(DeployAccountTransactionResponseResult result)? result,
+    TResult? Function(JsonRpcApiError error)? error,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(DeployAccountTransactionResponseResult result)? result,
+    TResult Function(JsonRpcApiError error)? error,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(DeployAccountTransactionResult value) result,
+    required TResult Function(DeployAccountTransactionError value) error,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(DeployAccountTransactionResult value)? result,
+    TResult? Function(DeployAccountTransactionError value)? error,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(DeployAccountTransactionResult value)? result,
+    TResult Function(DeployAccountTransactionError value)? error,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $DeployAccountTransactionResponseCopyWith<$Res> {
+  factory $DeployAccountTransactionResponseCopyWith(
+          DeployAccountTransactionResponse value,
+          $Res Function(DeployAccountTransactionResponse) then) =
+      _$DeployAccountTransactionResponseCopyWithImpl<$Res,
+          DeployAccountTransactionResponse>;
+}
+
+/// @nodoc
+class _$DeployAccountTransactionResponseCopyWithImpl<$Res,
+        $Val extends DeployAccountTransactionResponse>
+    implements $DeployAccountTransactionResponseCopyWith<$Res> {
+  _$DeployAccountTransactionResponseCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+}
+
+/// @nodoc
+abstract class _$$DeployAccountTransactionResultCopyWith<$Res> {
+  factory _$$DeployAccountTransactionResultCopyWith(
+          _$DeployAccountTransactionResult value,
+          $Res Function(_$DeployAccountTransactionResult) then) =
+      __$$DeployAccountTransactionResultCopyWithImpl<$Res>;
+  @useResult
+  $Res call({DeployAccountTransactionResponseResult result});
+
+  $DeployAccountTransactionResponseResultCopyWith<$Res> get result;
+}
+
+/// @nodoc
+class __$$DeployAccountTransactionResultCopyWithImpl<$Res>
+    extends _$DeployAccountTransactionResponseCopyWithImpl<$Res,
+        _$DeployAccountTransactionResult>
+    implements _$$DeployAccountTransactionResultCopyWith<$Res> {
+  __$$DeployAccountTransactionResultCopyWithImpl(
+      _$DeployAccountTransactionResult _value,
+      $Res Function(_$DeployAccountTransactionResult) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? result = null,
+  }) {
+    return _then(_$DeployAccountTransactionResult(
+      result: null == result
+          ? _value.result
+          : result // ignore: cast_nullable_to_non_nullable
+              as DeployAccountTransactionResponseResult,
+    ));
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $DeployAccountTransactionResponseResultCopyWith<$Res> get result {
+    return $DeployAccountTransactionResponseResultCopyWith<$Res>(_value.result,
+        (value) {
+      return _then(_value.copyWith(result: value));
+    });
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$DeployAccountTransactionResult
+    implements DeployAccountTransactionResult {
+  const _$DeployAccountTransactionResult(
+      {required this.result, final String? $type})
+      : $type = $type ?? 'result';
+
+  factory _$DeployAccountTransactionResult.fromJson(
+          Map<String, dynamic> json) =>
+      _$$DeployAccountTransactionResultFromJson(json);
+
+  @override
+  final DeployAccountTransactionResponseResult result;
+
+  @JsonKey(name: 'runtimeType')
+  final String $type;
+
+  @override
+  String toString() {
+    return 'DeployAccountTransactionResponse.result(result: $result)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$DeployAccountTransactionResult &&
+            (identical(other.result, result) || other.result == result));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, result);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$DeployAccountTransactionResultCopyWith<_$DeployAccountTransactionResult>
+      get copyWith => __$$DeployAccountTransactionResultCopyWithImpl<
+          _$DeployAccountTransactionResult>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(DeployAccountTransactionResponseResult result)
+        result,
+    required TResult Function(JsonRpcApiError error) error,
+  }) {
+    return result(this.result);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(DeployAccountTransactionResponseResult result)? result,
+    TResult? Function(JsonRpcApiError error)? error,
+  }) {
+    return result?.call(this.result);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(DeployAccountTransactionResponseResult result)? result,
+    TResult Function(JsonRpcApiError error)? error,
+    required TResult orElse(),
+  }) {
+    if (result != null) {
+      return result(this.result);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(DeployAccountTransactionResult value) result,
+    required TResult Function(DeployAccountTransactionError value) error,
+  }) {
+    return result(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(DeployAccountTransactionResult value)? result,
+    TResult? Function(DeployAccountTransactionError value)? error,
+  }) {
+    return result?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(DeployAccountTransactionResult value)? result,
+    TResult Function(DeployAccountTransactionError value)? error,
+    required TResult orElse(),
+  }) {
+    if (result != null) {
+      return result(this);
+    }
+    return orElse();
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$DeployAccountTransactionResultToJson(
+      this,
+    );
+  }
+}
+
+abstract class DeployAccountTransactionResult
+    implements DeployAccountTransactionResponse {
+  const factory DeployAccountTransactionResult(
+          {required final DeployAccountTransactionResponseResult result}) =
+      _$DeployAccountTransactionResult;
+
+  factory DeployAccountTransactionResult.fromJson(Map<String, dynamic> json) =
+      _$DeployAccountTransactionResult.fromJson;
+
+  DeployAccountTransactionResponseResult get result;
+  @JsonKey(ignore: true)
+  _$$DeployAccountTransactionResultCopyWith<_$DeployAccountTransactionResult>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$DeployAccountTransactionErrorCopyWith<$Res> {
+  factory _$$DeployAccountTransactionErrorCopyWith(
+          _$DeployAccountTransactionError value,
+          $Res Function(_$DeployAccountTransactionError) then) =
+      __$$DeployAccountTransactionErrorCopyWithImpl<$Res>;
+  @useResult
+  $Res call({JsonRpcApiError error});
+
+  $JsonRpcApiErrorCopyWith<$Res> get error;
+}
+
+/// @nodoc
+class __$$DeployAccountTransactionErrorCopyWithImpl<$Res>
+    extends _$DeployAccountTransactionResponseCopyWithImpl<$Res,
+        _$DeployAccountTransactionError>
+    implements _$$DeployAccountTransactionErrorCopyWith<$Res> {
+  __$$DeployAccountTransactionErrorCopyWithImpl(
+      _$DeployAccountTransactionError _value,
+      $Res Function(_$DeployAccountTransactionError) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? error = null,
+  }) {
+    return _then(_$DeployAccountTransactionError(
+      error: null == error
+          ? _value.error
+          : error // ignore: cast_nullable_to_non_nullable
+              as JsonRpcApiError,
+    ));
+  }
+
+  @override
+  @pragma('vm:prefer-inline')
+  $JsonRpcApiErrorCopyWith<$Res> get error {
+    return $JsonRpcApiErrorCopyWith<$Res>(_value.error, (value) {
+      return _then(_value.copyWith(error: value));
+    });
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$DeployAccountTransactionError implements DeployAccountTransactionError {
+  const _$DeployAccountTransactionError(
+      {required this.error, final String? $type})
+      : $type = $type ?? 'error';
+
+  factory _$DeployAccountTransactionError.fromJson(Map<String, dynamic> json) =>
+      _$$DeployAccountTransactionErrorFromJson(json);
+
+  @override
+  final JsonRpcApiError error;
+
+  @JsonKey(name: 'runtimeType')
+  final String $type;
+
+  @override
+  String toString() {
+    return 'DeployAccountTransactionResponse.error(error: $error)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$DeployAccountTransactionError &&
+            (identical(other.error, error) || other.error == error));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, error);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$DeployAccountTransactionErrorCopyWith<_$DeployAccountTransactionError>
+      get copyWith => __$$DeployAccountTransactionErrorCopyWithImpl<
+          _$DeployAccountTransactionError>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(DeployAccountTransactionResponseResult result)
+        result,
+    required TResult Function(JsonRpcApiError error) error,
+  }) {
+    return error(this.error);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(DeployAccountTransactionResponseResult result)? result,
+    TResult? Function(JsonRpcApiError error)? error,
+  }) {
+    return error?.call(this.error);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(DeployAccountTransactionResponseResult result)? result,
+    TResult Function(JsonRpcApiError error)? error,
+    required TResult orElse(),
+  }) {
+    if (error != null) {
+      return error(this.error);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(DeployAccountTransactionResult value) result,
+    required TResult Function(DeployAccountTransactionError value) error,
+  }) {
+    return error(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(DeployAccountTransactionResult value)? result,
+    TResult? Function(DeployAccountTransactionError value)? error,
+  }) {
+    return error?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(DeployAccountTransactionResult value)? result,
+    TResult Function(DeployAccountTransactionError value)? error,
+    required TResult orElse(),
+  }) {
+    if (error != null) {
+      return error(this);
+    }
+    return orElse();
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$DeployAccountTransactionErrorToJson(
+      this,
+    );
+  }
+}
+
+abstract class DeployAccountTransactionError
+    implements DeployAccountTransactionResponse {
+  const factory DeployAccountTransactionError(
+      {required final JsonRpcApiError error}) = _$DeployAccountTransactionError;
+
+  factory DeployAccountTransactionError.fromJson(Map<String, dynamic> json) =
+      _$DeployAccountTransactionError.fromJson;
+
+  JsonRpcApiError get error;
+  @JsonKey(ignore: true)
+  _$$DeployAccountTransactionErrorCopyWith<_$DeployAccountTransactionError>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+DeployAccountTransactionResponseResult
+    _$DeployAccountTransactionResponseResultFromJson(
+        Map<String, dynamic> json) {
+  return _DeployAccountTransactionResponseResult.fromJson(json);
+}
+
+/// @nodoc
+mixin _$DeployAccountTransactionResponseResult {
+  Felt get transactionHash => throw _privateConstructorUsedError;
+  Felt get contractAddress => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $DeployAccountTransactionResponseResultCopyWith<
+          DeployAccountTransactionResponseResult>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $DeployAccountTransactionResponseResultCopyWith<$Res> {
+  factory $DeployAccountTransactionResponseResultCopyWith(
+          DeployAccountTransactionResponseResult value,
+          $Res Function(DeployAccountTransactionResponseResult) then) =
+      _$DeployAccountTransactionResponseResultCopyWithImpl<$Res,
+          DeployAccountTransactionResponseResult>;
+  @useResult
+  $Res call({Felt transactionHash, Felt contractAddress});
+}
+
+/// @nodoc
+class _$DeployAccountTransactionResponseResultCopyWithImpl<$Res,
+        $Val extends DeployAccountTransactionResponseResult>
+    implements $DeployAccountTransactionResponseResultCopyWith<$Res> {
+  _$DeployAccountTransactionResponseResultCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? transactionHash = null,
+    Object? contractAddress = null,
+  }) {
+    return _then(_value.copyWith(
+      transactionHash: null == transactionHash
+          ? _value.transactionHash
+          : transactionHash // ignore: cast_nullable_to_non_nullable
+              as Felt,
+      contractAddress: null == contractAddress
+          ? _value.contractAddress
+          : contractAddress // ignore: cast_nullable_to_non_nullable
+              as Felt,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$_DeployAccountTransactionResponseResultCopyWith<$Res>
+    implements $DeployAccountTransactionResponseResultCopyWith<$Res> {
+  factory _$$_DeployAccountTransactionResponseResultCopyWith(
+          _$_DeployAccountTransactionResponseResult value,
+          $Res Function(_$_DeployAccountTransactionResponseResult) then) =
+      __$$_DeployAccountTransactionResponseResultCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({Felt transactionHash, Felt contractAddress});
+}
+
+/// @nodoc
+class __$$_DeployAccountTransactionResponseResultCopyWithImpl<$Res>
+    extends _$DeployAccountTransactionResponseResultCopyWithImpl<$Res,
+        _$_DeployAccountTransactionResponseResult>
+    implements _$$_DeployAccountTransactionResponseResultCopyWith<$Res> {
+  __$$_DeployAccountTransactionResponseResultCopyWithImpl(
+      _$_DeployAccountTransactionResponseResult _value,
+      $Res Function(_$_DeployAccountTransactionResponseResult) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? transactionHash = null,
+    Object? contractAddress = null,
+  }) {
+    return _then(_$_DeployAccountTransactionResponseResult(
+      transactionHash: null == transactionHash
+          ? _value.transactionHash
+          : transactionHash // ignore: cast_nullable_to_non_nullable
+              as Felt,
+      contractAddress: null == contractAddress
+          ? _value.contractAddress
+          : contractAddress // ignore: cast_nullable_to_non_nullable
+              as Felt,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$_DeployAccountTransactionResponseResult
+    implements _DeployAccountTransactionResponseResult {
+  const _$_DeployAccountTransactionResponseResult(
+      {required this.transactionHash, required this.contractAddress});
+
+  factory _$_DeployAccountTransactionResponseResult.fromJson(
+          Map<String, dynamic> json) =>
+      _$$_DeployAccountTransactionResponseResultFromJson(json);
+
+  @override
+  final Felt transactionHash;
+  @override
+  final Felt contractAddress;
+
+  @override
+  String toString() {
+    return 'DeployAccountTransactionResponseResult(transactionHash: $transactionHash, contractAddress: $contractAddress)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$_DeployAccountTransactionResponseResult &&
+            (identical(other.transactionHash, transactionHash) ||
+                other.transactionHash == transactionHash) &&
+            (identical(other.contractAddress, contractAddress) ||
+                other.contractAddress == contractAddress));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, transactionHash, contractAddress);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$_DeployAccountTransactionResponseResultCopyWith<
+          _$_DeployAccountTransactionResponseResult>
+      get copyWith => __$$_DeployAccountTransactionResponseResultCopyWithImpl<
+          _$_DeployAccountTransactionResponseResult>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$_DeployAccountTransactionResponseResultToJson(
+      this,
+    );
+  }
+}
+
+abstract class _DeployAccountTransactionResponseResult
+    implements DeployAccountTransactionResponseResult {
+  const factory _DeployAccountTransactionResponseResult(
+          {required final Felt transactionHash,
+          required final Felt contractAddress}) =
+      _$_DeployAccountTransactionResponseResult;
+
+  factory _DeployAccountTransactionResponseResult.fromJson(
+          Map<String, dynamic> json) =
+      _$_DeployAccountTransactionResponseResult.fromJson;
+
+  @override
+  Felt get transactionHash;
+  @override
+  Felt get contractAddress;
+  @override
+  @JsonKey(ignore: true)
+  _$$_DeployAccountTransactionResponseResultCopyWith<
+          _$_DeployAccountTransactionResponseResult>
+      get copyWith => throw _privateConstructorUsedError;
+}

--- a/packages/starknet/lib/src/provider/model/deploy_account_transaction.g.dart
+++ b/packages/starknet/lib/src/provider/model/deploy_account_transaction.g.dart
@@ -1,0 +1,96 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'deploy_account_transaction.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$_DeployAccountTransactionV1 _$$_DeployAccountTransactionV1FromJson(
+        Map<String, dynamic> json) =>
+    _$_DeployAccountTransactionV1(
+      signature: (json['signature'] as List<dynamic>)
+          .map((e) => Felt.fromJson(e as String))
+          .toList(),
+      maxFee: Felt.fromJson(json['max_fee'] as String),
+      nonce: Felt.fromJson(json['nonce'] as String),
+      contractAddressSalt:
+          Felt.fromJson(json['contract_address_salt'] as String),
+      constructorCalldata: (json['constructor_calldata'] as List<dynamic>)
+          .map((e) => Felt.fromJson(e as String))
+          .toList(),
+      classHash: Felt.fromJson(json['class_hash'] as String),
+      version: json['version'] as String? ?? '0x01',
+      type: json['type'] as String? ?? 'DEPOY_ACCOUNT',
+    );
+
+Map<String, dynamic> _$$_DeployAccountTransactionV1ToJson(
+        _$_DeployAccountTransactionV1 instance) =>
+    <String, dynamic>{
+      'signature': instance.signature.map((e) => e.toJson()).toList(),
+      'max_fee': instance.maxFee.toJson(),
+      'nonce': instance.nonce.toJson(),
+      'contract_address_salt': instance.contractAddressSalt.toJson(),
+      'constructor_calldata':
+          instance.constructorCalldata.map((e) => e.toJson()).toList(),
+      'class_hash': instance.classHash.toJson(),
+      'version': instance.version,
+      'type': instance.type,
+    };
+
+_$_DeployAccountTransactionRequest _$$_DeployAccountTransactionRequestFromJson(
+        Map<String, dynamic> json) =>
+    _$_DeployAccountTransactionRequest(
+      deployAccountTransaction: DeployAccountTransaction.fromJson(
+          json['deploy_account_transaction'] as Map<String, dynamic>),
+    );
+
+Map<String, dynamic> _$$_DeployAccountTransactionRequestToJson(
+        _$_DeployAccountTransactionRequest instance) =>
+    <String, dynamic>{
+      'deploy_account_transaction': instance.deployAccountTransaction.toJson(),
+    };
+
+_$DeployAccountTransactionResult _$$DeployAccountTransactionResultFromJson(
+        Map<String, dynamic> json) =>
+    _$DeployAccountTransactionResult(
+      result: DeployAccountTransactionResponseResult.fromJson(
+          json['result'] as Map<String, dynamic>),
+      $type: json['runtimeType'] as String?,
+    );
+
+Map<String, dynamic> _$$DeployAccountTransactionResultToJson(
+        _$DeployAccountTransactionResult instance) =>
+    <String, dynamic>{
+      'result': instance.result.toJson(),
+      'runtimeType': instance.$type,
+    };
+
+_$DeployAccountTransactionError _$$DeployAccountTransactionErrorFromJson(
+        Map<String, dynamic> json) =>
+    _$DeployAccountTransactionError(
+      error: JsonRpcApiError.fromJson(json['error'] as Map<String, dynamic>),
+      $type: json['runtimeType'] as String?,
+    );
+
+Map<String, dynamic> _$$DeployAccountTransactionErrorToJson(
+        _$DeployAccountTransactionError instance) =>
+    <String, dynamic>{
+      'error': instance.error.toJson(),
+      'runtimeType': instance.$type,
+    };
+
+_$_DeployAccountTransactionResponseResult
+    _$$_DeployAccountTransactionResponseResultFromJson(
+            Map<String, dynamic> json) =>
+        _$_DeployAccountTransactionResponseResult(
+          transactionHash: Felt.fromJson(json['transaction_hash'] as String),
+          contractAddress: Felt.fromJson(json['contract_address'] as String),
+        );
+
+Map<String, dynamic> _$$_DeployAccountTransactionResponseResultToJson(
+        _$_DeployAccountTransactionResponseResult instance) =>
+    <String, dynamic>{
+      'transaction_hash': instance.transactionHash.toJson(),
+      'contract_address': instance.contractAddress.toJson(),
+    };

--- a/packages/starknet/lib/src/provider/model/index.dart
+++ b/packages/starknet/lib/src/provider/model/index.dart
@@ -5,6 +5,7 @@ export 'call.dart';
 export 'chain_id.dart';
 export 'contract_storage_diff_item.dart';
 export 'declared_contract_item.dart';
+export 'deploy_account_transaction.dart';
 export 'deployed_contract_item.dart';
 export 'estimate_fee.dart';
 export 'event.dart';

--- a/packages/starknet/lib/src/provider/provider.dart
+++ b/packages/starknet/lib/src/provider/provider.dart
@@ -5,6 +5,8 @@ abstract class Provider implements ReadProvider {
       InvokeTransactionRequest request);
   Future<DeclareTransactionResponse> addDeclareTransaction(
       DeclareTransactionRequest request);
+  Future<DeployAccountTransactionResponse> addDeployAccountTransaction(
+      DeployAccountTransactionRequest request);
 }
 
 class JsonRpcProvider extends JsonRpcReadProvider implements Provider {
@@ -32,6 +34,16 @@ class JsonRpcProvider extends JsonRpcReadProvider implements Provider {
             method: 'starknet_addDeclareTransaction',
             params: request)
         .then(DeclareTransactionResponse.fromJson);
+  }
+
+  @override
+  Future<DeployAccountTransactionResponse> addDeployAccountTransaction(
+      DeployAccountTransactionRequest request) async {
+    return callRpcEndpoint(
+            nodeUri: nodeUri,
+            method: 'starknet_addDeployAccountTransaction',
+            params: request)
+        .then(DeployAccountTransactionResponse.fromJson);
   }
 
   static final devnet = JsonRpcProvider(nodeUri: devnetUri);

--- a/packages/starknet/lib/src/signer.dart
+++ b/packages/starknet/lib/src/signer.dart
@@ -125,4 +125,41 @@ class Signer {
 
     return [Felt(signature.r), Felt(signature.s)];
   }
+
+  List<Felt> signDeployAccountTransactionV1({
+    required Felt contractAddressSalt,
+    required Felt classHash,
+    required List<Felt> constructorCalldata,
+    required Felt chainId,
+    Felt? nonce,
+    Felt? maxFee,
+  }) {
+    maxFee = maxFee ?? defaultMaxFee;
+    nonce = nonce ?? defaultNonce;
+    final contractAddress = Contract.computeAddress(
+        classHash: classHash,
+        calldata: constructorCalldata,
+        salt: contractAddressSalt);
+
+    final transactionHash = calculateTransactionHashCommon(
+        txHashPrefix: TransactionHashPrefix.deployAccount.toBigInt(),
+        version: 1,
+        address: contractAddress.toBigInt(),
+        entryPointSelector: BigInt.from(0),
+        calldata: toBigIntList([
+          classHash,
+          contractAddressSalt,
+          ...constructorCalldata,
+        ]),
+        maxFee: maxFee.toBigInt(),
+        chainId: chainId.toBigInt(),
+        additionalData: [nonce.toBigInt()]);
+
+    final signature = starknet_sign(
+      privateKey: privateKey.toBigInt(),
+      messageHash: transactionHash,
+    );
+
+    return [Felt(signature.r), Felt(signature.s)];
+  }
 }

--- a/packages/starknet/lib/src/static_config.dart
+++ b/packages/starknet/lib/src/static_config.dart
@@ -49,6 +49,16 @@ final account1 = getAccount(
   privateKey: devnetAccount1PrivateKey,
 );
 
+final devnetAccount9Address = Felt.fromHexString(
+    "0x7f61fa3893ad0637b2ff76fed23ebbb91835aacd4f743c2347716f856438429");
+final devnetAccount9PublicKey = Felt.fromHexString(
+    "0xc11e246b1d54515a26204d2d3c8586ea25ed9eecae00df173405974cb86dbc");
+final devnetAccount9PrivateKey =
+    Felt.fromHexString("0x259f4329e6f4590b9a164106cf6a659e");
+final account9 = getAccount(
+  accountAddress: devnetAccount9Address,
+  privateKey: devnetAccount9PrivateKey,
+);
 // Testnet
 
 final v010PathfinderGoerliTestnetUri = Uri.parse('http://35.180.61.64');

--- a/packages/starknet/lib/src/static_config.dart
+++ b/packages/starknet/lib/src/static_config.dart
@@ -8,6 +8,7 @@ class StarknetChainId {
 class TransactionHashPrefix {
   static final declare = Felt.fromString('declare');
   static final deploy = Felt.fromString('deploy');
+  static final deployAccount = Felt.fromString('deploy_account');
   static final invoke = Felt.fromString('invoke');
   static final l1Handler = Felt.fromString('l1_handler');
 }
@@ -22,6 +23,10 @@ final udcAddress = Felt.fromHexString(
 // address is the same for mainnet & testnet
 final ethAddress = Felt.fromHexString(
     "0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7");
+
+// from starknet-devnet 0.4.0
+final openZeppelinAccountClassHash = Felt.fromHexString(
+    "0x1fac3074c9d5282f0acc5c69a4781a1c711efea5e73c550c5d9fb253cf7fd3d");
 
 // Devnet
 

--- a/packages/starknet/test/account_test.dart
+++ b/packages/starknet/test/account_test.dart
@@ -3,6 +3,12 @@ import 'package:test/test.dart';
 
 void main() {
   group('Account', () {
+    group('nonce', () {
+      test('get nonce', () async {
+        final nonce = await account9.getNonce();
+        expect(nonce, equals(Felt.fromInt(0)));
+      });
+    });
     group('declare', () {
       test('succeeds', () async {
         final balanceContract =

--- a/packages/starknet/test/account_test.dart
+++ b/packages/starknet/test/account_test.dart
@@ -10,7 +10,7 @@ void main() {
       });
     });
     group('declare', () {
-      test('succeeds', () async {
+      test('succeeds to declare a contract class hash', () async {
         final balanceContract =
             await parseContract('../../contracts/build/balance.json');
         final res = await account0.declare(compiledContract: balanceContract);
@@ -28,7 +28,7 @@ void main() {
       });
     }, tags: ['integration-devnet-040']);
     group('deploy', () {
-      test('succeeds', () async {
+      test('succeeds to deploy a contract', () async {
         // Balance contract
         final classHash = Felt.fromHexString(
             "0x5d077995ffe1356cfd48aa5990ece8bf420dacab9b7d3e6941e0c53c208a56b"); // 2023-02-06: class hash with 'runtimeType' included
@@ -39,6 +39,52 @@ void main() {
             contractAddress,
             equals(Felt.fromHexString(
                 '0x149867a6ce95f2d20ed96187abd430d7c2c48cdfb7dd541fb1337563ff8d9b9')));
+      });
+
+      test('succeeds to deploy an account', () async {
+        final accountPrivateKey = Felt.fromHexString("0x12345678");
+        final accountPublicKey = Felt.fromHexString(
+            "0x47de619de131463cbf799d321b50c617566dc897d4be614fb3927eacd55d7ad");
+        final accountConstructorCalldata = [accountPublicKey];
+        final accountSigner = Signer(privateKey: accountPrivateKey);
+        final classHash = openZeppelinAccountClassHash;
+        final maxFee = defaultMaxFee;
+        final provider = account0.provider;
+        // we have to compute account address to send token
+        final accountAddress = Contract.computeAddress(
+            classHash: classHash,
+            calldata: accountConstructorCalldata,
+            salt: Felt.fromInt(42));
+
+        Felt accountClassHash = (await provider.getClassHashAt(
+                contractAddress: accountAddress, blockId: BlockId.latest))
+            .when(
+                result: (result) => result,
+                error: ((error) => Felt.fromInt(0)));
+        expect(accountClassHash, equals(Felt.fromInt(0)));
+        // account address requires token to pay deploy fees
+        final txSend = await account0.send(
+            recipient: accountAddress,
+            amount: Uint256(low: maxFee, high: Felt.fromInt(0)));
+        bool success = await waitForAcceptance(
+            transactionHash: txSend, provider: account0.provider);
+        expect(success, equals(true));
+        final tx = await Account.deployAccount(
+            signer: accountSigner,
+            provider: provider,
+            constructorCalldata: accountConstructorCalldata,
+            maxFee: maxFee);
+        final contractAddress = tx.when(
+            result: (result) => result.contractAddress,
+            error: (error) =>
+                throw Exception("${error.code}: ${error.message}"));
+        expect(accountAddress, equals(contractAddress));
+        accountClassHash = (await provider.getClassHashAt(
+                contractAddress: accountAddress, blockId: BlockId.latest))
+            .when(
+                result: (result) => result,
+                error: ((error) => Felt.fromInt(0)));
+        expect(accountClassHash, equals(classHash));
       });
       // }, tags: ['integration-devnet-040']);
     }, tags: ['to-be-fixed']);

--- a/packages/starknet/test/contract/contract_test.dart
+++ b/packages/starknet/test/contract/contract_test.dart
@@ -12,25 +12,45 @@ void main() {
         final classHash = compiledContract.classHash();
         expect(
             classHash,
-            equals(BigInt.parse(
-                "2629893875186532358210942156370932694899207790379996755057537765547495171435")));
+            equals(
+              BigInt.parse(
+                  "2629893875186532358210942156370932694899207790379996755057537765547495171435"),
+            ));
       });
     });
 
-    group('Address', () {
+    group('Contract address', () {
       test('Compute contract address', () async {
         // data are coming from starknet-rs
         final salt = Felt.fromHexString(
             "0x0018a7a329d1d85b621350f2b5fc9c64b2e57dfe708525f0aff2c90de1e5b9c8");
         final classHash = Felt.fromHexString(
             "0x0750cd490a7cd1572411169eaa8be292325990d33c5d4733655fe6b926985062");
-        final callData = [Felt.fromInt(1)];
+        final calldata = [Felt.fromInt(1)];
         final contractAddress = Contract.computeAddress(
-            classHash: classHash, callData: callData, salt: salt);
+            classHash: classHash, calldata: calldata, salt: salt);
         expect(
             contractAddress,
-            equals(Felt.fromHexString(
-                "0x00da27ef7c3869c3a6cc6a0f7bf07a51c3e590825adba8a51cae27d815839eec")));
+            equals(
+              Felt.fromHexString(
+                  "0x00da27ef7c3869c3a6cc6a0f7bf07a51c3e590825adba8a51cae27d815839eec"),
+            ));
+      });
+
+      test('Compute account address', () async {
+        // value are from devnet account #1
+        final salt = Felt.fromInt(20);
+        // OpenZeppelin account class hash
+        final classHash = Felt.fromHexString(
+            "0x3FCBF77B28C96F4F2FB5BD2D176AB083A12A5E123ADEB0DE955D7EE228C9854");
+        // devnet account#1 public key
+        final publicKey = devnetAccount1PublicKey;
+        final accountAddress = Contract.computeAddress(
+            classHash: classHash, calldata: [publicKey], salt: salt);
+        expect(
+          accountAddress,
+          equals(devnetAccount1Address),
+        );
       });
     });
   }, tags: ['unit']);

--- a/packages/starknet/test/contract/contract_test.dart
+++ b/packages/starknet/test/contract/contract_test.dart
@@ -38,9 +38,9 @@ void main() {
       });
 
       test('Compute account address', () async {
-        // value are from devnet account #1
+        // value are from devnet (0.4.0) account #1
         final salt = Felt.fromInt(20);
-        // OpenZeppelin account class hash
+        // devnet (0.4.0) account class hash
         final classHash = Felt.fromHexString(
             "0x3FCBF77B28C96F4F2FB5BD2D176AB083A12A5E123ADEB0DE955D7EE228C9854");
         // devnet account#1 public key

--- a/packages/starknet/test/contract/contract_test.dart
+++ b/packages/starknet/test/contract/contract_test.dart
@@ -16,5 +16,22 @@ void main() {
                 "2629893875186532358210942156370932694899207790379996755057537765547495171435")));
       });
     });
+
+    group('Address', () {
+      test('Compute contract address', () async {
+        // data are coming from starknet-rs
+        final salt = Felt.fromHexString(
+            "0x0018a7a329d1d85b621350f2b5fc9c64b2e57dfe708525f0aff2c90de1e5b9c8");
+        final classHash = Felt.fromHexString(
+            "0x0750cd490a7cd1572411169eaa8be292325990d33c5d4733655fe6b926985062");
+        final callData = [Felt.fromInt(1)];
+        final contractAddress = Contract.computeAddress(
+            classHash: classHash, callData: callData, salt: salt);
+        expect(
+            contractAddress,
+            equals(Felt.fromHexString(
+                "0x00da27ef7c3869c3a6cc6a0f7bf07a51c3e590825adba8a51cae27d815839eec")));
+      });
+    });
   }, tags: ['unit']);
 }


### PR DESCRIPTION
This PR add support to declare transaction version 1.

To deploy an account, you have to call `Account.deployAccount` static method.
If `classHash` is null, we fallback on OpenZeppelin contract class hash.

Additional changes:
- A static method named `computeAddress` in `Contract` class 
- `getNonce` has been moved from `Contract` to `Account` class since it's account 

Closes #83 
Closes #121