### PR TITLE
✨ Check if device has biometry available on both iOS & macOS

### DIFF
--- a/packages/starknet_flutter/darwin/Classes/Interface.swift
+++ b/packages/starknet_flutter/darwin/Classes/Interface.swift
@@ -36,6 +36,7 @@ protocol StarknetInterface {
   func storeSecret(key: String, privateKey: FlutterStandardTypedData, completion: @escaping (Result<Void, Error>) -> Void)
   func removeSecret(key: String, completion: @escaping (Result<Void, Error>) -> Void)
   func getSecret(key: String, completion: @escaping (Result<FlutterStandardTypedData, Error>) -> Void)
+  func biometryAvailable() throws -> Bool
 }
 
 /// Generated setup class from Pigeon to handle messages through the `binaryMessenger`.
@@ -94,6 +95,19 @@ class StarknetInterfaceSetup {
       }
     } else {
       getSecretChannel.setMessageHandler(nil)
+    }
+    let biometryAvailableChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.StarknetInterface.biometryAvailable", binaryMessenger: binaryMessenger)
+    if let api = api {
+      biometryAvailableChannel.setMessageHandler { _, reply in
+        do {
+          let result = try api.biometryAvailable()
+          reply(wrapResult(result))
+        } catch {
+          reply(wrapError(error))
+        }
+      }
+    } else {
+      biometryAvailableChannel.setMessageHandler(nil)
     }
   }
 }

--- a/packages/starknet_flutter/darwin/Classes/Utils/AuthenticationUtil.swift
+++ b/packages/starknet_flutter/darwin/Classes/Utils/AuthenticationUtil.swift
@@ -22,4 +22,15 @@ struct AuthenticationUtil {
     sema.wait()
     return success
   }
+  
+  static func biometryAvailable() -> Bool {
+    let context = LAContext()
+    var error: NSError?
+    let biometryAvailable = context.canEvaluatePolicy(
+      .deviceOwnerAuthenticationWithBiometrics,
+      error: &error
+    )
+    
+    return (biometryAvailable && error == nil)
+  }
 }

--- a/packages/starknet_flutter/example/ios/Podfile.lock
+++ b/packages/starknet_flutter/example/ios/Podfile.lock
@@ -1,6 +1,8 @@
 PODS:
   - biometric_storage (0.0.1):
     - Flutter
+  - emoji_picker_flutter (0.0.1):
+    - Flutter
   - Flutter (1.0.0)
   - path_provider_foundation (0.0.1):
     - Flutter
@@ -13,6 +15,7 @@ PODS:
 
 DEPENDENCIES:
   - biometric_storage (from `.symlinks/plugins/biometric_storage/ios`)
+  - emoji_picker_flutter (from `.symlinks/plugins/emoji_picker_flutter/ios`)
   - Flutter (from `Flutter`)
   - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/ios`)
   - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/ios`)
@@ -21,6 +24,8 @@ DEPENDENCIES:
 EXTERNAL SOURCES:
   biometric_storage:
     :path: ".symlinks/plugins/biometric_storage/ios"
+  emoji_picker_flutter:
+    :path: ".symlinks/plugins/emoji_picker_flutter/ios"
   Flutter:
     :path: Flutter
   path_provider_foundation:
@@ -32,6 +37,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   biometric_storage: 1400f1382af3a4cc2bf05340e13c3d8de873ceb9
+  emoji_picker_flutter: df19dac03a2b39ac667dc8d1da939ef3a9e21347
   Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
   path_provider_foundation: c68054786f1b4f3343858c1e1d0caaded73f0be9
   shared_preferences_foundation: 986fc17f3d3251412d18b0265f9c64113a8c2472

--- a/packages/starknet_flutter/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/starknet_flutter/example/ios/Runner.xcodeproj/project.pbxproj
@@ -121,7 +121,6 @@
 				F628833F24FF0F052084F2DB /* Pods-Runner.release.xcconfig */,
 				62D2D49C816CF5494B677961 /* Pods-Runner.profile.xcconfig */,
 			);
-			name = Pods;
 			path = Pods;
 			sourceTree = "<group>";
 		};

