### PR TITLE
Install starknet-devnet with asdf

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -2,3 +2,4 @@ scarb 2.6.2
 action-validator 0.6.0
 
 starkli 0.2.9
+starknet-devnet 0.0.5

--- a/melos.yaml
+++ b/melos.yaml
@@ -29,7 +29,9 @@ scripts:
   starknet:setup:
     description: Install starknet dev env
     run: |
-      cargo install starknet-devnet --version $STARKNET_DEVNET_VERSION 2> /dev/null 2>&1
+      asdf plugin add starknet-devnet https://github.com/ptisserand/asdf-starknet-devnet.git
+      asdf install starknet-devnet $STARKNET_DEVNET_VERSION
+      asdf local starknet-devnet $STARKNET_DEVNET_VERSION
 
       asdf plugin add scarb
       asdf install scarb $SCARB_VERSION


### PR DESCRIPTION
Installation of starknet-devnet with asdf to avoid building from source.

On my laptop:
- Before:
```
$ time melos starknet:setup
....
real    11m58.736s
user    74m38.184s
sys     2m54.302s
```
- After:
```
$ time melos starknet:setup
....
real    0m4.606s
user    0m2.739s
sys     0m0.838s
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added `starknet-devnet 0.0.5` to the list of dependencies.
  - Updated the `starknet:setup` script to use `asdf` for managing StarkNet dev environment installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->