### PR TITLE
Feat: unit test in wallet_kit

### DIFF
--- a/packages/wallet_kit/test/utils/format_address_test.dart
+++ b/packages/wallet_kit/test/utils/format_address_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:wallet_kit/utils/format_address.dart';
+
+void main() {
+  test('formatAddress should format long addresses starting with "0x"', () {
+    // Arrange
+    const longAddress = "0x123456789abcdef";
+
+    // Act
+    final result = formatAddress(longAddress);
+
+    // Assert
+    expect(result, "0x1234...cdef");
+  });
+
+  test(
+      'formatAddress should return the same address for short addresses or those not starting with "0x"',
+      () {
+    // Arrange
+    const shortAddress = "0x123";
+    const nonPrefixedAddress = "123456789abcdef";
+
+    // Act
+    final shortResult = formatAddress(shortAddress);
+    final nonPrefixedResult = formatAddress(nonPrefixedAddress);
+
+    // Assert
+    expect(shortResult, shortAddress);
+    expect(nonPrefixedResult, nonPrefixedAddress);
+  });
+}

--- a/packages/wallet_kit/test/utils/group_by_test.dart
+++ b/packages/wallet_kit/test/utils/group_by_test.dart
@@ -1,0 +1,28 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:wallet_kit/utils/group_by.dart';
+
+void main() {
+  test('groupBy should group values by the given key', () {
+    // Arrange
+    final List<int> values = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+
+    // Act
+    final grouped = groupBy(values, (int value) => value % 3);
+
+    // Assert
+    expect(grouped[0], [3, 6, 9]);
+    expect(grouped[1], [1, 4, 7, 10]);
+    expect(grouped[2], [2, 5, 8]);
+  });
+
+  test('groupBy should handle empty input', () {
+    // Arrange
+    final List<int> values = [];
+
+    // Act
+    final grouped = groupBy(values, (int value) => value % 3);
+
+    // Assert
+    expect(grouped.isEmpty, true);
+  });
+}


### PR DESCRIPTION
|  `groupBy` Unit Test | `formatAddress` Unit Test |
| ------------- | ------------- |
| <img width="686" alt="Screenshot 2024-03-08 at 12 50 04" src="https://github.com/focustree/starknet.dart/assets/56479665/fd2d1353-bce6-4e4c-ae52-146c7cf83f63">  | <img width="782" alt="Screenshot 2024-03-08 at 12 47 55" src="https://github.com/focustree/starknet.dart/assets/56479665/e03ef2d6-d78d-4666-84d0-fb686c4cc9bd">  |
