### PR TITLE
fix: update wallet_app tutorial

### DIFF
--- a/docs/examples/mobile-wallet.mdx
+++ b/docs/examples/mobile-wallet.mdx
@@ -27,7 +27,8 @@ ACCOUNT_CLASS_HASH="0x061dac032f228abef9c6626f995015233097ae253a7f72d68552db02f2
 RPC="http://127.0.0.1:5050/rpc"
 ```
 
-> Please note that `ACCOUNT_CLASS_HASH` must match the one used by your version of `starknet-devnet`, it's displayed at startup:
+> Please note that `ACCOUNT_CLASS_HASH` must match the one used by your version of `starknet-devnet`, it's displayed at startup.
+Here is the value for `starknet-devnet 0.2.0`
 > ```
 > Predeployed accounts using class with hash: 0x061dac032f228abef9c6626f995015233097ae253a7f72d68552db02f2971b8f
 > ```
@@ -60,7 +61,7 @@ RPC="http://127.0.0.1:5050/rpc"
 7. Biometric support (optional)
 
 In order to use `Biometric` on Android, your `MainActivity` must inherit from `FlutterFragmentActivity` instead of `FlutterActity`.
-You need to modify your `MainActivity.tk` with:
+You need to modify your `MainActivity.kt` with:
 ```kotlin
 import io.flutter.embedding.android.FlutterFragmentActivity
 
@@ -258,7 +259,7 @@ With `starknet-devnet`, you can mint some ETH to your account address with the f
 ```shell
 curl --silent -H 'Content-type: application/json' \
   -X POST http://localhost:5050/mint \
-  -d '{"address": "0x5461cf5be91b3f21304ad81a3d0efeb5fe95f9655d7353ab0fc822e78b10837", "amount": 20000000000000000000, "unit": "WEI"}'
+  -d '{"address": ""<YOUR_ACCOUNT_ADDRESS>"", "amount": 20000000000000000000, "unit": "WEI"}'
 ```
 ```console
 {"new_balance":"20000000000000000000","unit":"WEI","tx_hash":"0x9d2d26cef777c50b64475592e0df6e6c6012014e660f97bb37aaf5138aff54"}

--- a/docs/examples/mobile-wallet.mdx
+++ b/docs/examples/mobile-wallet.mdx
@@ -190,21 +190,24 @@ class HomeScreen extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return const Layout2(
-      children: [
-        SizedBox(height: 32),
-        Column(
-          crossAxisAlignment: CrossAxisAlignment.center,
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            WalletSelector(),
-            AccountAddress(),
-          ],
-        ),
-        SizedBox(height: 32),
-        WalletBody(),
-        SendEthButton(),
-      ],
+    return const Scaffold(
+      body: Layout2(
+        children: [
+          SizedBox(height: 32),
+          Column(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              WalletSelector(),
+              AccountAddress(),
+              DeployAccountButton(),
+            ],
+          ),
+          SizedBox(height: 32),
+          WalletBody(),
+          SendEthButton(),
+        ],
+      ),
     );
   }
 }

--- a/docs/examples/mobile-wallet.mdx
+++ b/docs/examples/mobile-wallet.mdx
@@ -35,6 +35,22 @@ RPC="http://127.0.0.1:5050/rpc"
     - .env
 ```
 
+6. Update Android minimun SDK version
+`secure_store` package used by `wallet_kit` require Android minimum SDK version set to at least 23, you need to modify `android/app/build.gradle`:
+```
+    defaultConfig {
+        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
+        applicationId = "com.example.wallet_app"
+        // You can update the following values to match your application needs.
+        // For more information, see: https://flutter.dev/to/review-gradle-config.
+        minSdk = 23
+        targetSdk = flutter.targetSdkVersion
+        versionCode = flutter.versionCode
+        versionName = flutter.versionName
+    }
+```
+
+
 ## Let's write some code
 
 Let's start with a simple `main` function in your 'main.dart' file.

--- a/docs/examples/mobile-wallet.mdx
+++ b/docs/examples/mobile-wallet.mdx
@@ -253,7 +253,7 @@ Now you can run your app with `flutter run` and see your wallet in action! 💸
 
 ---
 
