### PR TITLE
Add support to Braavos account recovery from seed phrase

### DIFF
--- a/packages/starknet/example/examples/recovery_braavos.dart
+++ b/packages/starknet/example/examples/recovery_braavos.dart
@@ -1,0 +1,27 @@
+import 'package:starknet/starknet.dart';
+
+final mnemonic =
+    "toward antenna indicate reject must artist expect angry fit easy cupboard require"
+        .split(" ");
+
+void main() async {
+  final provider = JsonRpcProvider(nodeUri: infuraGoerliTestnetUri);
+  final chainId = StarknetChainId.testNet;
+
+  print("Retrieving Braavos accounts");
+  int index = 0;
+  bool valid = true;
+  while (valid) {
+    print("########################");
+    final account = Account.fromMnemonic(
+        mnemonic: mnemonic, provider: provider, chainId: chainId, index: index);
+    index += 1;
+    valid = await account.isValid;
+    if (valid) {
+      print("Address: ${account.accountAddress.toHexString()}");
+      print("Public Key: ${account.signer.publicKey.toHexString()}");
+      final balance = await account.balance();
+      print("Balance: ${balance.toBigInt().toDouble() * 1e-18}");
+    }
+  }
+}

--- a/packages/starknet/example/examples/recovery_braavos.dart
+++ b/packages/starknet/example/examples/recovery_braavos.dart
@@ -14,7 +14,11 @@ void main() async {
   while (valid) {
     print("########################");
     final account = Account.fromMnemonic(
-        mnemonic: mnemonic, provider: provider, chainId: chainId, index: index);
+      mnemonic: mnemonic,
+      provider: provider,
+      chainId: chainId,
+      index: index,
+    );
     index += 1;
     valid = await account.isValid;
     if (valid) {

--- a/packages/starknet/lib/src/account.dart
+++ b/packages/starknet/lib/src/account.dart
@@ -1,3 +1,8 @@
+import 'dart:typed_data';
+
+import 'package:bip32/bip32.dart' as bip32;
+import 'package:bip39/bip39.dart' as bip39;
+import 'package:pointycastle/digests/sha256.dart';
 import 'package:starknet/src/presets/udc.g.dart';
 import 'package:starknet/starknet.dart';
 
@@ -161,6 +166,16 @@ class Account {
     return txHash;
   }
 
+  Future<bool> get isValid async {
+    final accountClassHash = (await provider.getClassHashAt(
+            contractAddress: accountAddress, blockId: BlockId.latest))
+        .when(
+      result: (result) => result,
+      error: ((error) => Felt.fromInt(0)),
+    );
+    return accountClassHash != Felt.fromInt(0);
+  }
+
   static Future<DeployAccountTransactionResponse> deployAccount({
     required Signer signer,
     required Provider provider,
@@ -197,6 +212,31 @@ class Account {
       constructorCalldata: constructorCalldata,
     )));
   }
+
+  factory Account.fromMnemonic({
+    required List<String> mnemonic,
+    required Provider provider,
+    required Felt chainId,
+    int index = 0,
+    AccountDerivation? accountDerivation,
+  }) {
+    accountDerivation = accountDerivation ??
+        BraavosAccountDerivation(
+          provider: provider,
+          chainId: chainId,
+        );
+    final signer =
+        accountDerivation.deriveSigner(mnemonic: mnemonic, index: index);
+
+    final accountAddress =
+        accountDerivation.computeAddress(publicKey: signer.publicKey);
+    return Account(
+      accountAddress: accountAddress,
+      provider: provider,
+      signer: signer,
+      chainId: chainId,
+    );
+  }
 }
 
 Account getAccount({
@@ -227,4 +267,78 @@ Felt? getDeployedContractAddress(GetTransactionReceipt txReceipt) {
         return contractAddress;
       },
       error: (e) => throw Exception(e.message));
+}
+
+abstract class AccountDerivation {
+  Signer deriveSigner({required List<String> mnemonic, int index = 0});
+  Felt computeAddress({required Felt publicKey});
+
+  Uint8List grindKey(Uint8List key) {
+    final BigInt keyValLimit = pedersenParams.ecOrder;
+    final BigInt sha256MaxDigest = BigInt.parse(
+        '10000000000000000000000000000000000000000000000000000000000000000',
+        radix: 16);
+
+    final maxAllowed = sha256MaxDigest - (sha256MaxDigest % keyValLimit);
+    int index = 0;
+    key = _hashKeyWithIndex(key, index);
+    index++;
+    while (bytesToBigInt(key) > maxAllowed) {
+      key = _hashKeyWithIndex(key, index);
+      index++;
+    }
+    final result = bytesToBigInt(key) % keyValLimit;
+    return result.toUint8List();
+  }
+
+  Uint8List _hashKeyWithIndex(Uint8List key, int index) {
+    // Uint8List are not growable
+    final data = Uint8List.fromList(key + [index]);
+    return SHA256Digest().process(data);
+  }
+}
+
+class BraavosAccountDerivation extends AccountDerivation {
+  final Provider provider;
+  final Felt chainId;
+  final String pathPrefix = "m/44'/9004'/0'/0";
+
+  // FIXME: hardcoded value for testnet 2023-02-24
+  final classHash = Felt.fromHexString(
+      "0x03131fa018d520a037686ce3efddeab8f28895662f019ca3ca18a626650f7d1e");
+  final implementationAddress = Felt.fromHexString(
+      "0x5aa23d5bb71ddaa783da7ea79d405315bafa7cf0387a74f4593578c3e9e6570");
+  final initializerSelector = Felt.fromHexString(
+      "0x2dd76e7ad84dbed81c314ffe5e7a7cacfb8f4836f01af4e913f275f89a3de1a");
+
+  BraavosAccountDerivation({
+    required this.provider,
+    required this.chainId,
+  });
+
+  @override
+  Signer deriveSigner({required List<String> mnemonic, int index = 0}) {
+    final seed = bip39.mnemonicToSeed(mnemonic.join(" "));
+    final nodeFromSeed = bip32.BIP32.fromSeed(seed);
+    final child = nodeFromSeed.derivePath('$pathPrefix/$index');
+    Uint8List key = child.privateKey!;
+    key = grindKey(key);
+    final privateKey = Felt(bytesToBigInt(key));
+    return Signer(privateKey: privateKey);
+  }
+
+  @override
+  Felt computeAddress({required Felt publicKey}) {
+    final initializeData = [publicKey];
+    final calldata = [
+      implementationAddress,
+      initializerSelector,
+      Felt.fromInt(initializeData.length),
+      ...initializeData,
+    ];
+    final salt = publicKey;
+    final accountAddress = Contract.computeAddress(
+        classHash: classHash, calldata: calldata, salt: salt);
+    return accountAddress;
+  }
 }

