### PR TITLE
Allow running flutter example with devnet

### DIFF
--- a/packages/starknet/build.yaml
+++ b/packages/starknet/build.yaml
@@ -1,6 +1,9 @@
 targets:
   $default:
     builders:
+      freezed:
+        options:
+          union_key: starkNetRuntimeTypeToRemove
       json_serializable:
         options:
           explicit_to_json: true

--- a/packages/starknet/lib/src/contract/model/compiled_contract.dart
+++ b/packages/starknet/lib/src/contract/model/compiled_contract.dart
@@ -413,6 +413,8 @@ abstract class _JsonStringifier {
       writeString("{}");
       return true;
     }
+    // FIXME: workaround for freezed `union_key` present in generated json
+    map.remove("starkNetRuntimeTypeToRemove");
     var keyValueList = List<Object?>.filled(map.length * 2, null);
     var i = 0;
     var allStringKeys = true;

--- a/packages/starknet/lib/src/contract/model/contract_abi.freezed.dart
+++ b/packages/starknet/lib/src/contract/model/contract_abi.freezed.dart
@@ -15,7 +15,7 @@ final _privateConstructorUsedError = UnsupportedError(
     'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
 
 ContractAbiEntry _$ContractAbiEntryFromJson(Map<String, dynamic> json) {
-  switch (json['runtimeType']) {
+  switch (json['starkNetRuntimeTypeToRemove']) {
     case 'function':
       return FunctionAbiEntry.fromJson(json);
     case 'event':
@@ -26,8 +26,11 @@ ContractAbiEntry _$ContractAbiEntryFromJson(Map<String, dynamic> json) {
       return ConstructorAbiEntry.fromJson(json);
 
     default:
-      throw CheckedFromJsonException(json, 'runtimeType', 'ContractAbiEntry',
-          'Invalid union type "${json['runtimeType']}"!');
+      throw CheckedFromJsonException(
+          json,
+          'starkNetRuntimeTypeToRemove',
+          'ContractAbiEntry',
+          'Invalid union type "${json['starkNetRuntimeTypeToRemove']}"!');
   }
 }
 
@@ -269,7 +272,7 @@ class _$FunctionAbiEntry implements FunctionAbiEntry {
   @JsonKey(name: 'stateMutability', includeIfNull: false)
   final String? stateMutability;
 
-  @JsonKey(name: 'runtimeType')
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
   final String $type;
 
   @override
@@ -541,7 +544,7 @@ class _$EventAbiEntry implements EventAbiEntry {
     return EqualUnmodifiableListView(_data);
   }
 
-  @JsonKey(name: 'runtimeType')
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
   final String $type;
 
   @override
@@ -795,7 +798,7 @@ class _$StructAbiEntry implements StructAbiEntry {
     return EqualUnmodifiableListView(_members);
   }
 
-  @JsonKey(name: 'runtimeType')
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
   final String $type;
 
   @override
@@ -1056,7 +1059,7 @@ class _$ConstructorAbiEntry implements ConstructorAbiEntry {
     return EqualUnmodifiableListView(_outputs);
   }
 
-  @JsonKey(name: 'runtimeType')
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
   final String $type;
 
   @override

--- a/packages/starknet/lib/src/contract/model/contract_abi.g.dart
+++ b/packages/starknet/lib/src/contract/model/contract_abi.g.dart
@@ -17,7 +17,7 @@ _$FunctionAbiEntry _$$FunctionAbiEntryFromJson(Map<String, dynamic> json) =>
           .map((e) => TypedParameter.fromJson(e as Map<String, dynamic>))
           .toList(),
       stateMutability: json['stateMutability'] as String?,
-      $type: json['runtimeType'] as String?,
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
     );
 
 Map<String, dynamic> _$$FunctionAbiEntryToJson(_$FunctionAbiEntry instance) {
@@ -35,7 +35,7 @@ Map<String, dynamic> _$$FunctionAbiEntryToJson(_$FunctionAbiEntry instance) {
   }
 
   writeNotNull('stateMutability', instance.stateMutability);
-  val['runtimeType'] = instance.$type;
+  val['starkNetRuntimeTypeToRemove'] = instance.$type;
   return val;
 }
 
@@ -49,7 +49,7 @@ _$EventAbiEntry _$$EventAbiEntryFromJson(Map<String, dynamic> json) =>
       data: (json['data'] as List<dynamic>)
           .map((e) => TypedParameter.fromJson(e as Map<String, dynamic>))
           .toList(),
-      $type: json['runtimeType'] as String?,
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
     );
 
 Map<String, dynamic> _$$EventAbiEntryToJson(_$EventAbiEntry instance) =>
@@ -58,7 +58,7 @@ Map<String, dynamic> _$$EventAbiEntryToJson(_$EventAbiEntry instance) =>
       'name': instance.name,
       'keys': instance.keys.map((e) => e.toJson()).toList(),
       'data': instance.data.map((e) => e.toJson()).toList(),
-      'runtimeType': instance.$type,
+      'starkNetRuntimeTypeToRemove': instance.$type,
     };
 
 _$StructAbiEntry _$$StructAbiEntryFromJson(Map<String, dynamic> json) =>
@@ -69,7 +69,7 @@ _$StructAbiEntry _$$StructAbiEntryFromJson(Map<String, dynamic> json) =>
       members: (json['members'] as List<dynamic>)
           .map((e) => StructMember.fromJson(e as Map<String, dynamic>))
           .toList(),
-      $type: json['runtimeType'] as String?,
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
     );
 
 Map<String, dynamic> _$$StructAbiEntryToJson(_$StructAbiEntry instance) =>
@@ -78,7 +78,7 @@ Map<String, dynamic> _$$StructAbiEntryToJson(_$StructAbiEntry instance) =>
       'name': instance.name,
       'size': instance.size,
       'members': instance.members.map((e) => e.toJson()).toList(),