-Deploying an account require some ETH to pay transaction fees.
+Deploying an account requires some ETH to pay transaction fees.
 With `starknet-devnet`, you can mint some ETH to your account address with the following command:
 ```shell
 curl --silent -H 'Content-type: application/json' \

--- a/docs/examples/mobile-wallet.mdx
+++ b/docs/examples/mobile-wallet.mdx
@@ -23,11 +23,17 @@ flutter pub add wallet_kit hive_flutter hooks_riverpod flutter_dotenv
 4. Create a `.env` file in the root of your wallet_app project
 
 ```bash
-ACCOUNT_CLASS_HASH="0x05400e90f7e0ae78bd02c77cd75527280470e2fe19c54970dd79dc37a9d3645c"
+ACCOUNT_CLASS_HASH="0x061dac032f228abef9c6626f995015233097ae253a7f72d68552db02f2971b8f"
 RPC="http://127.0.0.1:5050/rpc"
 ```
 
-> If you are building for Android, use `RPC="http://10.0.2.2:5050/rpc"` instead.
+> Please note that `ACCOUNT_CLASS_HASH` must match the one used by your version of `starknet-devnet`, it's displayed at startup:
+> ```
+> Predeployed accounts using class with hash: 0x061dac032f228abef9c6626f995015233097ae253a7f72d68552db02f2971b8f
+> ```
+
+> If you are running on another device that the host running `starknet-devnet`, you should use the external IP of your host running and start `starknet-devnet` with `--host 0.0.0.0` argument
+
 
 5. Add `.env` file in your `pubspec.yaml`
 ```yaml
@@ -36,6 +42,7 @@ RPC="http://127.0.0.1:5050/rpc"
 ```
 
 6. Update Android minimun SDK version
+
 `secure_store` package used by `wallet_kit` require Android minimum SDK version set to at least 23, you need to modify `android/app/build.gradle`:
 ```
     defaultConfig {
@@ -50,6 +57,15 @@ RPC="http://127.0.0.1:5050/rpc"
     }
 ```
 
+7. Biometric support (optional)
+
+In order to use `Biometric` on Android, your `MainActivity` must inherit from `FlutterFragmentActivity` instead of `FlutterActity`.
+You need to modify your `MainActivity.tk` with:
+```kotlin
+import io.flutter.embedding.android.FlutterFragmentActivity
+
+class MainActivity: FlutterFragmentActivity()
+```
 
 ## Let's write some code
 
@@ -234,3 +250,16 @@ class WalletApp extends HookConsumerWidget {
 ```
 
 Now you can run your app with `flutter run` and see your wallet in action! 💸
+
+---
+
+Deploying an account require some ETH to pay transaction fees.
+With `starknet-devnet`, you can mint some ETH to your account address with the following command:
+```shell
+curl --silent -H 'Content-type: application/json' \
+  -X POST http://localhost:5050/mint \
+  -d '{"address": "0x5461cf5be91b3f21304ad81a3d0efeb5fe95f9655d7353ab0fc822e78b10837", "amount": 20000000000000000000, "unit": "WEI"}'
+```
+```console
+{"new_balance":"20000000000000000000","unit":"WEI","tx_hash":"0x9d2d26cef777c50b64475592e0df6e6c6012014e660f97bb37aaf5138aff54"}
+```

--- a/packages/wallet_kit/lib/services/wallet_service.dart
+++ b/packages/wallet_kit/lib/services/wallet_service.dart
@@ -151,7 +151,11 @@ class WalletService {
   }) async {
     final privateKey = await secureStore.getSecret(
         key: privateKeyKey(account.walletId, account.id));
-    s.Signer? signer = s.Signer(privateKey: s.Felt.fromHexString(privateKey!));
+    if (privateKey == null) {
+      throw Exception("Private key not found");
+    }
+
+    s.Signer? signer = s.Signer(privateKey: s.Felt.fromHexString(privateKey));
 
     final provider = WalletKit().provider;
 

--- a/packages/wallet_kit/lib/services/wallet_service.dart
+++ b/packages/wallet_kit/lib/services/wallet_service.dart
@@ -144,6 +144,38 @@ class WalletService {
     );
     return address;
   }
