### PR TITLE
melos: starknet-devnet and starkli are now part of asdf plugins community

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -30,7 +30,7 @@ scripts:
   starknet:setup:
     description: Install starknet dev env
     run: |
-      asdf plugin add starknet-devnet https://github.com/ptisserand/asdf-starknet-devnet.git
+      asdf plugin add starknet-devnet
       asdf install starknet-devnet $STARKNET_DEVNET_VERSION
       asdf local starknet-devnet $STARKNET_DEVNET_VERSION
 
@@ -38,7 +38,7 @@ scripts:
       asdf install scarb $SCARB_VERSION
       asdf local scarb $SCARB_VERSION
 
-      asdf plugin add starkli https://github.com/ptisserand/asdf-starkli.git
+      asdf plugin add starkli
       asdf install starkli $STARKLI_VERSION
       asdf local starkli $STARKLI_VERSION
 


### PR DESCRIPTION
[`starknet-devnet`](https://github.com/asdf-vm/asdf-plugins/pull/1012) and [`starkli`](https://github.com/asdf-vm/asdf-plugins/pull/1010) are now available in `asdf-vm` plugins community.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Simplified the installation process for `starknet-devnet` and `starkli` plugins by removing specific URLs.
	- Updated comments in the `contracts:invoke` script to clarify expected transaction behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->