-      'runtimeType': instance.$type,
+      'starkNetRuntimeTypeToRemove': instance.$type,
     };
 
 _$ConstructorAbiEntry _$$ConstructorAbiEntryFromJson(
@@ -92,7 +92,7 @@ _$ConstructorAbiEntry _$$ConstructorAbiEntryFromJson(
       outputs: (json['outputs'] as List<dynamic>)
           .map((e) => TypedParameter.fromJson(e as Map<String, dynamic>))
           .toList(),
-      $type: json['runtimeType'] as String?,
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
     );
 
 Map<String, dynamic> _$$ConstructorAbiEntryToJson(
@@ -102,7 +102,7 @@ Map<String, dynamic> _$$ConstructorAbiEntryToJson(
       'name': instance.name,
       'inputs': instance.inputs.map((e) => e.toJson()).toList(),
       'outputs': instance.outputs.map((e) => e.toJson()).toList(),
-      'runtimeType': instance.$type,
+      'starkNetRuntimeTypeToRemove': instance.$type,
     };
 
 _$_TypedParameter _$$_TypedParameterFromJson(Map<String, dynamic> json) =>

--- a/packages/starknet/lib/src/provider/call_rpc_endpoint.dart
+++ b/packages/starknet/lib/src/provider/call_rpc_endpoint.dart
@@ -1,6 +1,8 @@
 import 'dart:convert';
 import 'package:http/http.dart' as http;
 
+import '../contract/model/compiled_contract.dart';
+
 Future<Map<String, dynamic>> callRpcEndpoint(
     {required Uri nodeUri, required String method, Object? params}) async {
   const headers = {
@@ -14,8 +16,9 @@ Future<Map<String, dynamic>> callRpcEndpoint(
     'id': 0
   };
 
+  final filteredBody = CompiledContractJsonEncoder().convert(body);
   final response =
-      await http.post(nodeUri, headers: headers, body: json.encode(body));
+      await http.post(nodeUri, headers: headers, body: filteredBody);
 
   final jsonResponse = json.decode(response.body);
 

--- a/packages/starknet/lib/src/provider/model/block_hash_and_number.freezed.dart
+++ b/packages/starknet/lib/src/provider/model/block_hash_and_number.freezed.dart
@@ -15,15 +15,18 @@ final _privateConstructorUsedError = UnsupportedError(
     'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
 
 BlockHashAndNumber _$BlockHashAndNumberFromJson(Map<String, dynamic> json) {
-  switch (json['runtimeType']) {
+  switch (json['starkNetRuntimeTypeToRemove']) {
     case 'result':
       return BlockHashAndNumberResult.fromJson(json);
     case 'error':
       return BlockHashAndNumberError.fromJson(json);
 
     default:
-      throw CheckedFromJsonException(json, 'runtimeType', 'BlockHashAndNumber',
-          'Invalid union type "${json['runtimeType']}"!');
+      throw CheckedFromJsonException(
+          json,
+          'starkNetRuntimeTypeToRemove',
+          'BlockHashAndNumber',
+          'Invalid union type "${json['starkNetRuntimeTypeToRemove']}"!');
   }
 }
 
@@ -142,7 +145,7 @@ class _$BlockHashAndNumberResult implements BlockHashAndNumberResult {
   @override
   final BlockHashAndNumberResponseResult result;
 
-  @JsonKey(name: 'runtimeType')
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
   final String $type;
 
   @override
@@ -307,7 +310,7 @@ class _$BlockHashAndNumberError implements BlockHashAndNumberError {
   @override
   final JsonRpcApiError error;
 
-  @JsonKey(name: 'runtimeType')
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
   final String $type;
 
   @override

--- a/packages/starknet/lib/src/provider/model/block_hash_and_number.g.dart
+++ b/packages/starknet/lib/src/provider/model/block_hash_and_number.g.dart
@@ -11,28 +11,28 @@ _$BlockHashAndNumberResult _$$BlockHashAndNumberResultFromJson(
     _$BlockHashAndNumberResult(
       result: BlockHashAndNumberResponseResult.fromJson(
           json['result'] as Map<String, dynamic>),
-      $type: json['runtimeType'] as String?,
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
     );
 
 Map<String, dynamic> _$$BlockHashAndNumberResultToJson(
         _$BlockHashAndNumberResult instance) =>
     <String, dynamic>{
       'result': instance.result.toJson(),
-      'runtimeType': instance.$type,
+      'starkNetRuntimeTypeToRemove': instance.$type,
     };
 
 _$BlockHashAndNumberError _$$BlockHashAndNumberErrorFromJson(
         Map<String, dynamic> json) =>
     _$BlockHashAndNumberError(
       error: JsonRpcApiError.fromJson(json['error'] as Map<String, dynamic>),
-      $type: json['runtimeType'] as String?,
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
     );
 
 Map<String, dynamic> _$$BlockHashAndNumberErrorToJson(
         _$BlockHashAndNumberError instance) =>
     <String, dynamic>{
       'error': instance.error.toJson(),
-      'runtimeType': instance.$type,
+      'starkNetRuntimeTypeToRemove': instance.$type,
     };
 
 _$_BlockHashAndNumberResponseResult

--- a/packages/starknet/lib/src/provider/model/block_id.freezed.dart
+++ b/packages/starknet/lib/src/provider/model/block_id.freezed.dart
@@ -15,7 +15,7 @@ final _privateConstructorUsedError = UnsupportedError(
     'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
 
 BlockId _$BlockIdFromJson(Map<String, dynamic> json) {
-  switch (json['runtimeType']) {
+  switch (json['starkNetRuntimeTypeToRemove']) {
     case 'blockHash':
       return BlockIdHash.fromJson(json);
     case 'blockNumber':
@@ -24,8 +24,11 @@ BlockId _$BlockIdFromJson(Map<String, dynamic> json) {
       return BlockIdTag.fromJson(json);
 
     default:
-      throw CheckedFromJsonException(json, 'runtimeType', 'BlockId',
-          'Invalid union type "${json['runtimeType']}"!');
+      throw CheckedFromJsonException(
+          json,
+          'starkNetRuntimeTypeToRemove',
+          'BlockId',
+          'Invalid union type "${json['starkNetRuntimeTypeToRemove']}"!');
   }
 }
 
@@ -138,7 +141,7 @@ class _$BlockIdHash extends BlockIdHash {
   @override
   final Felt blockHash;
 
-  @JsonKey(name: 'runtimeType')
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
   final String $type;
 
   @override
@@ -291,7 +294,7 @@ class _$BlockIdNumber extends BlockIdNumber {
   @override
   final int blockNumber;
 
-  @JsonKey(name: 'runtimeType')
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
   final String $type;
 
   @override
@@ -444,7 +447,7 @@ class _$BlockIdTag extends BlockIdTag {
   @override
   final String blockTag;
 
-  @JsonKey(name: 'runtimeType')
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
   final String $type;
 
   @override

--- a/packages/starknet/lib/src/provider/model/block_id.g.dart
+++ b/packages/starknet/lib/src/provider/model/block_id.g.dart
@@ -9,16 +9,16 @@ part of 'block_id.dart';
 _$BlockIdHash _$$BlockIdHashFromJson(Map<String, dynamic> json) =>
     _$BlockIdHash(
       Felt.fromJson(json['block_hash'] as String),
-      $type: json['runtimeType'] as String?,
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
     );
 
 _$BlockIdNumber _$$BlockIdNumberFromJson(Map<String, dynamic> json) =>
     _$BlockIdNumber(
       json['block_number'] as int,
-      $type: json['runtimeType'] as String?,
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
     );
 
 _$BlockIdTag _$$BlockIdTagFromJson(Map<String, dynamic> json) => _$BlockIdTag(
       json['block_tag'] as String,
-      $type: json['runtimeType'] as String?,
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
     );

--- a/packages/starknet/lib/src/provider/model/block_number.freezed.dart
+++ b/packages/starknet/lib/src/provider/model/block_number.freezed.dart
@@ -15,15 +15,18 @@ final _privateConstructorUsedError = UnsupportedError(
     'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
 
 BlockNumber _$BlockNumberFromJson(Map<String, dynamic> json) {
-  switch (json['runtimeType']) {
+  switch (json['starkNetRuntimeTypeToRemove']) {
     case 'result':
       return BlockNumberResult.fromJson(json);
     case 'error':
       return BlockNumberError.fromJson(json);
 
     default:
-      throw CheckedFromJsonException(json, 'runtimeType', 'BlockNumber',
-          'Invalid union type "${json['runtimeType']}"!');
+      throw CheckedFromJsonException(
+          json,
+          'starkNetRuntimeTypeToRemove',
+          'BlockNumber',
+          'Invalid union type "${json['starkNetRuntimeTypeToRemove']}"!');
   }
 }
 
@@ -131,7 +134,7 @@ class _$BlockNumberResult implements BlockNumberResult {
   @override
   final int result;
 
-  @JsonKey(name: 'runtimeType')
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
   final String $type;
 
   @override
@@ -293,7 +296,7 @@ class _$BlockNumberError implements BlockNumberError {
   @override
   final JsonRpcApiError error;
 
-  @JsonKey(name: 'runtimeType')
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
   final String $type;
 
   @override

--- a/packages/starknet/lib/src/provider/model/block_number.g.dart
+++ b/packages/starknet/lib/src/provider/model/block_number.g.dart
@@ -9,23 +9,23 @@ part of 'block_number.dart';
 _$BlockNumberResult _$$BlockNumberResultFromJson(Map<String, dynamic> json) =>
     _$BlockNumberResult(
       result: json['result'] as int,
-      $type: json['runtimeType'] as String?,
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
     );
 
 Map<String, dynamic> _$$BlockNumberResultToJson(_$BlockNumberResult instance) =>
     <String, dynamic>{
       'result': instance.result,
-      'runtimeType': instance.$type,
+      'starkNetRuntimeTypeToRemove': instance.$type,
     };
 
 _$BlockNumberError _$$BlockNumberErrorFromJson(Map<String, dynamic> json) =>
     _$BlockNumberError(
       error: JsonRpcApiError.fromJson(json['error'] as Map<String, dynamic>),
-      $type: json['runtimeType'] as String?,
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
     );
 
 Map<String, dynamic> _$$BlockNumberErrorToJson(_$BlockNumberError instance) =>
     <String, dynamic>{
       'error': instance.error.toJson(),
-      'runtimeType': instance.$type,
+      'starkNetRuntimeTypeToRemove': instance.$type,
     };

--- a/packages/starknet/lib/src/provider/model/call.freezed.dart
+++ b/packages/starknet/lib/src/provider/model/call.freezed.dart
@@ -15,15 +15,18 @@ final _privateConstructorUsedError = UnsupportedError(
     'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
 
 Call _$CallFromJson(Map<String, dynamic> json) {
-  switch (json['runtimeType']) {
+  switch (json['starkNetRuntimeTypeToRemove']) {
     case 'result':
       return CallResult.fromJson(json);
     case 'error':
       return CallError.fromJson(json);
 
     default:
-      throw CheckedFromJsonException(json, 'runtimeType', 'Call',
-          'Invalid union type "${json['runtimeType']}"!');
+      throw CheckedFromJsonException(
+          json,
+          'starkNetRuntimeTypeToRemove',
+          'Call',
+          'Invalid union type "${json['starkNetRuntimeTypeToRemove']}"!');
   }
 }
 
@@ -136,7 +139,7 @@ class _$CallResult implements CallResult {
     return EqualUnmodifiableListView(_result);
   }
 
-  @JsonKey(name: 'runtimeType')
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
   final String $type;
 
   @override
@@ -298,7 +301,7 @@ class _$CallError implements CallError {
   @override
   final JsonRpcApiError error;
 
-  @JsonKey(name: 'runtimeType')
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
   final String $type;
 
   @override

--- a/packages/starknet/lib/src/provider/model/call.g.dart
+++ b/packages/starknet/lib/src/provider/model/call.g.dart
@@ -10,22 +10,22 @@ _$CallResult _$$CallResultFromJson(Map<String, dynamic> json) => _$CallResult(
       result: (json['result'] as List<dynamic>)
           .map((e) => Felt.fromJson(e as String))
           .toList(),
-      $type: json['runtimeType'] as String?,
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
     );
 
 Map<String, dynamic> _$$CallResultToJson(_$CallResult instance) =>
     <String, dynamic>{
       'result': instance.result.map((e) => e.toJson()).toList(),
-      'runtimeType': instance.$type,
+      'starkNetRuntimeTypeToRemove': instance.$type,
     };
 
 _$CallError _$$CallErrorFromJson(Map<String, dynamic> json) => _$CallError(
       error: JsonRpcApiError.fromJson(json['error'] as Map<String, dynamic>),
-      $type: json['runtimeType'] as String?,
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
     );
 
 Map<String, dynamic> _$$CallErrorToJson(_$CallError instance) =>
     <String, dynamic>{
       'error': instance.error.toJson(),
-      'runtimeType': instance.$type,
+      'starkNetRuntimeTypeToRemove': instance.$type,
     };

--- a/packages/starknet/lib/src/provider/model/chain_id.freezed.dart
+++ b/packages/starknet/lib/src/provider/model/chain_id.freezed.dart
@@ -15,15 +15,18 @@ final _privateConstructorUsedError = UnsupportedError(
     'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
 
 ChainId _$ChainIdFromJson(Map<String, dynamic> json) {
-  switch (json['runtimeType']) {
+  switch (json['starkNetRuntimeTypeToRemove']) {
     case 'result':
       return ChainIdResult.fromJson(json);
     case 'error':
       return ChainIdError.fromJson(json);
 
     default:
-      throw CheckedFromJsonException(json, 'runtimeType', 'ChainId',
-          'Invalid union type "${json['runtimeType']}"!');
+      throw CheckedFromJsonException(
+          json,
+          'starkNetRuntimeTypeToRemove',
+          'ChainId',
+          'Invalid union type "${json['starkNetRuntimeTypeToRemove']}"!');
   }
 }
 
@@ -130,7 +133,7 @@ class _$ChainIdResult implements ChainIdResult {
   @override
   final String result;
 
-  @JsonKey(name: 'runtimeType')
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
   final String $type;
 
   @override
@@ -291,7 +294,7 @@ class _$ChainIdError implements ChainIdError {
   @override
   final JsonRpcApiError error;
 
-  @JsonKey(name: 'runtimeType')
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
   final String $type;
 
   @override

--- a/packages/starknet/lib/src/provider/model/chain_id.g.dart
+++ b/packages/starknet/lib/src/provider/model/chain_id.g.dart
@@ -9,23 +9,23 @@ part of 'chain_id.dart';
 _$ChainIdResult _$$ChainIdResultFromJson(Map<String, dynamic> json) =>
     _$ChainIdResult(
       result: json['result'] as String,
-      $type: json['runtimeType'] as String?,
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
     );
 
 Map<String, dynamic> _$$ChainIdResultToJson(_$ChainIdResult instance) =>
     <String, dynamic>{
       'result': instance.result,
-      'runtimeType': instance.$type,
+      'starkNetRuntimeTypeToRemove': instance.$type,
     };
 
 _$ChainIdError _$$ChainIdErrorFromJson(Map<String, dynamic> json) =>
     _$ChainIdError(
       error: JsonRpcApiError.fromJson(json['error'] as Map<String, dynamic>),
-      $type: json['runtimeType'] as String?,
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
     );
 
 Map<String, dynamic> _$$ChainIdErrorToJson(_$ChainIdError instance) =>
     <String, dynamic>{
       'error': instance.error.toJson(),
-      'runtimeType': instance.$type,
+      'starkNetRuntimeTypeToRemove': instance.$type,
     };

--- a/packages/starknet/lib/src/provider/model/declare_transaction.freezed.dart
+++ b/packages/starknet/lib/src/provider/model/declare_transaction.freezed.dart
@@ -470,7 +470,7 @@ abstract class _DeclareTransaction implements DeclareTransaction {
 
 DeclareTransactionResponse _$DeclareTransactionResponseFromJson(
     Map<String, dynamic> json) {
-  switch (json['runtimeType']) {
+  switch (json['starkNetRuntimeTypeToRemove']) {
     case 'result':
       return DeclareTransactionResult.fromJson(json);
     case 'error':
@@ -479,9 +479,9 @@ DeclareTransactionResponse _$DeclareTransactionResponseFromJson(
     default:
       throw CheckedFromJsonException(
           json,
-          'runtimeType',
+          'starkNetRuntimeTypeToRemove',
           'DeclareTransactionResponse',
-          'Invalid union type "${json['runtimeType']}"!');
+          'Invalid union type "${json['starkNetRuntimeTypeToRemove']}"!');
   }
 }
 
@@ -603,7 +603,7 @@ class _$DeclareTransactionResult implements DeclareTransactionResult {
   @override
   final DeclareTransactionResponseResult result;
 
-  @JsonKey(name: 'runtimeType')
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
   final String $type;
 
   @override
@@ -769,7 +769,7 @@ class _$DeclareTransactionError implements DeclareTransactionError {
   @override
   final JsonRpcApiError error;
 
-  @JsonKey(name: 'runtimeType')
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
   final String $type;
 
   @override

--- a/packages/starknet/lib/src/provider/model/declare_transaction.g.dart
+++ b/packages/starknet/lib/src/provider/model/declare_transaction.g.dart
@@ -51,28 +51,28 @@ _$DeclareTransactionResult _$$DeclareTransactionResultFromJson(
     _$DeclareTransactionResult(
       result: DeclareTransactionResponseResult.fromJson(
           json['result'] as Map<String, dynamic>),
-      $type: json['runtimeType'] as String?,
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
     );
 
 Map<String, dynamic> _$$DeclareTransactionResultToJson(
         _$DeclareTransactionResult instance) =>
     <String, dynamic>{
       'result': instance.result.toJson(),
-      'runtimeType': instance.$type,
+      'starkNetRuntimeTypeToRemove': instance.$type,
     };
 
 _$DeclareTransactionError _$$DeclareTransactionErrorFromJson(
         Map<String, dynamic> json) =>
     _$DeclareTransactionError(
       error: JsonRpcApiError.fromJson(json['error'] as Map<String, dynamic>),
-      $type: json['runtimeType'] as String?,
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
     );
 
 Map<String, dynamic> _$$DeclareTransactionErrorToJson(
         _$DeclareTransactionError instance) =>
     <String, dynamic>{
       'error': instance.error.toJson(),
-      'runtimeType': instance.$type,
+      'starkNetRuntimeTypeToRemove': instance.$type,
     };
 
 _$_DeclareTransactionResponseResult

--- a/packages/starknet/lib/src/provider/model/deploy_account_transaction.freezed.dart
+++ b/packages/starknet/lib/src/provider/model/deploy_account_transaction.freezed.dart
@@ -489,7 +489,7 @@ abstract class _DeployAccountTransactionRequest
 
 DeployAccountTransactionResponse _$DeployAccountTransactionResponseFromJson(
     Map<String, dynamic> json) {
-  switch (json['runtimeType']) {
+  switch (json['starkNetRuntimeTypeToRemove']) {
     case 'result':
       return DeployAccountTransactionResult.fromJson(json);
     case 'error':
@@ -498,9 +498,9 @@ DeployAccountTransactionResponse _$DeployAccountTransactionResponseFromJson(
     default:
       throw CheckedFromJsonException(
           json,
-          'runtimeType',
+          'starkNetRuntimeTypeToRemove',
           'DeployAccountTransactionResponse',
-          'Invalid union type "${json['runtimeType']}"!');
+          'Invalid union type "${json['starkNetRuntimeTypeToRemove']}"!');
   }
 }
 
@@ -629,7 +629,7 @@ class _$DeployAccountTransactionResult
   @override
   final DeployAccountTransactionResponseResult result;
 
-  @JsonKey(name: 'runtimeType')
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
   final String $type;
 
   @override
@@ -799,7 +799,7 @@ class _$DeployAccountTransactionError implements DeployAccountTransactionError {
   @override
   final JsonRpcApiError error;
 
-  @JsonKey(name: 'runtimeType')
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
   final String $type;
 
   @override

--- a/packages/starknet/lib/src/provider/model/deploy_account_transaction.g.dart
+++ b/packages/starknet/lib/src/provider/model/deploy_account_transaction.g.dart
@@ -56,28 +56,28 @@ _$DeployAccountTransactionResult _$$DeployAccountTransactionResultFromJson(
     _$DeployAccountTransactionResult(
       result: DeployAccountTransactionResponseResult.fromJson(
           json['result'] as Map<String, dynamic>),
-      $type: json['runtimeType'] as String?,
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
     );
 
 Map<String, dynamic> _$$DeployAccountTransactionResultToJson(
         _$DeployAccountTransactionResult instance) =>
     <String, dynamic>{
       'result': instance.result.toJson(),
-      'runtimeType': instance.$type,
+      'starkNetRuntimeTypeToRemove': instance.$type,
     };
 
 _$DeployAccountTransactionError _$$DeployAccountTransactionErrorFromJson(
         Map<String, dynamic> json) =>
     _$DeployAccountTransactionError(
       error: JsonRpcApiError.fromJson(json['error'] as Map<String, dynamic>),
-      $type: json['runtimeType'] as String?,
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
     );
 
 Map<String, dynamic> _$$DeployAccountTransactionErrorToJson(
         _$DeployAccountTransactionError instance) =>
     <String, dynamic>{
       'error': instance.error.toJson(),
-      'runtimeType': instance.$type,
+      'starkNetRuntimeTypeToRemove': instance.$type,
     };
 
 _$_DeployAccountTransactionResponseResult

--- a/packages/starknet/lib/src/provider/model/estimate_fee.freezed.dart
+++ b/packages/starknet/lib/src/provider/model/estimate_fee.freezed.dart
@@ -15,15 +15,18 @@ final _privateConstructorUsedError = UnsupportedError(
     'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
 
 EstimateFee _$EstimateFeeFromJson(Map<String, dynamic> json) {
-  switch (json['runtimeType']) {
+  switch (json['starkNetRuntimeTypeToRemove']) {
     case 'result':
       return EstimateFeeResult.fromJson(json);
     case 'error':
       return EstimateFeeError.fromJson(json);
 
     default:
-      throw CheckedFromJsonException(json, 'runtimeType', 'EstimateFee',
-          'Invalid union type "${json['runtimeType']}"!');
+      throw CheckedFromJsonException(
+          json,
+          'starkNetRuntimeTypeToRemove',
+          'EstimateFee',
+          'Invalid union type "${json['starkNetRuntimeTypeToRemove']}"!');
   }
 }
 
@@ -141,7 +144,7 @@ class _$EstimateFeeResult implements EstimateFeeResult {
   @override
   final FeeEstimate result;
 
-  @JsonKey(name: 'runtimeType')
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
   final String $type;
 
   @override
@@ -303,7 +306,7 @@ class _$EstimateFeeError implements EstimateFeeError {
   @override
   final JsonRpcApiError error;
 
-  @JsonKey(name: 'runtimeType')
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
   final String $type;
 
   @override
@@ -413,7 +416,7 @@ abstract class EstimateFeeError implements EstimateFee {
 }
 
 BroadcastedTxn _$BroadcastedTxnFromJson(Map<String, dynamic> json) {
-  switch (json['runtimeType']) {
+  switch (json['starkNetRuntimeTypeToRemove']) {
     case 'broadcastedInvokeTxnV0':
       return BroadcastedInvokeTxnV0.fromJson(json);
     case 'broadcastedInvokeTxnV1':
@@ -426,8 +429,11 @@ BroadcastedTxn _$BroadcastedTxnFromJson(Map<String, dynamic> json) {
       return BroadcastedDeployAccountTxn.fromJson(json);
 
     default:
-      throw CheckedFromJsonException(json, 'runtimeType', 'BroadcastedTxn',
-          'Invalid union type "${json['runtimeType']}"!');
+      throw CheckedFromJsonException(
+          json,
+          'starkNetRuntimeTypeToRemove',
+          'BroadcastedTxn',
+          'Invalid union type "${json['starkNetRuntimeTypeToRemove']}"!');
   }
 }
 
@@ -782,7 +788,7 @@ class _$BroadcastedInvokeTxnV0 implements BroadcastedInvokeTxnV0 {
     return EqualUnmodifiableListView(_calldata);
   }
 
-  @JsonKey(name: 'runtimeType')
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
   final String $type;
 
   @override
@@ -1187,7 +1193,7 @@ class _$BroadcastedInvokeTxnV1 implements BroadcastedInvokeTxnV1 {
     return EqualUnmodifiableListView(_calldata);
   }
 
-  @JsonKey(name: 'runtimeType')
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
   final String $type;
 
   @override
@@ -1590,7 +1596,7 @@ class _$BroadcastedDeclareTxn implements BroadcastedDeclareTxn {
   @override
   final Felt senderAddress;
 
-  @JsonKey(name: 'runtimeType')
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
   final String $type;
 
   @override
@@ -1974,7 +1980,7 @@ class _$BroadcastedDeployTxn implements BroadcastedDeployTxn {
     return EqualUnmodifiableListView(_constructorCalldata);
   }
 
-  @JsonKey(name: 'runtimeType')
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
   final String $type;
 
   @override
@@ -2377,7 +2383,7 @@ class _$BroadcastedDeployAccountTxn implements BroadcastedDeployAccountTxn {
   @override
   final Felt nonce;
 
-  @JsonKey(name: 'runtimeType')
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
   final String $type;
 
   @override

--- a/packages/starknet/lib/src/provider/model/estimate_fee.g.dart
+++ b/packages/starknet/lib/src/provider/model/estimate_fee.g.dart
@@ -9,25 +9,25 @@ part of 'estimate_fee.dart';
 _$EstimateFeeResult _$$EstimateFeeResultFromJson(Map<String, dynamic> json) =>
     _$EstimateFeeResult(
       result: FeeEstimate.fromJson(json['result'] as Map<String, dynamic>),
-      $type: json['runtimeType'] as String?,
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
     );
 
 Map<String, dynamic> _$$EstimateFeeResultToJson(_$EstimateFeeResult instance) =>
     <String, dynamic>{
       'result': instance.result.toJson(),
-      'runtimeType': instance.$type,
+      'starkNetRuntimeTypeToRemove': instance.$type,
     };
 
 _$EstimateFeeError _$$EstimateFeeErrorFromJson(Map<String, dynamic> json) =>
     _$EstimateFeeError(
       error: JsonRpcApiError.fromJson(json['error'] as Map<String, dynamic>),
-      $type: json['runtimeType'] as String?,
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
     );
 
 Map<String, dynamic> _$$EstimateFeeErrorToJson(_$EstimateFeeError instance) =>
     <String, dynamic>{
       'error': instance.error.toJson(),
-      'runtimeType': instance.$type,
+      'starkNetRuntimeTypeToRemove': instance.$type,
     };
 
 _$BroadcastedInvokeTxnV0 _$$BroadcastedInvokeTxnV0FromJson(
@@ -46,7 +46,7 @@ _$BroadcastedInvokeTxnV0 _$$BroadcastedInvokeTxnV0FromJson(
       calldata: (json['calldata'] as List<dynamic>)
           .map((e) => Felt.fromJson(e as String))
           .toList(),
-      $type: json['runtimeType'] as String?,
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
     );
 
 Map<String, dynamic> _$$BroadcastedInvokeTxnV0ToJson(
@@ -68,7 +68,7 @@ Map<String, dynamic> _$$BroadcastedInvokeTxnV0ToJson(
   val['contract_address'] = instance.contractAddress.toJson();
   val['entry_point_selector'] = instance.entryPointSelector.toJson();
   val['calldata'] = instance.calldata.map((e) => e.toJson()).toList();
-  val['runtimeType'] = instance.$type;
+  val['starkNetRuntimeTypeToRemove'] = instance.$type;
   return val;
 }
 
@@ -86,7 +86,7 @@ _$BroadcastedInvokeTxnV1 _$$BroadcastedInvokeTxnV1FromJson(
       calldata: (json['calldata'] as List<dynamic>)
           .map((e) => Felt.fromJson(e as String))
           .toList(),
-      $type: json['runtimeType'] as String?,
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
     );
 
 Map<String, dynamic> _$$BroadcastedInvokeTxnV1ToJson(
@@ -99,7 +99,7 @@ Map<String, dynamic> _$$BroadcastedInvokeTxnV1ToJson(
       'nonce': instance.nonce.toJson(),
       'sender_address': instance.senderAddress.toJson(),
       'calldata': instance.calldata.map((e) => e.toJson()).toList(),
-      'runtimeType': instance.$type,
+      'starkNetRuntimeTypeToRemove': instance.$type,
     };
 
 _$BroadcastedDeclareTxn _$$BroadcastedDeclareTxnFromJson(
@@ -115,7 +115,7 @@ _$BroadcastedDeclareTxn _$$BroadcastedDeclareTxnFromJson(
       contractClass: ContractClass.fromJson(
           json['contract_class'] as Map<String, dynamic>),
       senderAddress: Felt.fromJson(json['sender_address'] as String),
-      $type: json['runtimeType'] as String?,
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
     );
 
 Map<String, dynamic> _$$BroadcastedDeclareTxnToJson(
@@ -128,7 +128,7 @@ Map<String, dynamic> _$$BroadcastedDeclareTxnToJson(
       'nonce': instance.nonce.toJson(),
       'contract_class': instance.contractClass.toJson(),
       'sender_address': instance.senderAddress.toJson(),
-      'runtimeType': instance.$type,
+      'starkNetRuntimeTypeToRemove': instance.$type,
     };
 
 _$BroadcastedDeployTxn _$$BroadcastedDeployTxnFromJson(
@@ -143,7 +143,7 @@ _$BroadcastedDeployTxn _$$BroadcastedDeployTxnFromJson(
       constructorCalldata: (json['constructor_calldata'] as List<dynamic>)
           .map((e) => Felt.fromJson(e as String))
           .toList(),
-      $type: json['runtimeType'] as String?,
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
     );
 
 Map<String, dynamic> _$$BroadcastedDeployTxnToJson(
@@ -155,7 +155,7 @@ Map<String, dynamic> _$$BroadcastedDeployTxnToJson(
       'contract_address_salt': instance.contractAddressSalt.toJson(),
       'constructor_calldata':
           instance.constructorCalldata.map((e) => e.toJson()).toList(),
-      'runtimeType': instance.$type,
+      'starkNetRuntimeTypeToRemove': instance.$type,
     };
 
 _$BroadcastedDeployAccountTxn _$$BroadcastedDeployAccountTxnFromJson(
@@ -174,7 +174,7 @@ _$BroadcastedDeployAccountTxn _$$BroadcastedDeployAccountTxnFromJson(
           .map((e) => Felt.fromJson(e as String))
           .toList(),
       nonce: Felt.fromJson(json['nonce'] as String),
-      $type: json['runtimeType'] as String?,
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
     );
 
 Map<String, dynamic> _$$BroadcastedDeployAccountTxnToJson(
@@ -189,5 +189,5 @@ Map<String, dynamic> _$$BroadcastedDeployAccountTxnToJson(
       'version': instance.version,
       'signature': instance.signature.map((e) => e.toJson()).toList(),
       'nonce': instance.nonce.toJson(),
-      'runtimeType': instance.$type,
+      'starkNetRuntimeTypeToRemove': instance.$type,
     };

--- a/packages/starknet/lib/src/provider/model/get_block_txn_count.freezed.dart
+++ b/packages/starknet/lib/src/provider/model/get_block_txn_count.freezed.dart
@@ -15,15 +15,18 @@ final _privateConstructorUsedError = UnsupportedError(
     'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
 
 GetBlockTxnCount _$GetBlockTxnCountFromJson(Map<String, dynamic> json) {
-  switch (json['runtimeType']) {
+  switch (json['starkNetRuntimeTypeToRemove']) {
     case 'result':
       return BlockTxnCountResult.fromJson(json);
     case 'error':
       return GetBlockTxnCountError.fromJson(json);
 
     default:
-      throw CheckedFromJsonException(json, 'runtimeType', 'GetBlockTxnCount',
-          'Invalid union type "${json['runtimeType']}"!');
+      throw CheckedFromJsonException(
+          json,
+          'starkNetRuntimeTypeToRemove',
+          'GetBlockTxnCount',
+          'Invalid union type "${json['starkNetRuntimeTypeToRemove']}"!');
   }
 }
 
@@ -131,7 +134,7 @@ class _$BlockTxnCountResult implements BlockTxnCountResult {
   @override
   final int result;
 
-  @JsonKey(name: 'runtimeType')
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
   final String $type;
 
   @override
@@ -294,7 +297,7 @@ class _$GetBlockTxnCountError implements GetBlockTxnCountError {
   @override
   final JsonRpcApiError error;
 
-  @JsonKey(name: 'runtimeType')
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
   final String $type;
 
   @override

--- a/packages/starknet/lib/src/provider/model/get_block_txn_count.g.dart
+++ b/packages/starknet/lib/src/provider/model/get_block_txn_count.g.dart
@@ -10,26 +10,26 @@ _$BlockTxnCountResult _$$BlockTxnCountResultFromJson(
         Map<String, dynamic> json) =>
     _$BlockTxnCountResult(
       result: json['result'] as int,
-      $type: json['runtimeType'] as String?,
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
     );
 
 Map<String, dynamic> _$$BlockTxnCountResultToJson(
         _$BlockTxnCountResult instance) =>
     <String, dynamic>{
       'result': instance.result,
-      'runtimeType': instance.$type,
+      'starkNetRuntimeTypeToRemove': instance.$type,
     };
 
 _$GetBlockTxnCountError _$$GetBlockTxnCountErrorFromJson(
         Map<String, dynamic> json) =>
     _$GetBlockTxnCountError(
       error: JsonRpcApiError.fromJson(json['error'] as Map<String, dynamic>),
-      $type: json['runtimeType'] as String?,
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
     );
 
 Map<String, dynamic> _$$GetBlockTxnCountErrorToJson(
         _$GetBlockTxnCountError instance) =>
     <String, dynamic>{
       'error': instance.error.toJson(),
-      'runtimeType': instance.$type,
+      'starkNetRuntimeTypeToRemove': instance.$type,
     };

--- a/packages/starknet/lib/src/provider/model/get_block_with_tx_hashes.freezed.dart
+++ b/packages/starknet/lib/src/provider/model/get_block_with_tx_hashes.freezed.dart
@@ -15,7 +15,7 @@ final _privateConstructorUsedError = UnsupportedError(
     'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
 
 GetBlockWithTxHashes _$GetBlockWithTxHashesFromJson(Map<String, dynamic> json) {
-  switch (json['runtimeType']) {
+  switch (json['starkNetRuntimeTypeToRemove']) {
     case 'result':
       return GetBlockWithTxHashesResult.fromJson(json);
     case 'error':
@@ -24,9 +24,9 @@ GetBlockWithTxHashes _$GetBlockWithTxHashesFromJson(Map<String, dynamic> json) {
     default:
       throw CheckedFromJsonException(
           json,
-          'runtimeType',
+          'starkNetRuntimeTypeToRemove',
           'GetBlockWithTxHashes',
-          'Invalid union type "${json['runtimeType']}"!');
+          'Invalid union type "${json['starkNetRuntimeTypeToRemove']}"!');
   }
 }
 
@@ -148,7 +148,7 @@ class _$GetBlockWithTxHashesResult implements GetBlockWithTxHashesResult {
   @override
   final BlockWithTxnHashes result;
 
-  @JsonKey(name: 'runtimeType')
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
   final String $type;
 
   @override
@@ -313,7 +313,7 @@ class _$GetBlockWithTxHashesError implements GetBlockWithTxHashesError {
   @override
   final JsonRpcApiError error;
 
-  @JsonKey(name: 'runtimeType')
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
   final String $type;
 
   @override
@@ -424,15 +424,18 @@ abstract class GetBlockWithTxHashesError implements GetBlockWithTxHashes {
 }
 
 BlockWithTxnHashes _$BlockWithTxnHashesFromJson(Map<String, dynamic> json) {
-  switch (json['runtimeType']) {
+  switch (json['starkNetRuntimeTypeToRemove']) {
     case 'resultingBlock':
       return ResultingBlock.fromJson(json);
     case 'pendingBlock':
       return PendingBlock.fromJson(json);
 
     default:
-      throw CheckedFromJsonException(json, 'runtimeType', 'BlockWithTxnHashes',
-          'Invalid union type "${json['runtimeType']}"!');
+      throw CheckedFromJsonException(
+          json,
+          'starkNetRuntimeTypeToRemove',
+          'BlockWithTxnHashes',
+          'Invalid union type "${json['starkNetRuntimeTypeToRemove']}"!');
   }
 }
 
@@ -688,7 +691,7 @@ class _$ResultingBlock implements ResultingBlock {
     return EqualUnmodifiableListView(_transactions);
   }
 
-  @JsonKey(name: 'runtimeType')
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
   final String $type;
 
   @override
@@ -956,7 +959,7 @@ class _$PendingBlock implements PendingBlock {
   @override
   final Felt parentHash;
 
-  @JsonKey(name: 'runtimeType')
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
   final String $type;
 
   @override

--- a/packages/starknet/lib/src/provider/model/get_block_with_tx_hashes.g.dart
+++ b/packages/starknet/lib/src/provider/model/get_block_with_tx_hashes.g.dart
@@ -10,28 +10,28 @@ _$GetBlockWithTxHashesResult _$$GetBlockWithTxHashesResultFromJson(
         Map<String, dynamic> json) =>
     _$GetBlockWithTxHashesResult(
       BlockWithTxnHashes.fromJson(json['result'] as Map<String, dynamic>),
-      $type: json['runtimeType'] as String?,
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
     );
 
 Map<String, dynamic> _$$GetBlockWithTxHashesResultToJson(
         _$GetBlockWithTxHashesResult instance) =>
     <String, dynamic>{
       'result': instance.result.toJson(),
-      'runtimeType': instance.$type,
+      'starkNetRuntimeTypeToRemove': instance.$type,
     };
 
 _$GetBlockWithTxHashesError _$$GetBlockWithTxHashesErrorFromJson(
         Map<String, dynamic> json) =>
     _$GetBlockWithTxHashesError(
       error: JsonRpcApiError.fromJson(json['error'] as Map<String, dynamic>),
-      $type: json['runtimeType'] as String?,
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
     );
 
 Map<String, dynamic> _$$GetBlockWithTxHashesErrorToJson(
         _$GetBlockWithTxHashesError instance) =>
     <String, dynamic>{
       'error': instance.error.toJson(),
-      'runtimeType': instance.$type,
+      'starkNetRuntimeTypeToRemove': instance.$type,
     };
 
 _$ResultingBlock _$$ResultingBlockFromJson(Map<String, dynamic> json) =>
@@ -46,7 +46,7 @@ _$ResultingBlock _$$ResultingBlockFromJson(Map<String, dynamic> json) =>
       transactions: (json['transactions'] as List<dynamic>)
           .map((e) => Felt.fromJson(e as String))
           .toList(),
-      $type: json['runtimeType'] as String?,
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
     );
 
 Map<String, dynamic> _$$ResultingBlockToJson(_$ResultingBlock instance) =>
@@ -59,7 +59,7 @@ Map<String, dynamic> _$$ResultingBlockToJson(_$ResultingBlock instance) =>
       'timestamp': instance.timestamp,
       'sequencer_address': instance.sequencerAddress.toJson(),
       'transactions': instance.transactions.map((e) => e.toJson()).toList(),
-      'runtimeType': instance.$type,
+      'starkNetRuntimeTypeToRemove': instance.$type,
     };
 
 _$PendingBlock _$$PendingBlockFromJson(Map<String, dynamic> json) =>
@@ -70,7 +70,7 @@ _$PendingBlock _$$PendingBlockFromJson(Map<String, dynamic> json) =>
       timestamp: json['timestamp'] as int,
       sequencerAddress: Felt.fromJson(json['sequencer_address'] as String),
       parentHash: Felt.fromJson(json['parent_hash'] as String),
-      $type: json['runtimeType'] as String?,
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
     );
 
 Map<String, dynamic> _$$PendingBlockToJson(_$PendingBlock instance) =>
@@ -79,5 +79,5 @@ Map<String, dynamic> _$$PendingBlockToJson(_$PendingBlock instance) =>
       'timestamp': instance.timestamp,
       'sequencer_address': instance.sequencerAddress.toJson(),
       'parent_hash': instance.parentHash.toJson(),
-      'runtimeType': instance.$type,
+      'starkNetRuntimeTypeToRemove': instance.$type,
     };

--- a/packages/starknet/lib/src/provider/model/get_block_with_txs.freezed.dart
+++ b/packages/starknet/lib/src/provider/model/get_block_with_txs.freezed.dart
@@ -15,15 +15,18 @@ final _privateConstructorUsedError = UnsupportedError(
     'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
 
 GetBlockWithTxs _$GetBlockWithTxsFromJson(Map<String, dynamic> json) {
-  switch (json['runtimeType']) {
+  switch (json['starkNetRuntimeTypeToRemove']) {
     case 'block':
       return GetBlockWithTxsResult.fromJson(json);
     case 'error':
       return GetBlockWithTxsError.fromJson(json);
 
     default:
-      throw CheckedFromJsonException(json, 'runtimeType', 'GetBlockWithTxs',
-          'Invalid union type "${json['runtimeType']}"!');
+      throw CheckedFromJsonException(
+          json,
+          'starkNetRuntimeTypeToRemove',
+          'GetBlockWithTxs',
+          'Invalid union type "${json['starkNetRuntimeTypeToRemove']}"!');
   }
 }
 
@@ -141,7 +144,7 @@ class _$GetBlockWithTxsResult implements GetBlockWithTxsResult {
   @override
   final BlockWithTxs result;
 
-  @JsonKey(name: 'runtimeType')
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
   final String $type;
 
   @override
@@ -304,7 +307,7 @@ class _$GetBlockWithTxsError implements GetBlockWithTxsError {
   @override
   final JsonRpcApiError error;
 
-  @JsonKey(name: 'runtimeType')
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
   final String $type;
 
   @override
@@ -415,15 +418,18 @@ abstract class GetBlockWithTxsError implements GetBlockWithTxs {
 }
 
 BlockWithTxs _$BlockWithTxsFromJson(Map<String, dynamic> json) {
-  switch (json['runtimeType']) {
+  switch (json['starkNetRuntimeTypeToRemove']) {
     case 'resultingBlock':
       return BlockWithTxsResponse.fromJson(json);
     case 'pendingBlock':
       return PendingBlockWithTxsResult.fromJson(json);
 
     default:
-      throw CheckedFromJsonException(json, 'runtimeType', 'BlockWithTxs',
-          'Invalid union type "${json['runtimeType']}"!');
+      throw CheckedFromJsonException(
+          json,
+          'starkNetRuntimeTypeToRemove',
+          'BlockWithTxs',
+          'Invalid union type "${json['starkNetRuntimeTypeToRemove']}"!');
   }
 }
 
@@ -687,7 +693,7 @@ class _$BlockWithTxsResponse implements BlockWithTxsResponse {
   @override
   final Felt sequencerAddress;
 
-  @JsonKey(name: 'runtimeType')
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
   final String $type;
 
   @override
@@ -961,7 +967,7 @@ class _$PendingBlockWithTxsResult implements PendingBlockWithTxsResult {
   @override
   final Felt blockHash;
 
-  @JsonKey(name: 'runtimeType')
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
   final String $type;
 
   @override

--- a/packages/starknet/lib/src/provider/model/get_block_with_txs.g.dart
+++ b/packages/starknet/lib/src/provider/model/get_block_with_txs.g.dart
@@ -10,28 +10,28 @@ _$GetBlockWithTxsResult _$$GetBlockWithTxsResultFromJson(
         Map<String, dynamic> json) =>
     _$GetBlockWithTxsResult(
       result: BlockWithTxs.fromJson(json['result'] as Map<String, dynamic>),
-      $type: json['runtimeType'] as String?,
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
     );
 
 Map<String, dynamic> _$$GetBlockWithTxsResultToJson(
         _$GetBlockWithTxsResult instance) =>
     <String, dynamic>{
       'result': instance.result.toJson(),
-      'runtimeType': instance.$type,
+      'starkNetRuntimeTypeToRemove': instance.$type,
     };
 
 _$GetBlockWithTxsError _$$GetBlockWithTxsErrorFromJson(
         Map<String, dynamic> json) =>
     _$GetBlockWithTxsError(
       error: JsonRpcApiError.fromJson(json['error'] as Map<String, dynamic>),
-      $type: json['runtimeType'] as String?,
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
     );
 
 Map<String, dynamic> _$$GetBlockWithTxsErrorToJson(
         _$GetBlockWithTxsError instance) =>
     <String, dynamic>{
       'error': instance.error.toJson(),
-      'runtimeType': instance.$type,
+      'starkNetRuntimeTypeToRemove': instance.$type,
     };
 
 _$BlockWithTxsResponse _$$BlockWithTxsResponseFromJson(
@@ -47,7 +47,7 @@ _$BlockWithTxsResponse _$$BlockWithTxsResponseFromJson(
       newRoot: Felt.fromJson(json['new_root'] as String),
       timestamp: json['timestamp'] as int,
       sequencerAddress: Felt.fromJson(json['sequencer_address'] as String),
-      $type: json['runtimeType'] as String?,
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
     );
 
 Map<String, dynamic> _$$BlockWithTxsResponseToJson(
@@ -61,7 +61,7 @@ Map<String, dynamic> _$$BlockWithTxsResponseToJson(
       'new_root': instance.newRoot.toJson(),
       'timestamp': instance.timestamp,
       'sequencer_address': instance.sequencerAddress.toJson(),
-      'runtimeType': instance.$type,
+      'starkNetRuntimeTypeToRemove': instance.$type,
     };
 
 _$PendingBlockWithTxsResult _$$PendingBlockWithTxsResultFromJson(
@@ -73,7 +73,7 @@ _$PendingBlockWithTxsResult _$$PendingBlockWithTxsResultFromJson(
       timestamp: json['timestamp'] as int,
       sequencerAddress: Felt.fromJson(json['sequencer_address'] as String),
       blockHash: Felt.fromJson(json['block_hash'] as String),
-      $type: json['runtimeType'] as String?,
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
     );
 
 Map<String, dynamic> _$$PendingBlockWithTxsResultToJson(
@@ -83,5 +83,5 @@ Map<String, dynamic> _$$PendingBlockWithTxsResultToJson(
       'timestamp': instance.timestamp,
       'sequencer_address': instance.sequencerAddress.toJson(),
       'block_hash': instance.blockHash.toJson(),
-      'runtimeType': instance.$type,
+      'starkNetRuntimeTypeToRemove': instance.$type,
     };

--- a/packages/starknet/lib/src/provider/model/get_class.freezed.dart
+++ b/packages/starknet/lib/src/provider/model/get_class.freezed.dart
@@ -15,15 +15,18 @@ final _privateConstructorUsedError = UnsupportedError(
     'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
 
 GetClass _$GetClassFromJson(Map<String, dynamic> json) {
-  switch (json['runtimeType']) {
+  switch (json['starkNetRuntimeTypeToRemove']) {
     case 'result':
       return GetClassResult.fromJson(json);
     case 'error':
       return GetClassError.fromJson(json);
 
     default:
-      throw CheckedFromJsonException(json, 'runtimeType', 'GetClass',
-          'Invalid union type "${json['runtimeType']}"!');
+      throw CheckedFromJsonException(
+          json,
+          'starkNetRuntimeTypeToRemove',
+          'GetClass',
+          'Invalid union type "${json['starkNetRuntimeTypeToRemove']}"!');
   }
 }
 
@@ -140,7 +143,7 @@ class _$GetClassResult implements GetClassResult {
   @override
   final ContractClass result;
 
-  @JsonKey(name: 'runtimeType')
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
   final String $type;
 
   @override
@@ -302,7 +305,7 @@ class _$GetClassError implements GetClassError {
   @override
   final JsonRpcApiError error;
 
-  @JsonKey(name: 'runtimeType')
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
   final String $type;
 
   @override

--- a/packages/starknet/lib/src/provider/model/get_class.g.dart
+++ b/packages/starknet/lib/src/provider/model/get_class.g.dart
@@ -9,23 +9,23 @@ part of 'get_class.dart';
 _$GetClassResult _$$GetClassResultFromJson(Map<String, dynamic> json) =>
     _$GetClassResult(
       result: ContractClass.fromJson(json['result'] as Map<String, dynamic>),
-      $type: json['runtimeType'] as String?,
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
     );
 
 Map<String, dynamic> _$$GetClassResultToJson(_$GetClassResult instance) =>
     <String, dynamic>{
       'result': instance.result.toJson(),
-      'runtimeType': instance.$type,
+      'starkNetRuntimeTypeToRemove': instance.$type,
     };
 
 _$GetClassError _$$GetClassErrorFromJson(Map<String, dynamic> json) =>
     _$GetClassError(
       error: JsonRpcApiError.fromJson(json['error'] as Map<String, dynamic>),
-      $type: json['runtimeType'] as String?,
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
     );
 
 Map<String, dynamic> _$$GetClassErrorToJson(_$GetClassError instance) =>
     <String, dynamic>{
       'error': instance.error.toJson(),
-      'runtimeType': instance.$type,
+      'starkNetRuntimeTypeToRemove': instance.$type,
     };

--- a/packages/starknet/lib/src/provider/model/get_class_hash_at.freezed.dart
+++ b/packages/starknet/lib/src/provider/model/get_class_hash_at.freezed.dart
@@ -15,15 +15,18 @@ final _privateConstructorUsedError = UnsupportedError(
     'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
 
 GetClassHashAt _$GetClassHashAtFromJson(Map<String, dynamic> json) {
-  switch (json['runtimeType']) {
+  switch (json['starkNetRuntimeTypeToRemove']) {
     case 'result':
       return GetClassHashAtResult.fromJson(json);
     case 'error':
       return GetClassHashAtError.fromJson(json);
 
     default:
-      throw CheckedFromJsonException(json, 'runtimeType', 'GetClassHashAt',
-          'Invalid union type "${json['runtimeType']}"!');
+      throw CheckedFromJsonException(
+          json,
+          'starkNetRuntimeTypeToRemove',
+          'GetClassHashAt',
+          'Invalid union type "${json['starkNetRuntimeTypeToRemove']}"!');
   }
 }
 
@@ -131,7 +134,7 @@ class _$GetClassHashAtResult implements GetClassHashAtResult {
   @override
   final Felt result;
 
-  @JsonKey(name: 'runtimeType')
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
   final String $type;
 
   @override
@@ -294,7 +297,7 @@ class _$GetClassHashAtError implements GetClassHashAtError {
   @override
   final JsonRpcApiError error;
 
-  @JsonKey(name: 'runtimeType')
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
   final String $type;
 
   @override

--- a/packages/starknet/lib/src/provider/model/get_class_hash_at.g.dart
+++ b/packages/starknet/lib/src/provider/model/get_class_hash_at.g.dart
@@ -10,26 +10,26 @@ _$GetClassHashAtResult _$$GetClassHashAtResultFromJson(
         Map<String, dynamic> json) =>
     _$GetClassHashAtResult(
       result: Felt.fromJson(json['result'] as String),
-      $type: json['runtimeType'] as String?,
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
     );
 
 Map<String, dynamic> _$$GetClassHashAtResultToJson(
         _$GetClassHashAtResult instance) =>
     <String, dynamic>{
       'result': instance.result.toJson(),
-      'runtimeType': instance.$type,
+      'starkNetRuntimeTypeToRemove': instance.$type,
     };
 
 _$GetClassHashAtError _$$GetClassHashAtErrorFromJson(
         Map<String, dynamic> json) =>
     _$GetClassHashAtError(
       error: JsonRpcApiError.fromJson(json['error'] as Map<String, dynamic>),
-      $type: json['runtimeType'] as String?,
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
     );
 
 Map<String, dynamic> _$$GetClassHashAtErrorToJson(
         _$GetClassHashAtError instance) =>
     <String, dynamic>{
       'error': instance.error.toJson(),
-      'runtimeType': instance.$type,
+      'starkNetRuntimeTypeToRemove': instance.$type,
     };

--- a/packages/starknet/lib/src/provider/model/get_events.freezed.dart
+++ b/packages/starknet/lib/src/provider/model/get_events.freezed.dart
@@ -15,15 +15,18 @@ final _privateConstructorUsedError = UnsupportedError(
     'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
 
 GetEvents _$GetEventsFromJson(Map<String, dynamic> json) {
-  switch (json['runtimeType']) {
+  switch (json['starkNetRuntimeTypeToRemove']) {
     case 'result':
       return GetEventsResult.fromJson(json);
     case 'error':
       return GetEventsError.fromJson(json);
 
     default:
-      throw CheckedFromJsonException(json, 'runtimeType', 'GetEvents',
-          'Invalid union type "${json['runtimeType']}"!');
+      throw CheckedFromJsonException(
+          json,
+          'starkNetRuntimeTypeToRemove',
+          'GetEvents',
+          'Invalid union type "${json['starkNetRuntimeTypeToRemove']}"!');
   }
 }
 
@@ -140,7 +143,7 @@ class _$GetEventsResult implements GetEventsResult {
   @override
   final GetEventsResponse result;
 
-  @JsonKey(name: 'runtimeType')
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
   final String $type;
 
   @override
@@ -302,7 +305,7 @@ class _$GetEventsError implements GetEventsError {
   @override
   final JsonRpcApiError error;
 
-  @JsonKey(name: 'runtimeType')
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
   final String $type;
 
   @override

--- a/packages/starknet/lib/src/provider/model/get_events.g.dart
+++ b/packages/starknet/lib/src/provider/model/get_events.g.dart
@@ -10,25 +10,25 @@ _$GetEventsResult _$$GetEventsResultFromJson(Map<String, dynamic> json) =>
     _$GetEventsResult(
       result:
           GetEventsResponse.fromJson(json['result'] as Map<String, dynamic>),
-      $type: json['runtimeType'] as String?,
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
     );
 
 Map<String, dynamic> _$$GetEventsResultToJson(_$GetEventsResult instance) =>
     <String, dynamic>{
       'result': instance.result.toJson(),
-      'runtimeType': instance.$type,
+      'starkNetRuntimeTypeToRemove': instance.$type,
     };
 
 _$GetEventsError _$$GetEventsErrorFromJson(Map<String, dynamic> json) =>
     _$GetEventsError(
       error: JsonRpcApiError.fromJson(json['error'] as Map<String, dynamic>),
-      $type: json['runtimeType'] as String?,
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
     );
 
 Map<String, dynamic> _$$GetEventsErrorToJson(_$GetEventsError instance) =>
     <String, dynamic>{
       'error': instance.error.toJson(),
-      'runtimeType': instance.$type,
+      'starkNetRuntimeTypeToRemove': instance.$type,
     };
 
 _$_GetEventsRequest _$$_GetEventsRequestFromJson(Map<String, dynamic> json) =>

--- a/packages/starknet/lib/src/provider/model/get_nonce.freezed.dart
+++ b/packages/starknet/lib/src/provider/model/get_nonce.freezed.dart
@@ -15,15 +15,18 @@ final _privateConstructorUsedError = UnsupportedError(
     'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
 
 GetNonce _$GetNonceFromJson(Map<String, dynamic> json) {
-  switch (json['runtimeType']) {
+  switch (json['starkNetRuntimeTypeToRemove']) {
     case 'result':
       return GetNonceResult.fromJson(json);
     case 'error':
       return GetNonceError.fromJson(json);
 
     default:
-      throw CheckedFromJsonException(json, 'runtimeType', 'GetNonce',
-          'Invalid union type "${json['runtimeType']}"!');
+      throw CheckedFromJsonException(
+          json,
+          'starkNetRuntimeTypeToRemove',
+          'GetNonce',
+          'Invalid union type "${json['starkNetRuntimeTypeToRemove']}"!');
   }
 }
 
@@ -130,7 +133,7 @@ class _$GetNonceResult implements GetNonceResult {
   @override
   final Felt result;
 
-  @JsonKey(name: 'runtimeType')
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
   final String $type;
 
   @override
@@ -291,7 +294,7 @@ class _$GetNonceError implements GetNonceError {
   @override
   final JsonRpcApiError error;
 
-  @JsonKey(name: 'runtimeType')
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
   final String $type;
 
   @override

--- a/packages/starknet/lib/src/provider/model/get_nonce.g.dart
+++ b/packages/starknet/lib/src/provider/model/get_nonce.g.dart
@@ -9,23 +9,23 @@ part of 'get_nonce.dart';
 _$GetNonceResult _$$GetNonceResultFromJson(Map<String, dynamic> json) =>
     _$GetNonceResult(
       result: Felt.fromJson(json['result'] as String),
-      $type: json['runtimeType'] as String?,
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
     );
 
 Map<String, dynamic> _$$GetNonceResultToJson(_$GetNonceResult instance) =>
     <String, dynamic>{
       'result': instance.result.toJson(),
-      'runtimeType': instance.$type,
+      'starkNetRuntimeTypeToRemove': instance.$type,
     };
 
 _$GetNonceError _$$GetNonceErrorFromJson(Map<String, dynamic> json) =>
     _$GetNonceError(
       error: JsonRpcApiError.fromJson(json['error'] as Map<String, dynamic>),
-      $type: json['runtimeType'] as String?,
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
     );
 
 Map<String, dynamic> _$$GetNonceErrorToJson(_$GetNonceError instance) =>
     <String, dynamic>{
       'error': instance.error.toJson(),
-      'runtimeType': instance.$type,
+      'starkNetRuntimeTypeToRemove': instance.$type,
     };

--- a/packages/starknet/lib/src/provider/model/get_state_update.freezed.dart
+++ b/packages/starknet/lib/src/provider/model/get_state_update.freezed.dart
@@ -15,15 +15,18 @@ final _privateConstructorUsedError = UnsupportedError(
     'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
 
 GetStateUpdate _$GetStateUpdateFromJson(Map<String, dynamic> json) {
-  switch (json['runtimeType']) {
+  switch (json['starkNetRuntimeTypeToRemove']) {
     case 'result':
       return GetStateUpdateResult.fromJson(json);
     case 'error':
       return GetStateUpdateError.fromJson(json);
 
     default:
-      throw CheckedFromJsonException(json, 'runtimeType', 'GetStateUpdate',
-          'Invalid union type "${json['runtimeType']}"!');
+      throw CheckedFromJsonException(
+          json,
+          'starkNetRuntimeTypeToRemove',
+          'GetStateUpdate',
+          'Invalid union type "${json['starkNetRuntimeTypeToRemove']}"!');
   }
 }
 
@@ -141,7 +144,7 @@ class _$GetStateUpdateResult implements GetStateUpdateResult {
   @override
   final StateUpdate result;
 
-  @JsonKey(name: 'runtimeType')
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
   final String $type;
 
   @override
@@ -304,7 +307,7 @@ class _$GetStateUpdateError implements GetStateUpdateError {
   @override
   final JsonRpcApiError error;
 
-  @JsonKey(name: 'runtimeType')
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
   final String $type;
 
   @override

--- a/packages/starknet/lib/src/provider/model/get_state_update.g.dart
+++ b/packages/starknet/lib/src/provider/model/get_state_update.g.dart
@@ -10,26 +10,26 @@ _$GetStateUpdateResult _$$GetStateUpdateResultFromJson(
         Map<String, dynamic> json) =>
     _$GetStateUpdateResult(
       result: StateUpdate.fromJson(json['result'] as Map<String, dynamic>),
-      $type: json['runtimeType'] as String?,
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
     );
 
 Map<String, dynamic> _$$GetStateUpdateResultToJson(
         _$GetStateUpdateResult instance) =>
     <String, dynamic>{
       'result': instance.result.toJson(),
-      'runtimeType': instance.$type,
+      'starkNetRuntimeTypeToRemove': instance.$type,
     };
 
 _$GetStateUpdateError _$$GetStateUpdateErrorFromJson(
         Map<String, dynamic> json) =>
     _$GetStateUpdateError(
       error: JsonRpcApiError.fromJson(json['error'] as Map<String, dynamic>),
-      $type: json['runtimeType'] as String?,
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
     );
 
 Map<String, dynamic> _$$GetStateUpdateErrorToJson(
         _$GetStateUpdateError instance) =>
     <String, dynamic>{
       'error': instance.error.toJson(),
-      'runtimeType': instance.$type,
+      'starkNetRuntimeTypeToRemove': instance.$type,
     };

--- a/packages/starknet/lib/src/provider/model/get_storage.freezed.dart
+++ b/packages/starknet/lib/src/provider/model/get_storage.freezed.dart
@@ -15,15 +15,18 @@ final _privateConstructorUsedError = UnsupportedError(
     'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
 
 GetStorage _$GetStorageFromJson(Map<String, dynamic> json) {
-  switch (json['runtimeType']) {
+  switch (json['starkNetRuntimeTypeToRemove']) {
     case 'result':
       return GetStorageResult.fromJson(json);
     case 'error':
       return GetStorageError.fromJson(json);
 
     default:
-      throw CheckedFromJsonException(json, 'runtimeType', 'GetStorage',
-          'Invalid union type "${json['runtimeType']}"!');
+      throw CheckedFromJsonException(
+          json,
+          'starkNetRuntimeTypeToRemove',
+          'GetStorage',
+          'Invalid union type "${json['starkNetRuntimeTypeToRemove']}"!');
   }
 }
 
@@ -131,7 +134,7 @@ class _$GetStorageResult implements GetStorageResult {
   @override
   final Felt result;
 
-  @JsonKey(name: 'runtimeType')
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
   final String $type;
 
   @override
@@ -293,7 +296,7 @@ class _$GetStorageError implements GetStorageError {
   @override
   final JsonRpcApiError error;
 
-  @JsonKey(name: 'runtimeType')
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
   final String $type;
 
   @override

--- a/packages/starknet/lib/src/provider/model/get_storage.g.dart
+++ b/packages/starknet/lib/src/provider/model/get_storage.g.dart
@@ -9,23 +9,23 @@ part of 'get_storage.dart';
 _$GetStorageResult _$$GetStorageResultFromJson(Map<String, dynamic> json) =>
     _$GetStorageResult(
       result: Felt.fromJson(json['result'] as String),
-      $type: json['runtimeType'] as String?,
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
     );
 
 Map<String, dynamic> _$$GetStorageResultToJson(_$GetStorageResult instance) =>
     <String, dynamic>{
       'result': instance.result.toJson(),
-      'runtimeType': instance.$type,
+      'starkNetRuntimeTypeToRemove': instance.$type,
     };
 
 _$GetStorageError _$$GetStorageErrorFromJson(Map<String, dynamic> json) =>
     _$GetStorageError(
       error: JsonRpcApiError.fromJson(json['error'] as Map<String, dynamic>),
-      $type: json['runtimeType'] as String?,
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
     );
 
 Map<String, dynamic> _$$GetStorageErrorToJson(_$GetStorageError instance) =>
     <String, dynamic>{
       'error': instance.error.toJson(),
-      'runtimeType': instance.$type,
+      'starkNetRuntimeTypeToRemove': instance.$type,
     };

--- a/packages/starknet/lib/src/provider/model/get_transaction.freezed.dart
+++ b/packages/starknet/lib/src/provider/model/get_transaction.freezed.dart
@@ -15,15 +15,18 @@ final _privateConstructorUsedError = UnsupportedError(
     'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
 
 GetTransaction _$GetTransactionFromJson(Map<String, dynamic> json) {
-  switch (json['runtimeType']) {
+  switch (json['starkNetRuntimeTypeToRemove']) {
     case 'result':
       return GetTransactionResult.fromJson(json);
     case 'error':
       return GetTransactionError.fromJson(json);
 
     default:
-      throw CheckedFromJsonException(json, 'runtimeType', 'GetTransaction',
-          'Invalid union type "${json['runtimeType']}"!');
+      throw CheckedFromJsonException(
+          json,
+          'starkNetRuntimeTypeToRemove',
+          'GetTransaction',
+          'Invalid union type "${json['starkNetRuntimeTypeToRemove']}"!');
   }
 }
 
@@ -141,7 +144,7 @@ class _$GetTransactionResult implements GetTransactionResult {
   @override
   final Txn result;
 
-  @JsonKey(name: 'runtimeType')
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
   final String $type;
 
   @override
@@ -304,7 +307,7 @@ class _$GetTransactionError implements GetTransactionError {
   @override
   final JsonRpcApiError error;
 
-  @JsonKey(name: 'runtimeType')
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
   final String $type;
 
   @override
@@ -415,7 +418,7 @@ abstract class GetTransactionError implements GetTransaction {
 }
 
 Txn _$TxnFromJson(Map<String, dynamic> json) {
-  switch (json['runtimeType']) {
+  switch (json['starkNetRuntimeTypeToRemove']) {
     case 'invokeTxnV0':
       return InvokeTxnV0.fromJson(json);
     case 'invokeTxnV1':
@@ -430,8 +433,8 @@ Txn _$TxnFromJson(Map<String, dynamic> json) {
       return L1HandlerTxn.fromJson(json);
 
     default:
-      throw CheckedFromJsonException(json, 'runtimeType', 'Txn',
-          'Invalid union type "${json['runtimeType']}"!');
+      throw CheckedFromJsonException(json, 'starkNetRuntimeTypeToRemove', 'Txn',
+          'Invalid union type "${json['starkNetRuntimeTypeToRemove']}"!');
   }
 }
 
@@ -849,7 +852,7 @@ class _$InvokeTxnV0 implements InvokeTxnV0 {
     return EqualUnmodifiableListView(value);
   }
 
-  @JsonKey(name: 'runtimeType')
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
   final String $type;
 
   @override
@@ -1320,7 +1323,7 @@ class _$InvokeTxnV1 implements InvokeTxnV1 {
     return EqualUnmodifiableListView(value);
   }
 
-  @JsonKey(name: 'runtimeType')
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
   final String $type;
 
   @override
@@ -1777,7 +1780,7 @@ class _$DeclareTxn implements DeclareTxn {
   @override
   final Felt? senderAddress;
 
-  @JsonKey(name: 'runtimeType')
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
   final String $type;
 
   @override
@@ -2213,7 +2216,7 @@ class _$DeployTxn implements DeployTxn {
     return EqualUnmodifiableListView(value);
   }
 
-  @JsonKey(name: 'runtimeType')
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
   final String $type;
 
   @override
@@ -2679,7 +2682,7 @@ class _$DeployAccountTxn implements DeployAccountTxn {
     return EqualUnmodifiableListView(value);
   }
 
-  @JsonKey(name: 'runtimeType')
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
   final String $type;
 
   @override
@@ -3129,7 +3132,7 @@ class _$L1HandlerTxn implements L1HandlerTxn {
     return EqualUnmodifiableListView(value);
   }
 
-  @JsonKey(name: 'runtimeType')
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
   final String $type;
 
   @override

--- a/packages/starknet/lib/src/provider/model/get_transaction.g.dart
+++ b/packages/starknet/lib/src/provider/model/get_transaction.g.dart
@@ -10,28 +10,28 @@ _$GetTransactionResult _$$GetTransactionResultFromJson(
         Map<String, dynamic> json) =>
     _$GetTransactionResult(
       result: Txn.fromJson(json['result'] as Map<String, dynamic>),
-      $type: json['runtimeType'] as String?,
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
     );
 
 Map<String, dynamic> _$$GetTransactionResultToJson(
         _$GetTransactionResult instance) =>
     <String, dynamic>{
       'result': instance.result.toJson(),
-      'runtimeType': instance.$type,
+      'starkNetRuntimeTypeToRemove': instance.$type,
     };
 
 _$GetTransactionError _$$GetTransactionErrorFromJson(
         Map<String, dynamic> json) =>
     _$GetTransactionError(
       error: JsonRpcApiError.fromJson(json['error'] as Map<String, dynamic>),
-      $type: json['runtimeType'] as String?,
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
     );
 
 Map<String, dynamic> _$$GetTransactionErrorToJson(
         _$GetTransactionError instance) =>
     <String, dynamic>{
       'error': instance.error.toJson(),
-      'runtimeType': instance.$type,
+      'starkNetRuntimeTypeToRemove': instance.$type,
     };
 
 _$InvokeTxnV0 _$$InvokeTxnV0FromJson(Map<String, dynamic> json) =>
@@ -58,7 +58,7 @@ _$InvokeTxnV0 _$$InvokeTxnV0FromJson(Map<String, dynamic> json) =>
       calldata: (json['calldata'] as List<dynamic>?)
           ?.map((e) => Felt.fromJson(e as String))
           .toList(),
-      $type: json['runtimeType'] as String?,
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
     );
 
 Map<String, dynamic> _$$InvokeTxnV0ToJson(_$InvokeTxnV0 instance) =>
@@ -72,7 +72,7 @@ Map<String, dynamic> _$$InvokeTxnV0ToJson(_$InvokeTxnV0 instance) =>
       'contract_address': instance.contractAddress?.toJson(),
       'entry_point_selector': instance.entryPointSelector?.toJson(),
       'calldata': instance.calldata?.map((e) => e.toJson()).toList(),
-      'runtimeType': instance.$type,
+      'starkNetRuntimeTypeToRemove': instance.$type,
     };
 
 _$InvokeTxnV1 _$$InvokeTxnV1FromJson(Map<String, dynamic> json) =>
@@ -96,7 +96,7 @@ _$InvokeTxnV1 _$$InvokeTxnV1FromJson(Map<String, dynamic> json) =>
       calldata: (json['calldata'] as List<dynamic>?)
           ?.map((e) => Felt.fromJson(e as String))
           .toList(),
-      $type: json['runtimeType'] as String?,
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
     );
 
 Map<String, dynamic> _$$InvokeTxnV1ToJson(_$InvokeTxnV1 instance) =>
@@ -109,7 +109,7 @@ Map<String, dynamic> _$$InvokeTxnV1ToJson(_$InvokeTxnV1 instance) =>
       'type': instance.type,
       'sender_address': instance.sender_address?.toJson(),
       'calldata': instance.calldata?.map((e) => e.toJson()).toList(),
-      'runtimeType': instance.$type,
+      'starkNetRuntimeTypeToRemove': instance.$type,
     };
 
 _$DeclareTxn _$$DeclareTxnFromJson(Map<String, dynamic> json) => _$DeclareTxn(
@@ -132,7 +132,7 @@ _$DeclareTxn _$$DeclareTxnFromJson(Map<String, dynamic> json) => _$DeclareTxn(
       senderAddress: json['sender_address'] == null
           ? null
           : Felt.fromJson(json['sender_address'] as String),
-      $type: json['runtimeType'] as String?,
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
     );
 
 Map<String, dynamic> _$$DeclareTxnToJson(_$DeclareTxn instance) =>
@@ -145,7 +145,7 @@ Map<String, dynamic> _$$DeclareTxnToJson(_$DeclareTxn instance) =>
       'type': instance.type,
       'class_hash': instance.classHash?.toJson(),
       'sender_address': instance.senderAddress?.toJson(),
-      'runtimeType': instance.$type,
+      'starkNetRuntimeTypeToRemove': instance.$type,
     };
 
 _$DeployTxn _$$DeployTxnFromJson(Map<String, dynamic> json) => _$DeployTxn(
@@ -163,7 +163,7 @@ _$DeployTxn _$$DeployTxnFromJson(Map<String, dynamic> json) => _$DeployTxn(
       constructorCalldata: (json['constructor_calldata'] as List<dynamic>?)
           ?.map((e) => Felt.fromJson(e as String))
           .toList(),
-      $type: json['runtimeType'] as String?,
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
     );
 
 Map<String, dynamic> _$$DeployTxnToJson(_$DeployTxn instance) =>
@@ -175,7 +175,7 @@ Map<String, dynamic> _$$DeployTxnToJson(_$DeployTxn instance) =>
       'contract_address_salt': instance.contractAddressSalt?.toJson(),
       'constructor_calldata':
           instance.constructorCalldata?.map((e) => e.toJson()).toList(),
-      'runtimeType': instance.$type,
+      'starkNetRuntimeTypeToRemove': instance.$type,
     };
 
 _$DeployAccountTxn _$$DeployAccountTxnFromJson(Map<String, dynamic> json) =>
@@ -202,7 +202,7 @@ _$DeployAccountTxn _$$DeployAccountTxnFromJson(Map<String, dynamic> json) =>
       constructorCalldata: (json['constructor_calldata'] as List<dynamic>?)
           ?.map((e) => Felt.fromJson(e as String))
           .toList(),
-      $type: json['runtimeType'] as String?,
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
     );
 
 Map<String, dynamic> _$$DeployAccountTxnToJson(_$DeployAccountTxn instance) =>
@@ -217,7 +217,7 @@ Map<String, dynamic> _$$DeployAccountTxnToJson(_$DeployAccountTxn instance) =>
       'class_hash': instance.classHash?.toJson(),
       'constructor_calldata':
           instance.constructorCalldata?.map((e) => e.toJson()).toList(),
-      'runtimeType': instance.$type,
+      'starkNetRuntimeTypeToRemove': instance.$type,
     };
 
 _$L1HandlerTxn _$$L1HandlerTxnFromJson(Map<String, dynamic> json) =>
@@ -238,7 +238,7 @@ _$L1HandlerTxn _$$L1HandlerTxnFromJson(Map<String, dynamic> json) =>
       calldata: (json['calldata'] as List<dynamic>?)
           ?.map((e) => Felt.fromJson(e as String))
           .toList(),
-      $type: json['runtimeType'] as String?,
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
     );
 
 Map<String, dynamic> _$$L1HandlerTxnToJson(_$L1HandlerTxn instance) =>
@@ -250,5 +250,5 @@ Map<String, dynamic> _$$L1HandlerTxnToJson(_$L1HandlerTxn instance) =>
       'contract_address': instance.contractAddress?.toJson(),
       'entry_point_selector': instance.entryPointSelector?.toJson(),
       'calldata': instance.calldata?.map((e) => e.toJson()).toList(),
-      'runtimeType': instance.$type,
+      'starkNetRuntimeTypeToRemove': instance.$type,
     };

--- a/packages/starknet/lib/src/provider/model/get_transaction_receipt.freezed.dart
+++ b/packages/starknet/lib/src/provider/model/get_transaction_receipt.freezed.dart
@@ -16,7 +16,7 @@ final _privateConstructorUsedError = UnsupportedError(
 
 GetTransactionReceipt _$GetTransactionReceiptFromJson(
     Map<String, dynamic> json) {
-  switch (json['runtimeType']) {
+  switch (json['starkNetRuntimeTypeToRemove']) {
     case 'result':
       return GetTransactionReceiptResult.fromJson(json);
     case 'error':
@@ -25,9 +25,9 @@ GetTransactionReceipt _$GetTransactionReceiptFromJson(
     default:
       throw CheckedFromJsonException(
           json,
-          'runtimeType',
+          'starkNetRuntimeTypeToRemove',
           'GetTransactionReceipt',
-          'Invalid union type "${json['runtimeType']}"!');
+          'Invalid union type "${json['starkNetRuntimeTypeToRemove']}"!');
   }
 }
 
@@ -150,7 +150,7 @@ class _$GetTransactionReceiptResult implements GetTransactionReceiptResult {
   @override
   final TxnReceipt result;
 
-  @JsonKey(name: 'runtimeType')
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
   final String $type;
 
   @override
@@ -316,7 +316,7 @@ class _$GetTransactionReceiptError implements GetTransactionReceiptError {
   @override
   final JsonRpcApiError error;
 
-  @JsonKey(name: 'runtimeType')
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
   final String $type;
 
   @override
@@ -427,7 +427,7 @@ abstract class GetTransactionReceiptError implements GetTransactionReceipt {
 }
 
 TxnReceipt _$TxnReceiptFromJson(Map<String, dynamic> json) {
-  switch (json['runtimeType']) {
+  switch (json['starkNetRuntimeTypeToRemove']) {
     case 'invokeTxnReceipt':
       return InvokeTxnReceipt.fromJson(json);
     case 'declareTxnReceipt':
@@ -444,8 +444,11 @@ TxnReceipt _$TxnReceiptFromJson(Map<String, dynamic> json) {
       return PendingCommonReceiptProperties.fromJson(json);
 
     default:
-      throw CheckedFromJsonException(json, 'runtimeType', 'TxnReceipt',
-          'Invalid union type "${json['runtimeType']}"!');
+      throw CheckedFromJsonException(
+          json,
+          'starkNetRuntimeTypeToRemove',
+          'TxnReceipt',
+          'Invalid union type "${json['starkNetRuntimeTypeToRemove']}"!');
   }
 }
 
@@ -887,7 +890,7 @@ class _$InvokeTxnReceipt implements InvokeTxnReceipt {
     return EqualUnmodifiableListView(_events);
   }
 
-  @JsonKey(name: 'runtimeType')
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
   final String $type;
 
   @override
@@ -1368,7 +1371,7 @@ class _$DeclareTxnReceipt implements DeclareTxnReceipt {
     return EqualUnmodifiableListView(_events);
   }
 
-  @JsonKey(name: 'runtimeType')
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
   final String $type;
 
   @override
@@ -1849,7 +1852,7 @@ class _$L1HandlerTxnReceipt implements L1HandlerTxnReceipt {
     return EqualUnmodifiableListView(_events);
   }
 
-  @JsonKey(name: 'runtimeType')
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
   final String $type;
 
   @override
@@ -2342,7 +2345,7 @@ class _$DeployTxnReceipt implements DeployTxnReceipt {
   @override
   final Felt contractAddress;
 
-  @JsonKey(name: 'runtimeType')
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
   final String $type;
 
   @override
@@ -2839,7 +2842,7 @@ class _$DeployAccountTxnReceipt implements DeployAccountTxnReceipt {
   @override
   final Felt contractAddress;
 
-  @JsonKey(name: 'runtimeType')
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
   final String $type;
 
   @override
@@ -3310,7 +3313,7 @@ class _$PendingDeployTxnReceipt implements PendingDeployTxnReceipt {
   @override
   final Felt contractAddress;
 
-  @JsonKey(name: 'runtimeType')
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
   final String $type;
 
   @override
@@ -3760,7 +3763,7 @@ class _$PendingCommonReceiptProperties
     return EqualUnmodifiableListView(_events);
   }
 
-  @JsonKey(name: 'runtimeType')
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
   final String $type;
 
   @override

--- a/packages/starknet/lib/src/provider/model/get_transaction_receipt.g.dart
+++ b/packages/starknet/lib/src/provider/model/get_transaction_receipt.g.dart
@@ -10,28 +10,28 @@ _$GetTransactionReceiptResult _$$GetTransactionReceiptResultFromJson(
         Map<String, dynamic> json) =>
     _$GetTransactionReceiptResult(
       result: TxnReceipt.fromJson(json['result'] as Map<String, dynamic>),
-      $type: json['runtimeType'] as String?,
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
     );
 
 Map<String, dynamic> _$$GetTransactionReceiptResultToJson(
         _$GetTransactionReceiptResult instance) =>
     <String, dynamic>{
       'result': instance.result.toJson(),
-      'runtimeType': instance.$type,
+      'starkNetRuntimeTypeToRemove': instance.$type,
     };
 
 _$GetTransactionReceiptError _$$GetTransactionReceiptErrorFromJson(
         Map<String, dynamic> json) =>
     _$GetTransactionReceiptError(
       error: JsonRpcApiError.fromJson(json['error'] as Map<String, dynamic>),
-      $type: json['runtimeType'] as String?,
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
     );
 
 Map<String, dynamic> _$$GetTransactionReceiptErrorToJson(
         _$GetTransactionReceiptError instance) =>
     <String, dynamic>{
       'error': instance.error.toJson(),
-      'runtimeType': instance.$type,
+      'starkNetRuntimeTypeToRemove': instance.$type,
     };
 
 _$InvokeTxnReceipt _$$InvokeTxnReceiptFromJson(Map<String, dynamic> json) =>
@@ -50,7 +50,7 @@ _$InvokeTxnReceipt _$$InvokeTxnReceiptFromJson(Map<String, dynamic> json) =>
       events: (json['events'] as List<dynamic>)
           .map((e) => Event.fromJson(e as Map<String, dynamic>))
           .toList(),
-      $type: json['runtimeType'] as String?,
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
     );
 
 Map<String, dynamic> _$$InvokeTxnReceiptToJson(_$InvokeTxnReceipt instance) =>
@@ -63,7 +63,7 @@ Map<String, dynamic> _$$InvokeTxnReceiptToJson(_$InvokeTxnReceipt instance) =>
       'type': instance.type,
       'messages_sent': instance.messagesSent.map((e) => e.toJson()).toList(),
       'events': instance.events.map((e) => e.toJson()).toList(),
-      'runtimeType': instance.$type,
+      'starkNetRuntimeTypeToRemove': instance.$type,
     };
 
 _$DeclareTxnReceipt _$$DeclareTxnReceiptFromJson(Map<String, dynamic> json) =>
@@ -82,7 +82,7 @@ _$DeclareTxnReceipt _$$DeclareTxnReceiptFromJson(Map<String, dynamic> json) =>
       events: (json['events'] as List<dynamic>)
           .map((e) => Event.fromJson(e as Map<String, dynamic>))
           .toList(),
-      $type: json['runtimeType'] as String?,
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
     );
 
 Map<String, dynamic> _$$DeclareTxnReceiptToJson(_$DeclareTxnReceipt instance) =>
@@ -95,7 +95,7 @@ Map<String, dynamic> _$$DeclareTxnReceiptToJson(_$DeclareTxnReceipt instance) =>
       'type': instance.type,
       'messages_sent': instance.messagesSent.map((e) => e.toJson()).toList(),
       'events': instance.events.map((e) => e.toJson()).toList(),
-      'runtimeType': instance.$type,
+      'starkNetRuntimeTypeToRemove': instance.$type,
     };
 
 _$L1HandlerTxnReceipt _$$L1HandlerTxnReceiptFromJson(
@@ -115,7 +115,7 @@ _$L1HandlerTxnReceipt _$$L1HandlerTxnReceiptFromJson(
       events: (json['events'] as List<dynamic>)
           .map((e) => Event.fromJson(e as Map<String, dynamic>))
           .toList(),
-      $type: json['runtimeType'] as String?,
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
     );
 
 Map<String, dynamic> _$$L1HandlerTxnReceiptToJson(
@@ -129,7 +129,7 @@ Map<String, dynamic> _$$L1HandlerTxnReceiptToJson(
       'type': instance.type,
       'messages_sent': instance.messagesSent.map((e) => e.toJson()).toList(),
       'events': instance.events.map((e) => e.toJson()).toList(),
-      'runtimeType': instance.$type,
+      'starkNetRuntimeTypeToRemove': instance.$type,
     };
 
 _$DeployTxnReceipt _$$DeployTxnReceiptFromJson(Map<String, dynamic> json) =>
@@ -149,7 +149,7 @@ _$DeployTxnReceipt _$$DeployTxnReceiptFromJson(Map<String, dynamic> json) =>
           .map((e) => Event.fromJson(e as Map<String, dynamic>))
           .toList(),
       contractAddress: Felt.fromJson(json['contract_address'] as String),
-      $type: json['runtimeType'] as String?,
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
     );
 
 Map<String, dynamic> _$$DeployTxnReceiptToJson(_$DeployTxnReceipt instance) =>
@@ -163,7 +163,7 @@ Map<String, dynamic> _$$DeployTxnReceiptToJson(_$DeployTxnReceipt instance) =>
       'messages_sent': instance.messagesSent.map((e) => e.toJson()).toList(),
       'events': instance.events.map((e) => e.toJson()).toList(),
       'contract_address': instance.contractAddress.toJson(),
-      'runtimeType': instance.$type,
+      'starkNetRuntimeTypeToRemove': instance.$type,
     };
 
 _$DeployAccountTxnReceipt _$$DeployAccountTxnReceiptFromJson(
@@ -184,7 +184,7 @@ _$DeployAccountTxnReceipt _$$DeployAccountTxnReceiptFromJson(
           .map((e) => Event.fromJson(e as Map<String, dynamic>))
           .toList(),
       contractAddress: Felt.fromJson(json['contract_address'] as String),
-      $type: json['runtimeType'] as String?,
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
     );
 
 Map<String, dynamic> _$$DeployAccountTxnReceiptToJson(
@@ -199,7 +199,7 @@ Map<String, dynamic> _$$DeployAccountTxnReceiptToJson(
       'messages_sent': instance.messagesSent.map((e) => e.toJson()).toList(),
       'events': instance.events.map((e) => e.toJson()).toList(),
       'contract_address': instance.contractAddress.toJson(),
-      'runtimeType': instance.$type,
+      'starkNetRuntimeTypeToRemove': instance.$type,
     };
 
 _$PendingDeployTxnReceipt _$$PendingDeployTxnReceiptFromJson(
@@ -215,7 +215,7 @@ _$PendingDeployTxnReceipt _$$PendingDeployTxnReceiptFromJson(
           .map((e) => Event.fromJson(e as Map<String, dynamic>))
           .toList(),
       contractAddress: Felt.fromJson(json['contract_address'] as String),
-      $type: json['runtimeType'] as String?,
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
     );
 
 Map<String, dynamic> _$$PendingDeployTxnReceiptToJson(
@@ -227,7 +227,7 @@ Map<String, dynamic> _$$PendingDeployTxnReceiptToJson(
       'messages_sent': instance.messagesSent.map((e) => e.toJson()).toList(),
       'events': instance.events.map((e) => e.toJson()).toList(),
       'contract_address': instance.contractAddress.toJson(),
-      'runtimeType': instance.$type,
+      'starkNetRuntimeTypeToRemove': instance.$type,
     };
 
 _$PendingCommonReceiptProperties _$$PendingCommonReceiptPropertiesFromJson(
@@ -242,7 +242,7 @@ _$PendingCommonReceiptProperties _$$PendingCommonReceiptPropertiesFromJson(
       events: (json['events'] as List<dynamic>)
           .map((e) => Event.fromJson(e as Map<String, dynamic>))
           .toList(),
-      $type: json['runtimeType'] as String?,
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
     );
 
 Map<String, dynamic> _$$PendingCommonReceiptPropertiesToJson(
@@ -253,5 +253,5 @@ Map<String, dynamic> _$$PendingCommonReceiptPropertiesToJson(
       'type': instance.type,
       'messages_sent': instance.messagesSent.map((e) => e.toJson()).toList(),
       'events': instance.events.map((e) => e.toJson()).toList(),
-      'runtimeType': instance.$type,
+      'starkNetRuntimeTypeToRemove': instance.$type,
     };

--- a/packages/starknet/lib/src/provider/model/invoke_transaction.freezed.dart
+++ b/packages/starknet/lib/src/provider/model/invoke_transaction.freezed.dart
@@ -734,7 +734,7 @@ abstract class _InvokeTransactionV1 implements InvokeTransactionV1 {
 
 InvokeTransactionResponse _$InvokeTransactionResponseFromJson(
     Map<String, dynamic> json) {
-  switch (json['runtimeType']) {
+  switch (json['starkNetRuntimeTypeToRemove']) {
     case 'result':
       return InvokeTransactionResult.fromJson(json);
     case 'error':
@@ -743,9 +743,9 @@ InvokeTransactionResponse _$InvokeTransactionResponseFromJson(
     default:
       throw CheckedFromJsonException(
           json,
-          'runtimeType',
+          'starkNetRuntimeTypeToRemove',
           'InvokeTransactionResponse',
-          'Invalid union type "${json['runtimeType']}"!');
+          'Invalid union type "${json['starkNetRuntimeTypeToRemove']}"!');
   }
 }
 
@@ -866,7 +866,7 @@ class _$InvokeTransactionResult implements InvokeTransactionResult {
   @override
   final InvokeTransactionResponseResult result;
 
-  @JsonKey(name: 'runtimeType')
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
   final String $type;
 
   @override
@@ -1031,7 +1031,7 @@ class _$InvokeTransactionError implements InvokeTransactionError {
   @override
   final JsonRpcApiError error;
 
-  @JsonKey(name: 'runtimeType')
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
   final String $type;
 
   @override

--- a/packages/starknet/lib/src/provider/model/invoke_transaction.g.dart
+++ b/packages/starknet/lib/src/provider/model/invoke_transaction.g.dart
@@ -80,28 +80,28 @@ _$InvokeTransactionResult _$$InvokeTransactionResultFromJson(
     _$InvokeTransactionResult(
       result: InvokeTransactionResponseResult.fromJson(
           json['result'] as Map<String, dynamic>),
-      $type: json['runtimeType'] as String?,
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
     );
 
 Map<String, dynamic> _$$InvokeTransactionResultToJson(
         _$InvokeTransactionResult instance) =>
     <String, dynamic>{
       'result': instance.result.toJson(),
-      'runtimeType': instance.$type,
+      'starkNetRuntimeTypeToRemove': instance.$type,
     };
 
 _$InvokeTransactionError _$$InvokeTransactionErrorFromJson(
         Map<String, dynamic> json) =>
     _$InvokeTransactionError(
       error: JsonRpcApiError.fromJson(json['error'] as Map<String, dynamic>),
-      $type: json['runtimeType'] as String?,
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
     );
 
 Map<String, dynamic> _$$InvokeTransactionErrorToJson(
         _$InvokeTransactionError instance) =>
     <String, dynamic>{
       'error': instance.error.toJson(),
-      'runtimeType': instance.$type,
+      'starkNetRuntimeTypeToRemove': instance.$type,
     };
 
 _$_InvokeTransactionResponseResult _$$_InvokeTransactionResponseResultFromJson(

--- a/packages/starknet/lib/src/provider/model/pending_transactions.freezed.dart
+++ b/packages/starknet/lib/src/provider/model/pending_transactions.freezed.dart
@@ -15,15 +15,18 @@ final _privateConstructorUsedError = UnsupportedError(
     'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
 
 PendingTransactions _$PendingTransactionsFromJson(Map<String, dynamic> json) {
-  switch (json['runtimeType']) {
+  switch (json['starkNetRuntimeTypeToRemove']) {
     case 'result':
       return PendingTransactionsResult.fromJson(json);
     case 'error':
       return PendingTransactionsError.fromJson(json);
 
     default:
-      throw CheckedFromJsonException(json, 'runtimeType', 'PendingTransactions',
-          'Invalid union type "${json['runtimeType']}"!');
+      throw CheckedFromJsonException(
+          json,
+          'starkNetRuntimeTypeToRemove',
+          'PendingTransactions',
+          'Invalid union type "${json['starkNetRuntimeTypeToRemove']}"!');
   }
 }
 
@@ -139,7 +142,7 @@ class _$PendingTransactionsResult implements PendingTransactionsResult {
     return EqualUnmodifiableListView(_result);
   }
 
-  @JsonKey(name: 'runtimeType')
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
   final String $type;
 
   @override
@@ -303,7 +306,7 @@ class _$PendingTransactionsError implements PendingTransactionsError {
   @override
   final JsonRpcApiError error;
 
-  @JsonKey(name: 'runtimeType')
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
   final String $type;
 
   @override

--- a/packages/starknet/lib/src/provider/model/pending_transactions.g.dart
+++ b/packages/starknet/lib/src/provider/model/pending_transactions.g.dart
@@ -12,26 +12,26 @@ _$PendingTransactionsResult _$$PendingTransactionsResultFromJson(
       result: (json['result'] as List<dynamic>)
           .map((e) => Txn.fromJson(e as Map<String, dynamic>))
           .toList(),
-      $type: json['runtimeType'] as String?,
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
     );
 
 Map<String, dynamic> _$$PendingTransactionsResultToJson(
         _$PendingTransactionsResult instance) =>
     <String, dynamic>{
       'result': instance.result.map((e) => e.toJson()).toList(),
-      'runtimeType': instance.$type,
+      'starkNetRuntimeTypeToRemove': instance.$type,
     };
 
 _$PendingTransactionsError _$$PendingTransactionsErrorFromJson(
         Map<String, dynamic> json) =>
     _$PendingTransactionsError(
       error: JsonRpcApiError.fromJson(json['error'] as Map<String, dynamic>),
-      $type: json['runtimeType'] as String?,
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
     );
 
 Map<String, dynamic> _$$PendingTransactionsErrorToJson(
         _$PendingTransactionsError instance) =>
     <String, dynamic>{
       'error': instance.error.toJson(),
-      'runtimeType': instance.$type,
+      'starkNetRuntimeTypeToRemove': instance.$type,
     };

--- a/packages/starknet/lib/src/provider/model/syncing.freezed.dart
+++ b/packages/starknet/lib/src/provider/model/syncing.freezed.dart
@@ -15,7 +15,7 @@ final _privateConstructorUsedError = UnsupportedError(
     'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#custom-getters-and-methods');
 
 Syncing _$SyncingFromJson(Map<String, dynamic> json) {
-  switch (json['runtimeType']) {
+  switch (json['starkNetRuntimeTypeToRemove']) {
     case 'synchronized':
       return Synchronized.fromJson(json);
     case 'notSynchronized':
@@ -24,8 +24,11 @@ Syncing _$SyncingFromJson(Map<String, dynamic> json) {
       return SyncingError.fromJson(json);
 
     default:
-      throw CheckedFromJsonException(json, 'runtimeType', 'Syncing',
-          'Invalid union type "${json['runtimeType']}"!');
+      throw CheckedFromJsonException(
+          json,
+          'starkNetRuntimeTypeToRemove',
+          'Syncing',
+          'Invalid union type "${json['starkNetRuntimeTypeToRemove']}"!');
   }
 }
 
@@ -148,7 +151,7 @@ class _$Synchronized implements Synchronized {
   @override
   final SyncStatus result;
 
-  @JsonKey(name: 'runtimeType')
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
   final String $type;
 
   @override
@@ -306,7 +309,7 @@ class _$NotSynchronized implements NotSynchronized {
   @override
   final bool result;
 
-  @JsonKey(name: 'runtimeType')
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
   final String $type;
 
   @override
@@ -474,7 +477,7 @@ class _$SyncingError implements SyncingError {
   @override
   final JsonRpcApiError error;
 
-  @JsonKey(name: 'runtimeType')
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
   final String $type;
 
   @override

--- a/packages/starknet/lib/src/provider/model/syncing.g.dart
+++ b/packages/starknet/lib/src/provider/model/syncing.g.dart
@@ -9,35 +9,35 @@ part of 'syncing.dart';
 _$Synchronized _$$SynchronizedFromJson(Map<String, dynamic> json) =>
     _$Synchronized(
       result: SyncStatus.fromJson(json['result'] as Map<String, dynamic>),
-      $type: json['runtimeType'] as String?,
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
     );
 
 Map<String, dynamic> _$$SynchronizedToJson(_$Synchronized instance) =>
     <String, dynamic>{
       'result': instance.result.toJson(),
-      'runtimeType': instance.$type,
+      'starkNetRuntimeTypeToRemove': instance.$type,
     };
 
 _$NotSynchronized _$$NotSynchronizedFromJson(Map<String, dynamic> json) =>
     _$NotSynchronized(
       result: json['result'] as bool,
-      $type: json['runtimeType'] as String?,
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
     );
 
 Map<String, dynamic> _$$NotSynchronizedToJson(_$NotSynchronized instance) =>
     <String, dynamic>{
       'result': instance.result,
-      'runtimeType': instance.$type,
+      'starkNetRuntimeTypeToRemove': instance.$type,
     };
 
 _$SyncingError _$$SyncingErrorFromJson(Map<String, dynamic> json) =>
     _$SyncingError(
       error: JsonRpcApiError.fromJson(json['error'] as Map<String, dynamic>),
-      $type: json['runtimeType'] as String?,
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
     );
 
 Map<String, dynamic> _$$SyncingErrorToJson(_$SyncingError instance) =>
     <String, dynamic>{
       'error': instance.error.toJson(),
-      'runtimeType': instance.$type,
+      'starkNetRuntimeTypeToRemove': instance.$type,
     };

--- a/packages/starknet/lib/src/static_config.dart
+++ b/packages/starknet/lib/src/static_config.dart
@@ -102,24 +102,9 @@ final ozAccountUpgradableClassHash = Felt.fromHexString(
   "0x018509044a92ab8fb00cf7067c7c7578a77ec11d55b628541c1bfb38cd4d01ef",
 );
 
-// Compiled contract class hashes with 'runtimeType' (freezed)
-// needs
-final balanceClassHashWithRuntimeType = Felt.fromHexString(
-  "0x4a303eefe561262d53f3d8f75aef9579dac78098c1749f39fe375d3cab87812",
-);
 // with constructor argument: 42
 final balanceContractAddress = Felt.fromHexString(
-  "0xc50f29f9806c112bba78d12e26ff20cdb8d59e4fb50702974a20bb7d295069",
-);
-final ozAccountClassHashWithRuntimeType = Felt.fromHexString(
-  "0x200076549cbe401adaa35d5ad5fbe8c01e4ef8a6150f012e36fd6ab687498b2",
-);
-
-final ozProxyClassHashWithRuntimeType = Felt.fromHexString(
-  "0x00eafb0413e759430def79539db681f8a4eb98cf4196fe457077d694c6aeeb82",
-);
-final ozAccountUpgradableClassHashWithRuntimetype = Felt.fromHexString(
-  "0x018509044a92ab8fb00cf7067c7c7578a77ec11d55b628541c1bfb38cd4d01ef",
+  "0x44f4d0e41832e184d152be425ceb95795fa450e9b4425d5dea5188a05560117",
 );
 
 // devnet 0.4.0 value

--- a/packages/starknet/test/account_test.dart
+++ b/packages/starknet/test/account_test.dart
@@ -19,8 +19,8 @@ void main() {
             expect(
               result.classHash,
               equals(
-                balanceClassHashWithRuntimeType,
-              ), // 2023-02-06: class hash with 'runtimeType' included
+                balanceClassHash,
+              ),
             );
             expect(result.classHash, equals(Felt(balanceContract.classHash())));
             return result.transactionHash.toHexString();
@@ -54,8 +54,7 @@ void main() {
     group('deploy', () {
       test('succeeds to deploy a contract', () async {
         // Balance contract
-        final classHash =
-            balanceClassHashWithRuntimeType; // 2023-02-06: class hash with 'runtimeType' included
+        final classHash = balanceClassHash;
 
         final contractAddress = await account0
             .deploy(classHash: classHash, calldata: [Felt.fromInt(42)]);

--- a/packages/starknet/test/contract/contract_test.dart
+++ b/packages/starknet/test/contract/contract_test.dart
@@ -14,7 +14,7 @@ void main() {
           final classHash = compiledContract.classHash();
           expect(
             classHash,
-            equals(balanceClassHashWithRuntimeType.toBigInt()),
+            equals(balanceClassHash.toBigInt()),
           );
         });
         test('Compute class hash for contract with attributes', () async {
@@ -24,7 +24,7 @@ void main() {
           final classHash = compiledContract.classHash();
           expect(
             classHash,
-            equals(ozAccountClassHashWithRuntimeType.toBigInt()),
+            equals(ozAccountClassHash.toBigInt()),
           );
         });
       });

--- a/packages/starknet/tool/declare_contract.dart
+++ b/packages/starknet/tool/declare_contract.dart
@@ -1,0 +1,48 @@
+/// Declare given compiled contracts on devnet
+///
+/// ```shell
+/// ```
+import 'package:starknet/starknet.dart';
+
+void main(List<String> args) async {
+  final account = account0;
+  for (var arg in args) {
+    final contractPath = arg;
+    final compiledContract = await parseContract(contractPath);
+    Felt classHash = Felt(compiledContract.classHash());
+
+    print(
+      "$contractPath : ${classHash.toHexString()}",
+    );
+    Felt txHash = Felt.fromInt(0);
+    final declareTx = await account.declare(compiledContract: compiledContract);
+    declareTx.when(
+      result: (result) {
+        classHash = result.classHash;
+        txHash = result.transactionHash;
+        print(
+          "Contract ClassHash: ${classHash.toHexString()} (${txHash.toHexString()})",
+        );
+      },
+      error: (error) {
+        throw Exception(
+          "Failed to declare contract: ${error.code}: ${error.message}",
+        );
+      },
+    );
+    bool txStatus = await waitForAcceptance(
+      transactionHash: txHash.toHexString(),
+      provider: account.provider,
+    );
+    if (!txStatus) {
+      final tx = await account.provider.getTransactionByHash(txHash);
+      print("Contract declare transaction failed");
+      prettyPrintJson(tx.toJson());
+      throw Exception("Declare transaction failed");
+    } else {
+      final txReceipt = await account.provider.getTransactionReceipt(txHash);
+      print("Contract declare transaction OK!");
+      prettyPrintJson(txReceipt.toJson());
+    }
+  }
+}

--- a/packages/starknet/tool/send_eth.dart
+++ b/packages/starknet/tool/send_eth.dart
@@ -1,0 +1,36 @@
+/// Send ETH to given address
+///
+import 'package:starknet/starknet.dart';
+
+void main(List<String> args) async {
+  final account = account0;
+  final amount = 0.01;
+  final recipient = Felt.fromHexString(args[0]);
+  print("Recipent: ${recipient.toHexString()}");
+
+  final txHash = await account.send(
+    recipient: recipient,
+    amount: Uint256(
+      high: Felt.fromInt(0),
+      low: Felt(BigInt.from(amount * 1e18)),
+    ),
+  );
+  print("Transaction: $txHash");
+
+  bool txStatus = await waitForAcceptance(
+    transactionHash: txHash,
+    provider: account.provider,
+  );
+  if (!txStatus) {
+    final tx =
+        await account.provider.getTransactionByHash(Felt.fromHexString(txHash));
+    print("Sending ETH transaction failed");
+    prettyPrintJson(tx.toJson());
+    throw Exception("Sending ETH transaction failed");
+  } else {
+    final txReceipt = await account.provider
+        .getTransactionReceipt(Felt.fromHexString(txHash));
+    print("Contract declare transaction OK!");
+    prettyPrintJson(txReceipt.toJson());
+  }
+}

--- a/scripts/python/commands/devnet.py
+++ b/scripts/python/commands/devnet.py
@@ -4,7 +4,7 @@ import subprocess
 from scripts.python.commands.deploy import deploy_balance, deploy_erc20_upgradeable
 
 command = '''
-poetry run starknet-devnet --seed 0
+poetry run starknet-devnet --host 0.0.0.0 --seed 0
 '''
 
 


### PR DESCRIPTION
This PR ease running flutter example application with devnet.

Please note that `devnet` is now listening on `0.0.0.0` instead of `127.0.0.1`

I have modified `build.yaml` in starknet package, so you need to regenerate freezed files:
`dart run build_runner build`

To deploy OpenZeppelin contract:
1- Start poetry:
`poetry run devnet start`
2- declare OpenZeppelin contracts:
`dart run ./tool/declare_contract.dart ../../contracts/build/proxy.json ../../contracts/build/oz_account_upgradable.json `

To send 0.01 ETH to a given address:
`dart run ./tool/send_eth.dart 0x7571f412349405dd49463b8a969feb8765755f500a1f28585909a9c88da8dcb`

In order to connect flutter example to local devnet, you need to replace:
`infuraGoerliTestnetUri` by `Uri.parse("http://YOUR_HOST_IP:5050/rpc")`

Closes #179 