+
+  static Future<bool> deployAccount({
+    required SecureStore secureStore,
+    required Account account,
+  }) async {
+    final privateKey = await secureStore.getSecret(
+        key: privateKeyKey(account.walletId, account.id));
+    s.Signer? signer = s.Signer(privateKey: s.Felt.fromHexString(privateKey!));
+
+    final provider = WalletKit().provider;
+
+    // call data depends on class hash...
+    final constructorCalldata = [signer.publicKey];
+    final tx = await s.Account.deployAccount(
+      signer: signer,
+      provider: provider,
+      constructorCalldata: constructorCalldata,
+      classHash: WalletKit().accountClassHash,
+    );
+    signer = null;
+    final (contractAddress, txHash) = tx.when(
+      result: (result) =>
+          (result.contractAddress, result.transactionHash.toHexString()),
+      error: (error) => throw Exception('${error.code}: ${error.message}'),
+    );
+    bool success = await s.waitForAcceptance(
+      transactionHash: txHash,
+      provider: provider,
+    );
+
+    return success;
+  }
 }
 
 seedPhraseKey(String walletId) {
@@ -168,12 +200,13 @@ Future<String> sendEth({
   s.Signer? signer = s.Signer(privateKey: privateKey);
 
   final provider = WalletKit().provider;
+  final chainId = WalletKit().chainId;
 
   final fundingAccount = s.Account(
     provider: provider,
     signer: signer,
     accountAddress: s.Felt.fromHexString(account.address),
-    chainId: s.StarknetChainId.testNet,
+    chainId: chainId,
   );
 
   final txHash = await fundingAccount.send(

--- a/packages/wallet_kit/lib/wallet_state/wallet_provider.dart
+++ b/packages/wallet_kit/lib/wallet_state/wallet_provider.dart
@@ -184,6 +184,19 @@ class Wallets extends _$Wallets with PersistedState<WalletsState> {
     state = state.copyWith(wallets: {}, selected: null);
   }
 
+  refreshAccount(String walletId, int accountId) async {
+    await refreshEthBalance(walletId, accountId);
+    await refreshStrkBalance(walletId, accountId);
+    final isDeployed = await WalletService.isAccountValid(
+      account: state.wallets[walletId]!.accounts[accountId]!,
+    );
+    updateSelectedAccountIsDeployed(
+      walletId: walletId,
+      accountId: accountId,
+      isDeployed: isDeployed,
+    );
+  }
+
   refreshEthBalance(String walletId, int accountId) async {
     final accountAddress =
         state.wallets[walletId]?.accounts[accountId]?.address;

--- a/packages/wallet_kit/lib/wallet_state/wallet_provider.dart
+++ b/packages/wallet_kit/lib/wallet_state/wallet_provider.dart
@@ -128,6 +128,19 @@ class Wallets extends _$Wallets with PersistedState<WalletsState> {
     );
   }
 
+  deployAccount({
+    required SecureStore secureStore,
+    required Account account,
+  }) async {
+    final success = await WalletService.deployAccount(
+        secureStore: secureStore, account: account);
+    updateSelectedAccountIsDeployed(
+      walletId: account.walletId,
+      accountId: account.id,
+      isDeployed: success,
+    );
+  }
+
   updateSelectedAccountIsDeployed({
     required String walletId,
     required int accountId,

--- a/packages/wallet_kit/lib/wallet_state/wallet_provider.dart
+++ b/packages/wallet_kit/lib/wallet_state/wallet_provider.dart
@@ -211,7 +211,7 @@ class Wallets extends _$Wallets with PersistedState<WalletsState> {
           accountId: account.copyWith(
             balances: {
               ...account.balances,
-              'ETH': double.parse(ethBalance.toStringAsFixed(4)),
+              TokenSymbol.ETH.name: double.parse(ethBalance.toStringAsFixed(4)),
             },
           ),
         },
@@ -246,7 +246,8 @@ class Wallets extends _$Wallets with PersistedState<WalletsState> {
           accountId: account.copyWith(
             balances: {
               ...account.balances,
-              'STRK': double.parse(strkBalance.toStringAsFixed(4)),
+              TokenSymbol.STRK.name:
+                  double.parse(strkBalance.toStringAsFixed(4)),
             },
           ),
         },

--- a/packages/wallet_kit/lib/widgets/deploy_account_button.dart
+++ b/packages/wallet_kit/lib/widgets/deploy_account_button.dart
@@ -13,17 +13,22 @@ class DeployAccountButton extends HookConsumerWidget {
       walletsProvider.select((value) => value.selectedAccount),
     );
     if (selectedAccount?.isDeployed == false) {
+      final ethBalance =
+          selectedAccount!.balances[TokenSymbol.ETH.name] ?? 0.00;
+      final enoughBalance = ethBalance >= 0.00001;
       return PrimaryButton(
-          label: 'Deploy account',
-          onPressed: () async {
-            final secureStore = await ref
-                .read(walletsProvider.notifier)
-                .getSecureStoreForWallet(context: context);
-            await ref.read(walletsProvider.notifier).deployAccount(
-                  secureStore: secureStore,
-                  account: selectedAccount!,
-                );
-          });
+          label: enoughBalance ? 'Deploy account' : 'Not enougth ETH',
+          onPressed: enoughBalance
+              ? () async {
+                  final secureStore = await ref
+                      .read(walletsProvider.notifier)
+                      .getSecureStoreForWallet(context: context);
+                  await ref.read(walletsProvider.notifier).deployAccount(
+                        secureStore: secureStore,
+                        account: selectedAccount!,
+                      );
+                }
+              : null);
     } else {
       return const SizedBox.shrink();
     }

--- a/packages/wallet_kit/lib/widgets/deploy_account_button.dart
+++ b/packages/wallet_kit/lib/widgets/deploy_account_button.dart
@@ -7,6 +7,9 @@ class DeployAccountButton extends HookConsumerWidget {
     super.key,
   });
 
+  // ignore: constant_identifier_names
+  static const double MINIMUN_ETH_BALANCE = 0.00001;
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final selectedAccount = ref.watch(
@@ -15,9 +18,9 @@ class DeployAccountButton extends HookConsumerWidget {
     if (selectedAccount?.isDeployed == false) {
       final ethBalance =
           selectedAccount!.balances[TokenSymbol.ETH.name] ?? 0.00;
-      final enoughBalance = ethBalance >= 0.00001;
+      final enoughBalance = ethBalance >= MINIMUN_ETH_BALANCE;
       return PrimaryButton(
-          label: enoughBalance ? 'Deploy account' : 'Not enougth ETH',
+          label: enoughBalance ? 'Deploy account' : 'Not enough ETH',
           onPressed: enoughBalance
               ? () async {
                   final secureStore = await ref

--- a/packages/wallet_kit/lib/widgets/deploy_account_button.dart
+++ b/packages/wallet_kit/lib/widgets/deploy_account_button.dart
@@ -25,7 +25,7 @@ class DeployAccountButton extends HookConsumerWidget {
                       .getSecureStoreForWallet(context: context);
                   await ref.read(walletsProvider.notifier).deployAccount(
                         secureStore: secureStore,
-                        account: selectedAccount!,
+                        account: selectedAccount,
                       );
                 }
               : null);

--- a/packages/wallet_kit/lib/widgets/deploy_account_button.dart
+++ b/packages/wallet_kit/lib/widgets/deploy_account_button.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import '../wallet_kit.dart';
+
+class DeployAccountButton extends HookConsumerWidget {
+  const DeployAccountButton({
+    super.key,
+  });
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final selectedAccount = ref.watch(
+      walletsProvider.select((value) => value.selectedAccount),
+    );
+    if (selectedAccount?.isDeployed == false) {
+      return PrimaryButton(
+          label: 'Deploy account',
+          onPressed: () async {
+            final secureStore = await ref
+                .read(walletsProvider.notifier)
+                .getSecureStoreForWallet(context: context);
+            await ref.read(walletsProvider.notifier).deployAccount(
+                  secureStore: secureStore,
+                  account: selectedAccount!,
+                );
+          });
+    } else {
+      return const SizedBox.shrink();
+    }
+  }
+}

--- a/packages/wallet_kit/lib/widgets/index.dart
+++ b/packages/wallet_kit/lib/widgets/index.dart
@@ -8,3 +8,4 @@ export 'send_eth_button.dart';
 export 'account_address.dart';
 export 'nft_list.dart';
 export 'nft_details.dart';
+export 'deploy_account_button.dart';

--- a/packages/wallet_kit/lib/widgets/send_eth_button.dart
+++ b/packages/wallet_kit/lib/widgets/send_eth_button.dart
@@ -16,22 +16,25 @@ class SendEthButton extends HookConsumerWidget {
     final selectedAccount = ref.watch(walletsProvider.select(
       (value) => value.selectedAccount,
     ));
+    if (selectedAccount == null) {
+      return const SizedBox.shrink();
+    }
+
     return PrimaryButton(
       label: 'Send',
-      onPressed: () async {
-        if (selectedAccount == null) {
-          throw Exception('Account is required');
-        }
-        final password = await showPasswordModal(context);
-        if (password == null) {
-          throw Exception('Password is required');
-        }
-        await sendEth(
-            account: selectedAccount,
-            password: password,
-            recipientAddress: recipientAddress,
-            amount: 0.001);
-      },
+      onPressed: selectedAccount.isDeployed
+          ? () async {
+              final password = await showPasswordModal(context);
+              if (password == null) {
+                throw Exception('Password is required');
+              }
+              await sendEth(
+                  account: selectedAccount,
+                  password: password,
+                  recipientAddress: recipientAddress,
+                  amount: 0.001);
+            }
+          : null,
     );
   }
 }

--- a/packages/wallet_kit/lib/widgets/token_list.dart
+++ b/packages/wallet_kit/lib/widgets/token_list.dart
@@ -14,10 +14,15 @@ class TokenList extends HookConsumerWidget {
 
     useEffect(() {
       if (selectedAccount != null) {
-        ref.read(walletsProvider.notifier).refreshEthBalance(
-              selectedAccount.walletId,
-              selectedAccount.id,
-            );
+        ref.read(walletsProvider.notifier)
+          ..refreshEthBalance(
+            selectedAccount.walletId,
+            selectedAccount.id,
+          )
+          ..refreshStrkBalance(
+            selectedAccount.walletId,
+            selectedAccount.id,
+          );
       }
       return;
     }, [selectedAccount?.id]);

--- a/packages/wallet_kit/lib/widgets/token_list.dart
+++ b/packages/wallet_kit/lib/widgets/token_list.dart
@@ -44,7 +44,7 @@ class TokenListItem extends HookConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final balance = ref.watch(walletsProvider.select(
-      (value) => value.selectedAccount?.balances[symbol] ?? 0.00,
+      (value) => value.selectedAccount?.balances[symbol.name] ?? 0.00,
     ));
 
     return Padding(

--- a/packages/wallet_kit/lib/widgets/wallet_list.dart
+++ b/packages/wallet_kit/lib/widgets/wallet_list.dart
@@ -130,7 +130,29 @@ class WalletCell extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final controller = useState<ExpandableController?>(null);
+    useEffect(() {
+      controller.value = ExpandableController();
+      return () => controller.value?.dispose();
+    }, []);
+
+    useEffect(() {
+      if (controller.value != null) {
+        void onExpanded() {
+          if (controller.value!.expanded) {
+            wallet.accounts.forEach((key, value) => ref
+                .read(walletsProvider.notifier)
+                .refreshEthBalance(value.walletId, value.id));
+          }
+        }
+
+        controller.value!.addListener(onExpanded);
+        return () => controller.value?.removeListener(onExpanded);
+      }
+    }, [controller.value]);
+
     return ExpandableNotifier(
+      controller: controller.value,
       child: Container(
         decoration: BoxDecoration(
           color: Colors.grey.withValues(alpha: 0.1),

--- a/packages/wallet_kit/lib/widgets/wallet_list.dart
+++ b/packages/wallet_kit/lib/widgets/wallet_list.dart
@@ -148,6 +148,8 @@ class WalletCell extends HookConsumerWidget {
 
         controller.value!.addListener(onExpanded);
         return () => controller.value?.removeListener(onExpanded);
+      } else {
+        return null;
       }
     }, [controller.value]);
 

--- a/packages/wallet_kit/lib/widgets/wallet_list.dart
+++ b/packages/wallet_kit/lib/widgets/wallet_list.dart
@@ -140,11 +140,11 @@ class WalletCell extends HookConsumerWidget {
       if (controller.value != null) {
         void onExpanded() {
           if (controller.value!.expanded) {
-            wallet.accounts.forEach((key, value) {
-              ref.read(walletsProvider.notifier)
-                ..refreshEthBalance(value.walletId, value.id)
-                ..refreshStrkBalance(value.walletId, value.id);
-            });
+            wallet.accounts.forEach(
+              (key, value) => ref
+                  .read(walletsProvider.notifier)
+                  .refreshAccount(value.walletId, value.id),
+            );
           }
         }
 

--- a/packages/wallet_kit/lib/widgets/wallet_list.dart
+++ b/packages/wallet_kit/lib/widgets/wallet_list.dart
@@ -205,12 +205,15 @@ class AccountCell extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final isDeployed = account.isDeployed;
     return FilledButton.tonal(
       style: ButtonStyle(
         padding: WidgetStateProperty.all(
           const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
         ),
-        backgroundColor: WidgetStateProperty.all(Colors.white),
+        backgroundColor: WidgetStateProperty.all(isDeployed
+            ? Colors.white
+            : Colors.grey.shade400.withValues(alpha: 0.5)),
         side: WidgetStateProperty.all(BorderSide.none),
         overlayColor:
             WidgetStateProperty.all(Colors.grey.withValues(alpha: 0.05)),

--- a/packages/wallet_kit/lib/widgets/wallet_list.dart
+++ b/packages/wallet_kit/lib/widgets/wallet_list.dart
@@ -268,7 +268,8 @@ class AccountCell extends HookConsumerWidget {
               Text(formatAddress(account.address)),
             ],
           ),
-          Text('${(account.balances['ETH'] ?? 0).toString()} ETH'),
+          Text(
+              '${(account.balances[TokenSymbol.ETH.name] ?? 0).toString()} ETH'),
         ],
       ),
     );

--- a/packages/wallet_kit/lib/widgets/wallet_list.dart
+++ b/packages/wallet_kit/lib/widgets/wallet_list.dart
@@ -140,9 +140,11 @@ class WalletCell extends HookConsumerWidget {
       if (controller.value != null) {
         void onExpanded() {
           if (controller.value!.expanded) {
-            wallet.accounts.forEach((key, value) => ref
-                .read(walletsProvider.notifier)
-                .refreshEthBalance(value.walletId, value.id));
+            wallet.accounts.forEach((key, value) {
+              ref.read(walletsProvider.notifier)
+                ..refreshEthBalance(value.walletId, value.id)
+                ..refreshStrkBalance(value.walletId, value.id);
+            });
           }
         }
 


### PR DESCRIPTION
- docs: `secure_store` require Android minimum SDK version set to at least 23
- wallet_kit: add deploy account support
- wallet_kit: refresh ETH and STRK balances when wallet is expanded
- wallet_kit: disable `Disable deploy button` when ETH balance is not enough
- docs: add information about devnet classhash and minting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added account deployment functionality for mobile wallet.
  - Introduced `DeployAccountButton` for deploying undeployed accounts.
  - Enhanced balance refresh for Ethereum and STRK tokens.

- **Improvements**
  - Updated Android SDK compatibility to at least version 23.
  - Added optional biometric support for Android.
  - Improved error handling for account and transaction management.
  - Enhanced interactivity and visual feedback in wallet management components.

- **Documentation**
  - Updated mobile wallet tutorial with new deployment instructions.
  - Added guidance for minting ETH for transaction fees.

- **Compatibility**
  - Updated `ACCOUNT_CLASS_HASH` for `starknet-devnet`.
  - Adjusted token symbol handling for better maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->