### PR TITLE
fix: trigger new packages release to fix broken dependencies

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -11,11 +11,11 @@ The goal of this SDK is to be able to interact with StarkNet smart contracts in 
 
 | Feature        | State              | Version |
 | -------------- | ------------------ | ------- |
-| invoke         | ✅ | 0, 1    |
-| declare        | ✅ | 1, 2    |
-| deploy_account | ✅ | 1       |
+| invoke         | ✅ | 0, 1, 3    |
+| declare        | ✅ | 1, 2, 3    |
+| deploy_account | ✅ | 1, 3       |
 
-### Supported RPC methods for JSON RPC v0.3.0
+### Supported RPC methods for JSON RPC v0.7.1
 
 | Feature                                  | State              |
 | ---------------------------------------- | ------------------ |

--- a/packages/starknet/README.md
+++ b/packages/starknet/README.md
@@ -44,15 +44,6 @@ To run the tests on **devnet** use the following command:
 NETWORK=devnet dart test -t integration
 ```
 
-### Release a new version to pub.dev
-
-You simply need to create a PR where you:
-
-1. Bump the package version
-2. Add an entry to the `CHANGELOG`
-
-Make sure it passes all the CI tests, then merge it to release a new version of the package.
-
 ### Generate freezed model classes
 
 To avoid writing too much boilerplate, we use the [freezed](https://github.com/rrousselGit/freezed) library to automatically generate serializer logic.

--- a/packages/starknet_provider/README.md
+++ b/packages/starknet_provider/README.md
@@ -1,3 +1,11 @@
 # Starknet provider
 
 Starknet provider for Dart and Flutter applications
+
+### Transaction support
+
+| Feature        | State              | Version |
+| -------------- | ------------------ | ------- |
+| invoke         | ✅ | 0, 1, 3    |
+| declare        | ✅ | 1, 2, 3    |
+| deploy_account | ✅ | 1, 3       |


### PR DESCRIPTION
This PR is to trigger new packages release to fix broken dependencies on pub.dev


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated compatibility section for transactions in the StarkNet SDK documentation, reflecting new version numbers for `invoke`, `declare`, and `deploy_account`.
	- Revised supported RPC methods from JSON RPC v0.3.0 to v0.7.1.
	- Removed the "Release a new version to pub.dev" section from the Starknet package README.
	- Added a new "Transaction support" section in the Starknet provider README, detailing feature availability and versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->