### PR TITLE
Only renovate packages + 1 PR per package

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,28 @@
   "extends": ["config:base"],
   "python": {
     "enabled": false
-  }
+  },
+  "ignorePaths": ["**/examples/**", "**/test/**", "**/docs/**"],
+  "packageRules": [
+    {
+      "paths": ["packages/secure_store"],
+      "groupName": "secure_store updates"
+    },
+    {
+      "paths": ["packages/starknet"],
+      "groupName": "starknet updates"
+    },
+    {
+      "paths": ["packages/starknet_provider"],
+      "groupName": "starknet_provider updates"
+    },
+    {
+      "paths": ["packages/starknet_builder"],
+      "groupName": "starknet_builder updates"
+    },
+    {
+      "paths": ["packages/wallet_kit"],
+      "groupName": "wallet_kit updates"
+    }
+  ]
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Configured Renovate to ignore updates in example, test, and docs directories.
  - Added specific update grouping rules for secure_store, starknet, starknet_provider, starknet_builder, and wallet_kit packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->