### PR TITLE
starknet: #178: fix 'unsigned' conversion for generated private key

### DIFF
--- a/packages/starknet/lib/src/convert.dart
+++ b/packages/starknet/lib/src/convert.dart
@@ -40,3 +40,7 @@ String bytesToHexString(List<int> bytes) {
 List<BigInt> toBigIntList(List<Felt> feltList) {
   return feltList.map((felt) => felt.toBigInt()).toList();
 }
+
+BigInt bytesToUnsignedInt(Uint8List bytes) {
+  return decodeBigIntWithSign(1, bytes);
+}

--- a/packages/starknet/lib/src/crypto/derivation.dart
+++ b/packages/starknet/lib/src/crypto/derivation.dart
@@ -1,0 +1,50 @@
+import 'dart:typed_data';
+
+import 'package:bip32/bip32.dart' as bip32;
+import 'package:bip39/bip39.dart' as bip39;
+import 'package:pointycastle/digests/sha256.dart';
+
+import '../convert.dart';
+import '../types/felt.dart';
+import 'model/pedersen_params.dart';
+
+/// To ensure that private key is less that [pedersenParams.ecOrder]
+///
+/// See https://community.starknet.io/t/account-keys-and-addresses-derivation-standard/1230
+Uint8List grindKey(Uint8List keySeed) {
+  final BigInt keyValLimit = pedersenParams.ecOrder;
+  final BigInt sha256MaxDigest = BigInt.parse(
+    '10000000000000000000000000000000000000000000000000000000000000000',
+    radix: 16,
+  );
+
+  final maxAllowed = sha256MaxDigest - (sha256MaxDigest % keyValLimit);
+  int index = 0;
+  Uint8List key;
+  do {
+    key = _hashKeyWithIndex(keySeed, index);
+    index++;
+  } while (bytesToUnsignedInt(key) >= maxAllowed);
+  final result = bytesToUnsignedInt(key) % keyValLimit;
+  return result.toUint8List();
+}
+
+Uint8List _hashKeyWithIndex(Uint8List key, int index) {
+  // Uint8List are not growable
+  final data = Uint8List.fromList(key + [index]);
+  return SHA256Digest().process(data);
+}
+
+Felt derivePrivateKey({
+  required List<String> mnemonic,
+  int index = 0,
+  String pathPrefix = "m/44'/9004'/0'/0",
+}) {
+  final seed = bip39.mnemonicToSeed(mnemonic.join(" "));
+  final nodeFromSeed = bip32.BIP32.fromSeed(seed);
+  final child = nodeFromSeed.derivePath('$pathPrefix/$index');
+  Uint8List key = child.privateKey!;
+  key = grindKey(key);
+  final privateKey = Felt(bytesToUnsignedInt(key));
+  return privateKey;
+}

--- a/packages/starknet/lib/src/crypto/index.dart
+++ b/packages/starknet/lib/src/crypto/index.dart
@@ -1,6 +1,7 @@
 import 'package:starknet/starknet.dart';
 
 export 'model/pedersen_params.dart';
+export 'derivation.dart';
 export 'keccak.dart';
 export 'pedersen.dart';
 export 'signature.dart';

--- a/packages/starknet/test/account_test.dart
+++ b/packages/starknet/test/account_test.dart
@@ -1,3 +1,4 @@
+import 'package:starknet/src/crypto/derivation.dart';
 import 'package:starknet/starknet.dart';
 import 'package:test/test.dart';
 
@@ -163,6 +164,26 @@ void main() {
             signer.publicKey,
             equals(Felt.fromHexString(
                 "0x01ff0cdadb901570e76dc764dca53101b3c388203e0867243760d90494850d44")));
+      });
+
+      test('Bug #178 error while computing public key', () async {
+        final mnemonic =
+            "rotate nice pattern oven twice upper defense exile squirrel gym script sight"
+                .split(" ");
+        final Felt privateKey = derivePrivateKey(mnemonic: mnemonic);
+        expect(
+            privateKey,
+            equals(
+              Felt.fromHexString(
+                  "0xe2e4c6ab3d0942add52a707e16c844c1aa78e6c827b2e43070065a498e83bc"),
+            ));
+        final signer = Signer(privateKey: privateKey);
+        expect(
+            signer.publicKey,
+            equals(
+              Felt.fromHexString(
+                  "0x1537768ebeabb7b811c5eeb8e38d8bafc9c957051ff0f311abad2d608f29d53"),
+            ));
       });
     });
   });

--- a/packages/starknet/test/account_test.dart
+++ b/packages/starknet/test/account_test.dart
@@ -1,4 +1,3 @@
-import 'package:starknet/src/crypto/derivation.dart';
 import 'package:starknet/starknet.dart';
 import 'package:test/test.dart';
 


### PR DESCRIPTION
This PR add an 'unsigned' conversion between `Uint8List` and `BigInt` to ensure generated private key from mnemonic are always positive.

Close #178 