--- a/packages/starknet_flutter/example/macos/Podfile.lock
+++ b/packages/starknet_flutter/example/macos/Podfile.lock
@@ -40,7 +40,7 @@ SPEC CHECKSUMS:
   emoji_picker_flutter: 533634326b1c5de9a181ba14b9758e6dfe967a20
   FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
   path_provider_foundation: c68054786f1b4f3343858c1e1d0caaded73f0be9
-  shared_preferences_foundation: 297b3ebca31b34ec92be11acd7fb0ba932c822ca
+  shared_preferences_foundation: 986fc17f3d3251412d18b0265f9c64113a8c2472
   starknet_flutter: d1af7f5538e412c8d89472675f94bafefdca6029
 
 PODFILE CHECKSUM: 353c8bcc5d5b0994e508d035b5431cfe18c1dea7

--- a/packages/starknet_flutter/ios/Classes/StarknetApi.swift
+++ b/packages/starknet_flutter/ios/Classes/StarknetApi.swift
@@ -56,4 +56,8 @@ class StarknetApi : NSObject, StarknetInterface {
       completion(.failure(error))
     }
   }
+  
+  func biometryAvailable() throws -> Bool {
+    return AuthenticationUtil.biometryAvailable()
+  }
 }

--- a/packages/starknet_flutter/lib/pigeon.dart
+++ b/packages/starknet_flutter/lib/pigeon.dart
@@ -88,4 +88,31 @@ class StarknetInterface {
       return (replyList[0] as Uint8List?)!;
     }
   }
+
+  Future<bool> biometryAvailable() async {
+    final BasicMessageChannel<Object?> channel = BasicMessageChannel<Object?>(
+        'dev.flutter.pigeon.StarknetInterface.biometryAvailable', codec,
+        binaryMessenger: _binaryMessenger);
+    final List<Object?>? replyList =
+        await channel.send(null) as List<Object?>?;
+    if (replyList == null) {
+      throw PlatformException(
+        code: 'channel-error',
+        message: 'Unable to establish connection on channel.',
+      );
+    } else if (replyList.length > 1) {
+      throw PlatformException(
+        code: replyList[0]! as String,
+        message: replyList[1] as String?,
+        details: replyList[2],
+      );
+    } else if (replyList[0] == null) {
+      throw PlatformException(
+        code: 'null-error',
+        message: 'Host platform returned null value for non-null return value.',
+      );
+    } else {
+      return (replyList[0] as bool?)!;
+    }
+  }
 }

--- a/packages/starknet_flutter/lib/src/store/secure_store.dart
+++ b/packages/starknet_flutter/lib/src/store/secure_store.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 
 import 'package:biometric_storage/biometric_storage.dart';
 import 'package:flutter/foundation.dart';
+import 'package:starknet_flutter/pigeon.dart';
 import 'package:starknet_flutter/src/store/biometric_store.dart';
 import 'package:starknet_flutter/src/store/password_store.dart';
 import 'package:starknet_flutter/src/store/secure_store_options.dart';
@@ -67,8 +68,7 @@ abstract class SecureStore {
   /// Returns true if the device has biometric capabilities and has them setup.
   static Future<bool> hasBiometricStore() async {
     if (!kIsWeb && (Platform.isIOS || Platform.isMacOS)) {
-      // TODO Using Secure Enclave doesn't mean that we will use biometric authentication for every access
-      return true;
+      return StarknetInterface().biometryAvailable();
     } else {
       final response = await BiometricStorage().canAuthenticate();
       return response == CanAuthenticateResponse.success;

--- a/packages/starknet_flutter/macos/Classes/StarknetApi.swift
+++ b/packages/starknet_flutter/macos/Classes/StarknetApi.swift
@@ -56,4 +56,8 @@ class StarknetApi : NSObject, StarknetInterface {
       completion(.failure(error))
     }
   }
+  
+  func biometryAvailable() throws -> Bool {
+    return AuthenticationUtil.biometryAvailable()
+  }
 }

--- a/packages/starknet_flutter/pigeons/interface.dart
+++ b/packages/starknet_flutter/pigeons/interface.dart
@@ -10,4 +10,6 @@ abstract class StarknetInterface {
 
   @async
   Uint8List getSecret(String key);
+
+  bool biometryAvailable();
 }


### PR DESCRIPTION
This PR add a way to check if the device has a biometry feature (FaceID or TouchID) available.

This is intended to use the Secure Enclave method to store Starknet private key (if biometry available) or fallback to passcode screen if none.