### PR TITLE
✨ [SecureEnclave] Prompt biometric when storing private key

### DIFF
--- a/packages/starknet_flutter/darwin/Classes/Managers/SecureEnclaveManager.swift
+++ b/packages/starknet_flutter/darwin/Classes/Managers/SecureEnclaveManager.swift
@@ -140,6 +140,13 @@ class SecureEnclaveManager {
     // If the secret key does not exist, generate a new key pair and save the private key in the secure enclave.
     if (secretKey == nil) {
       secretKey = try generateKeypair(key: key)
+    } else {
+#if os(iOS)
+      let biometricResult = promptBiometric()
+      if (!biometricResult) {
+        throw SecureEnclaveErrors.biometricNotAvailable
+      }
+#endif
     }
     
     // Get the public key from the secret key.
@@ -201,6 +208,13 @@ class SecureEnclaveManager {
     guard let secAttrApplicationTag = "\(SecureEnclaveManager.starknetTag)\(SecureEnclaveManager.tagSeparator)\(key)".data(using: .utf8) else {
       throw SecureEnclaveErrors.tagConvertion
     }
+
+#if os(iOS)
+    let biometricResult = promptBiometric()
+    if (!biometricResult) {
+      throw SecureEnclaveErrors.biometricNotAvailable
+    }
+#endif
     
     // Attempt to retrieve the secret key from the secure enclave.
     let secretKey = try getSecretKey(key: key)

--- a/packages/starknet_flutter/darwin/Classes/Managers/SecureEnclaveManager.swift
+++ b/packages/starknet_flutter/darwin/Classes/Managers/SecureEnclaveManager.swift
@@ -140,13 +140,6 @@ class SecureEnclaveManager {
     // If the secret key does not exist, generate a new key pair and save the private key in the secure enclave.
     if (secretKey == nil) {
       secretKey = try generateKeypair(key: key)
-    } else {
-#if os(iOS)
-      let biometricResult = promptBiometric()
-      if (!biometricResult) {
-        throw SecureEnclaveErrors.biometricNotAvailable
-      }
-#endif
     }
     
     // Get the public key from the secret key.
@@ -208,13 +201,6 @@ class SecureEnclaveManager {
     guard let secAttrApplicationTag = "\(SecureEnclaveManager.starknetTag)\(SecureEnclaveManager.tagSeparator)\(key)".data(using: .utf8) else {
       throw SecureEnclaveErrors.tagConvertion
     }
-
-#if os(iOS)
-    let biometricResult = promptBiometric()
-    if (!biometricResult) {
-      throw SecureEnclaveErrors.biometricNotAvailable
-    }
-#endif
     
     // Attempt to retrieve the secret key from the secure enclave.
     let secretKey = try getSecretKey(key: key)

--- a/packages/starknet_flutter/darwin/Classes/Utils/AuthenticationUtil.swift
+++ b/packages/starknet_flutter/darwin/Classes/Utils/AuthenticationUtil.swift
@@ -1,0 +1,25 @@
+import LocalAuthentication
+
+struct AuthenticationUtil {
+  // Prompt for biometric authentication
+  static func promptBiometric() -> Bool {
+    let context = LAContext()
+    let permissions = context.canEvaluatePolicy(
+      .deviceOwnerAuthentication,
+      error: nil
+    )
+    // Biometric permissions not granted
+    if !permissions {
+      return false
+    }
+    
+    var success = false
+    let sema = DispatchSemaphore(value: 0)
+    context.evaluatePolicy(.deviceOwnerAuthentication, localizedReason: "Authenticate with biometrics to store private key.", reply: { (result, error) in
+      success = result && error == nil
+      sema.signal()
+    })
+    sema.wait()
+    return success
+  }
+}

--- a/packages/starknet_flutter/ios/Classes/Utils/AuthenticationUtil.swift
+++ b/packages/starknet_flutter/ios/Classes/Utils/AuthenticationUtil.swift
@@ -1,0 +1,1 @@
+../../../darwin/Classes/Utils/AuthenticationUtil.swift

--- a/packages/starknet_flutter/macos/Classes/Utils/AuthenticationUtil.swift
+++ b/packages/starknet_flutter/macos/Classes/Utils/AuthenticationUtil.swift
@@ -1,0 +1,1 @@
+../../../darwin/Classes/Utils/AuthenticationUtil.swift


### PR DESCRIPTION
- On iOS, add a biometric validation before storing key in the Secure Enclave.
- Change application tag to be a valid identifier.