### PR TITLE
features: use asdf to manage starkli version

### DIFF
--- a/.env.devnet
+++ b/.env.devnet
@@ -7,7 +7,7 @@ export DEVNET_DUMP_PATH="./assets/devnet-dump.json"
 
 export CAIRO_VERSION=2.6.2
 export SCARB_VERSION=2.6.2
-export STARKNET_DEVNET_VERSION=0.5.0
+export STARKNET_DEVNET_VERSION=0.0.5
 export STARKLI_VERSION=0.2.9
 
 export STARKNET_ACCOUNT=.starkli/account_0.json

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,4 @@
 scarb 2.6.2
 action-validator 0.6.0
 
+starkli 0.2.9

--- a/melos.yaml
+++ b/melos.yaml
@@ -31,12 +31,13 @@ scripts:
     run: |
       cargo install starknet-devnet --version $STARKNET_DEVNET_VERSION
 
-      curl https://get.starkli.sh | sh
-      starkliup -v v$STARKLI_VERSION
-
       asdf plugin add scarb
       asdf install scarb $SCARB_VERSION
       asdf local scarb $SCARB_VERSION
+
+      asdf plugin add starkli https://github.com/ptisserand/asdf-starkli.git
+      asdf install starkli $STARKLI_VERSION
+      asdf local starkli $STARKLI_VERSION
 
       asdf plugin add action-validator
       asdf install action-validator latest


### PR DESCRIPTION
By using asdf to manage starkli version, user can have a specific version of starkli for each of his projects.

This PR also set correct version of starknet-devnet (0.0.5 and not 0.5.0)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated `STARKNET_DEVNET_VERSION` to `0.0.5` for development environment.
  - Added `starkli` version `0.2.9` to tool versions.
  - Improved installation process for tools in `melos.yaml`, including `starkli`, `scarb`, and `action-validator`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->