--- a/packages/starknet/lib/src/contract/contract.dart
+++ b/packages/starknet/lib/src/contract/contract.dart
@@ -49,7 +49,9 @@ class Contract {
 
   /// Execute contract given [selector] with [calldata]
   Future<InvokeTransactionResponse> execute(
-      String selector, List<Felt> calldata) async {
+    String selector,
+    List<Felt> calldata,
+  ) async {
     final Felt maxFee = defaultMaxFee;
 
     final trx = await account.execute(

--- a/packages/starknet/lib/src/signer.dart
+++ b/packages/starknet/lib/src/signer.dart
@@ -5,6 +5,11 @@ class Signer {
 
   Signer({required this.privateKey});
 
+  Felt get publicKey {
+    final point = generatorPoint * privateKey.toBigInt();
+    return Felt(point!.x!.toBigInteger()!);
+  }
+
   List<Felt> signInvokeTransactionsV1(
       {required List<FunctionCall> transactions,
       required Felt senderAddress,

--- a/packages/starknet/lib/src/types/felt.dart
+++ b/packages/starknet/lib/src/types/felt.dart
@@ -73,12 +73,18 @@ class Felt {
   @override
   int get hashCode => _bigInt.hashCode;
 
-  Uint8List _bigIntToUint8List(BigInt bigInt) =>
-      _bigIntToByteData(bigInt).buffer.asUint8List();
+  /// Interprets felt as a string
+  String toSymbol() {
+    return Utf8Codec().decode(_bigInt.toUint8List());
+  }
+}
 
-  ByteData _bigIntToByteData(BigInt bigInt) {
-    final data = ByteData((bigInt.bitLength / 8).ceil());
-    var val = bigInt;
+extension Starknet on BigInt {
+  Uint8List toUint8List() => toByteData().buffer.asUint8List();
+
+  ByteData toByteData() {
+    final data = ByteData((bitLength / 8).ceil());
+    var val = this;
 
     for (var i = 1; i <= data.lengthInBytes; i++) {
       data.setUint8(data.lengthInBytes - i, val.toUnsigned(8).toInt());
@@ -86,10 +92,5 @@ class Felt {
     }
 
     return data;
-  }
-
-  /// Interprets felt as a string
-  String toSymbol() {
-    return Utf8Codec().decode(_bigIntToUint8List(_bigInt));
   }
 }

--- a/packages/starknet/pubspec.yaml
+++ b/packages/starknet/pubspec.yaml
@@ -7,6 +7,8 @@ environment:
   sdk: ">=2.17.3 <3.0.0"
 
 dependencies:
+  bip32: ^2.0.0
+  bip39: ^1.0.6
   crypto: ^3.0.2
   freezed_annotation: ^2.0.3
   http: ^0.13.4

--- a/packages/starknet/test/account_test.dart
+++ b/packages/starknet/test/account_test.dart
@@ -127,5 +127,43 @@ void main() {
         expect(newBalance, equals(previousBalance));
       });
     });
+
+    group('recovery from seed phrase', () {
+      final mnemonic =
+          "toward antenna indicate reject must artist expect angry fit easy cupboard require"
+              .split(" ");
+      final provider = JsonRpcProvider(nodeUri: devnetUri);
+      final chainId = StarknetChainId.testNet;
+      test('braavos account private key', () async {
+        Signer signer =
+            BraavosAccountDerivation(provider: provider, chainId: chainId)
+                .deriveSigner(mnemonic: mnemonic, index: 0);
+        expect(
+            signer.privateKey,
+            equals(Felt.fromHexString(
+                "0x079474858947854da7c14f19cb5d2edb39414d358a7da68b9436caff9dfb04a6")));
+        signer = BraavosAccountDerivation(provider: provider, chainId: chainId)
+            .deriveSigner(mnemonic: mnemonic, index: 1);
+        expect(
+            signer.privateKey,
+            equals(Felt.fromHexString(
+                "0x06b79a30ac27b1b29a559e84cfe538ea2a35e5460d58558d3d1cd8487a363633")));
+      });
+      test('braavos account public key', () async {
+        Signer signer =
+            BraavosAccountDerivation(provider: provider, chainId: chainId)
+                .deriveSigner(mnemonic: mnemonic, index: 0);
+        expect(
+            signer.publicKey,
+            equals(Felt.fromHexString(
+                "0x04e633f0627b70c55eb53afdfd368c464f5767efe600e36157487bf988a2a106")));
+        signer = BraavosAccountDerivation(provider: provider, chainId: chainId)
+            .deriveSigner(mnemonic: mnemonic, index: 1);
+        expect(
+            signer.publicKey,
+            equals(Felt.fromHexString(
+                "0x01ff0cdadb901570e76dc764dca53101b3c388203e0867243760d90494850d44")));
+      });
+    });
   });
 }

--- a/packages/starknet/test/signer_test.dart
+++ b/packages/starknet/test/signer_test.dart
@@ -1,5 +1,17 @@
+import 'dart:convert';
 import 'package:starknet/starknet.dart';
 import 'package:test/test.dart';
+
+class TestKeyPair {
+  final Felt private;
+  final Felt public;
+
+  TestKeyPair(this.private, this.public);
+
+  TestKeyPair.fromJson(Map<String, dynamic> json)
+      : private = Felt.fromHexString(json['private']),
+        public = Felt.fromHexString(json['public']);
+}
 
 void main() {
   group('Signer', () {
@@ -26,6 +38,56 @@ void main() {
               Felt.fromIntString(
                   "1900499411596333527352644243441454261068804171091393084934334076069283020499")
             ]));
+      });
+    });
+
+    group('Public key', () {
+      test('returns the correct public key for given a private key', () {
+        final keyPairsJson = '''
+[
+  {
+    "public": "0x7e52885445756b313ea16849145363ccb73fb4ab0440dbac333cf9d13de82b9",
+    "private": "0xe3e70682c2094cac629f6fbed82c07cd"
+  }, {
+    "public": "0x175666e92f540a19eb24fa299ce04c23f3b75cb2d2332e3ff2021bf6d615fa5",
+    "private": "0xf728b4fa42485e3a0a5d2f346baa9455"
+  }, {
+    "public": "0x58100ffde2b924de16520921f6bfe13a8bdde9d296a338b9469dd7370ade6cb",
+    "private": "0xeb1167b367a9c3787c65c1e582e2e662"
+  }, {
+    "public": "0xff104dba23c3aec5eb7c74a4605c05ef81a29ac94621c71dd88907f196aa2b",
+    "private": "0xf7c1bd874da5e709d4713d60c8a70639"
+  }, {
+    "public": "0x1f0eea3a599b1eec7e02053a2d9a2712efefc3f61265d4b3166c14ade4152d8",
+    "private": "0xe443df789558867f5ba91faf7a024204"
+  }, {
+    "public": "0x5801376a836c9feb6941157bee10f24d942efa42d6d5e90fef25349c9471816",
+    "private": "0x23a7711a8133287637ebdcd9e87a1613"
+  }, {
+    "public": "0x5a5a41e723be9e339b73a41bd1de92cde8fa4ebf9022ca951a92b0ac95a3c44",
+    "private": "0x1846d424c17c627923c6612f48268673"
+  }, {
+    "public": "0x5f2aa391b1548fa0c5fb216fc7c424328ffb7d1c8e2a1ff614683cc31896ca3",
+    "private": "0xfcbd04c340212ef7cca5a5a19e4d6e3c"
+  }, {
+    "public": "0x2c94f628d125cd0e86eaefea735ba24c262b9a441728f63e5776661829a4066",
+    "private": "0xb4862b21fb97d43588561712e8e5216a"
+  }, {
+    "public": "0xc11e246b1d54515a26204d2d3c8586ea25ed9eecae00df173405974cb86dbc",
+    "private": "0x259f4329e6f4590b9a164106cf6a659e"
+  }, {
+    "public": "0x04e633f0627b70c55eb53afdfd368c464f5767efe600e36157487bf988a2a106",
+    "private": "0x079474858947854da7c14f19cb5d2edb39414d358a7da68b9436caff9dfb04a6"
+  }
+      ]
+''';
+        final keyPairs = List<TestKeyPair>.from(
+            (json.decode(keyPairsJson) as List)
+                .map((e) => TestKeyPair.fromJson(e)));
+        for (var e in keyPairs) {
+          final signer = Signer(privateKey: e.private);
+          expect(signer.publicKey, equals(e.public));
+        }
       });
     });
   }, tags: ['unit']);

--- a/packages/starknet/test/types/felt_test.dart
+++ b/packages/starknet/test/types/felt_test.dart
@@ -1,0 +1,13 @@
+import 'package:starknet/starknet.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Felt', () {
+    test('convert Felt to short string', () {
+      String result = Felt.fromHexString("0x464c5554544552").toSymbol();
+      expect(result, equals("FLUTTER"));
+      result = Felt.fromHexString("0x535441524b4e4554").toSymbol();
+      expect(result, equals("STARKNET"));
+    });
+  });
+}


### PR DESCRIPTION
This PR add support to recover Braavos account from a seed phrase.
Private key derivation is using BIP-44 standard.

Dependencies to [bip32](https://pub.dev/packages/bip32) and [bip39](https://pub.dev/packages/bip39) packages have been added.

**Please note that Braavos implementation address has been hardcoded**

Closes #120 