### PR TITLE
fix: redirect `cargo install` output to stdout to prevent false error detection

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -29,7 +29,7 @@ scripts:
   starknet:setup:
     description: Install starknet dev env
     run: |
-      cargo install starknet-devnet --version $STARKNET_DEVNET_VERSION
+      cargo install starknet-devnet --version $STARKNET_DEVNET_VERSION 2> /dev/null 2>&1
 
       asdf plugin add scarb
       asdf install scarb $SCARB_VERSION


### PR DESCRIPTION
`melos` assume that `stderr` is error only but `cargo install` log on `stderr`
So this PR redirect `cargo install` logs to `stdout`

Closes: #373 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved the installation script for `starknet-devnet` to suppress error messages, ensuring a cleaner setup process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->