### PR TITLE
No account nonce fallback

### DIFF
--- a/packages/starknet/lib/src/account.dart
+++ b/packages/starknet/lib/src/account.dart
@@ -35,23 +35,9 @@ class Account {
       contractAddress: accountAddress,
     );
     return (response.when(
-      error: (error) async {
-        // fallback to account contract call
-        final response = await provider.call(
-          request: FunctionCall(
-            contractAddress: accountAddress,
-            entryPointSelector: getSelectorByName("get_nonce"),
-            calldata: [],
-          ),
-          blockId: blockId,
-        );
-        return (response.when(
-          error: (error) {
-            throw Exception(
-                "Error retrieving nonce (${error.code}): ${error.message}");
-          },
-          result: (result) => result[0],
-        ));
+      error: (error) {
+        throw Exception(
+            "Error retrieving nonce (${error.code}): ${error.message}");
       },
       result: (result) => result,
     ));


### PR DESCRIPTION
This PR remove fallback to call `get_nonce` on account contract if `starknet_getNonce` failed.

`get_nonce` is no more implemented in *standard* account contract (argent, braavos, open zeppelin) and the fallback prevent to get `starknet_getNonce` error if any.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Simplified error handling in the Account class, improving clarity and reducing potential points of failure by removing complex fallback logic.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->