### PR TITLE
Migrate provider_test to the devnet

### DIFF
--- a/packages/starknet_provider/test/provider_test.dart
+++ b/packages/starknet_provider/test/provider_test.dart
@@ -2,6 +2,8 @@
 import 'package:starknet/starknet.dart';
 import 'package:starknet_provider/starknet_provider.dart';
 import 'package:test/test.dart';
+import 'dart:convert';
+import 'dart:io';
 
 import 'utils.dart';
 
@@ -10,7 +12,7 @@ void main() {
     test(
       'invokeTransactionV0',
       () async {
-        final account = getJsonRpcProvider();
+        final account = getJsonRpcProvider(network: 'devnet');
         final request = InvokeTransactionRequest(
           invokeTransaction: InvokeTransactionV0(
             contractAddress: Felt.fromHexString(
@@ -39,7 +41,7 @@ void main() {
     test(
       'mintAspectNFT',
       () async {
-        final account = getJsonRpcProvider();
+        final account = getJsonRpcProvider(network: 'devnet');
         final request = InvokeTransactionRequest(
             invokeTransaction: InvokeTransactionV0(
           contractAddress: Felt.fromHexString(
@@ -83,7 +85,7 @@ void main() {
     test(
       'declareTransaction',
       () async {
-        final account = getJsonRpcProvider(network: 'integration');
+        final account = getJsonRpcProvider(network: 'devnet');
         final request = DeclareTransactionRequest(
           declareTransaction: DeclareTransactionV1(
             max_fee: defaultMaxFee,

--- a/packages/starknet_provider/test/provider_test.dart
+++ b/packages/starknet_provider/test/provider_test.dart
@@ -2,9 +2,6 @@
 import 'package:starknet/starknet.dart';
 import 'package:starknet_provider/starknet_provider.dart';
 import 'package:test/test.dart';
-import 'dart:convert';
-import 'dart:io';
-
 import 'utils.dart';
 
 void main() {

--- a/packages/starknet_provider/test/provider_test.dart
+++ b/packages/starknet_provider/test/provider_test.dart
@@ -114,6 +114,7 @@ void main() {
           },
         );
       },
+      skip: true,
     );
-  }, tags: ['integration'], skip: true);
+  }, tags: ['integration']);
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,3 +4,4 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 dev_dependencies:
   melos: ^6.0.0
+  test: ^1.25.7

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,4 +4,3 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 dev_dependencies:
   melos: ^6.0.0
-  test: ^1.25.7


### PR DESCRIPTION
The first 2 tests work fine on the devnet, the third one is skipped because of the use of deprecated version of declare transaction

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Updated test cases to specify the network parameter ('devnet') for `getJsonRpcProvider()`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->