### PR TITLE
Fix pending transaction parsing and wait `maxRetries` to ensure transaction is not received

### DIFF
--- a/packages/starknet/lib/src/provider/model/get_transaction_receipt.dart
+++ b/packages/starknet/lib/src/provider/model/get_transaction_receipt.dart
@@ -111,8 +111,10 @@ class TxnReceipt with _$TxnReceipt {
 
   // User arrow func to have freezed generator work properly
   factory TxnReceipt.fromJson(Map<String, Object?> json) =>
-      json['type'] == 'INVOKE'
-          ? InvokeTxnReceipt.fromJson(json)
+      !json.containsKey('status')
+          ? (json.containsKey('contract_address')
+              ? PendingDeployTxnReceipt.fromJson(json)
+              : PendingCommonReceiptProperties.fromJson(json))
           : json['type'] == 'DECLARE'
               ? DeclareTxnReceipt.fromJson(json)
               : json['type'] == 'DEPLOY'
@@ -121,9 +123,7 @@ class TxnReceipt with _$TxnReceipt {
                       ? DeployAccountTxnReceipt.fromJson(json)
                       : json['type'] == 'L1_HANDLER'
                           ? L1HandlerTxnReceipt.fromJson(json)
-                          : json.containsKey('contract_address')
-                              ? PendingDeployTxnReceipt.fromJson(json)
-                              : PendingCommonReceiptProperties.fromJson(json);
+                          : InvokeTxnReceipt.fromJson(json);
 }
 
 // abstract class CommonReceiptProperties {


### PR DESCRIPTION
Closes #188 

`waitForAcceptance` now use a *retry loop* to ensure transaction is not received: there is a delay between transaction sent is known as received by infura node.

Default value for retry is: 60 retries with 5 seconds interval between each query.
