### PR TITLE
fix: build wallet_app example with java 21

### DIFF
--- a/.env.ci
+++ b/.env.ci
@@ -1,3 +1,4 @@
 FLUTTER_VERSION=3.27.1
+JAVA_VERSION=21
 STARKNET_RPC=http://localhost:5050
 DEVNET_DUMP_PATH=/devnet-dump.json

--- a/.github/actions/android-setup/action.yaml
+++ b/.github/actions/android-setup/action.yaml
@@ -1,4 +1,5 @@
 name: 'Setup environment to build Android application'
+description: 'Configures Java and Android SDK for building Android applications'
 
 runs:
   using: "composite"

--- a/.github/actions/android-setup/action.yaml
+++ b/.github/actions/android-setup/action.yaml
@@ -1,0 +1,17 @@
+name: 'Setup environment to build Android application'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Dotenv Action
+      id: load-env
+      uses: falti/dotenv-action@v1.1.4
+      with:
+        path: .env.ci
+    - name: Java setup
+      uses: actions/setup-java@v4
+      with:
+        distribution: 'zulu'
+        java-version: ${{ steps.load-env.outputs.java_version }}
+    - name: Setup Android SDK
+      uses: android-actions/setup-android@v3

--- a/.github/workflows/build-android-examples.yaml
+++ b/.github/workflows/build-android-examples.yaml
@@ -1,4 +1,4 @@
-name: Build androind examples
+name: Build android examples
 
 on:
   workflow_dispatch:
@@ -14,5 +14,5 @@ jobs:
         uses: ./.github/actions/android-setup
       - uses: bluefireteam/melos-action@v3
       - name: Build wallet_app example
-        run : flutter build appbundle
+        run: flutter build appbundle
         working-directory: ./examples/wallet_app

--- a/.github/workflows/build-android-examples.yaml
+++ b/.github/workflows/build-android-examples.yaml
@@ -1,0 +1,18 @@
+name: Build androind examples
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-wallet-app-example:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Flutter setup
+        uses: ./.github/actions/flutter-setup
+      - name: Java/Android setup
+        uses: ./.github/actions/android-setup
+      - uses: bluefireteam/melos-action@v3
+      - name: Build wallet_app example
+        run : flutter build appbundle
+        working-directory: ./examples/wallet_app

--- a/examples/wallet_app/android/settings.gradle
+++ b/examples/wallet_app/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.1.0" apply false
+    id "com.android.application" version "8.2.1" apply false
     id "org.jetbrains.kotlin.android" version "1.9.10" apply false
 }
 


### PR DESCRIPTION
- Add job to build wallet_app example on Android

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added GitHub Actions workflow for Android application build process
	- Introduced environment configuration for Java version 21
	- Created automated setup for Android development environment

- **Chores**
	- Configured CI/CD pipeline for building Android examples
	- Set up Flutter and Android dependency management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->