### PR TITLE
fix: starknet counter example

### DIFF
--- a/.github/workflows/build-android-examples.yaml
+++ b/.github/workflows/build-android-examples.yaml
@@ -16,3 +16,6 @@ jobs:
       - name: Build wallet_app example
         run: flutter build appbundle
         working-directory: ./examples/wallet_app
+      - name: Build starknet_counter example
+        run: flutter build appbundle
+        working-directory: ./examples/starknet_counter

--- a/docs/examples/starknet-counter.mdx
+++ b/docs/examples/starknet-counter.mdx
@@ -217,7 +217,6 @@ dependencies:
     sdk: flutter
   cupertino_icons: ^1.0.2
   starknet:
-  starknet_flutter:
   flutter_lints: ^2.0.0
   build_runner: ^2.4.6
   starknet_provider:

--- a/examples/starknet_counter/android/app/build.gradle
+++ b/examples/starknet_counter/android/app/build.gradle
@@ -63,5 +63,3 @@ android {
 flutter {
     source '../..'
 }
-
-dependencies {}

--- a/examples/starknet_counter/android/build.gradle
+++ b/examples/starknet_counter/android/build.gradle
@@ -1,16 +1,3 @@
-buildscript {
-    ext.kotlin_version = '1.7.10'
-    repositories {
-        google()
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.0'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    }
-}
-
 allprojects {
     repositories {
         google()

--- a/examples/starknet_counter/android/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/starknet_counter/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-all.zip

--- a/examples/starknet_counter/android/settings.gradle
+++ b/examples/starknet_counter/android/settings.gradle
@@ -5,16 +5,21 @@ pluginManagement {
         def flutterSdkPath = properties.getProperty("flutter.sdk")
         assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
         return flutterSdkPath
-    }
-    settings.ext.flutterSdkPath = flutterSdkPath()
+    }()
 
-    includeBuild("${settings.ext.flutterSdkPath}/packages/flutter_tools/gradle")
+    includeBuild("$flutterSdkPath/packages/flutter_tools/gradle")
 
-    plugins {
-        id "dev.flutter.flutter-gradle-plugin" version "1.0.0" apply false
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
     }
 }
 
-include ":app"
+plugins {
+    id "dev.flutter.flutter-plugin-loader" version "1.0.0"
+    id "com.android.application" version "8.2.1" apply false
+    id "org.jetbrains.kotlin.android" version "1.9.10" apply false
+}
 
-apply from: "${settings.ext.flutterSdkPath}/packages/flutter_tools/gradle/app_plugin_loader.gradle"
+include ":app"

--- a/examples/starknet_counter/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/examples/starknet_counter/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,12 +5,6 @@
 import FlutterMacOS
 import Foundation
 
-import mobile_scanner
-import path_provider_foundation
-import starknet_flutter
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
-  MobileScannerPlugin.register(with: registry.registrar(forPlugin: "MobileScannerPlugin"))
-  PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
-  StarknetFlutterPlugin.register(with: registry.registrar(forPlugin: "StarknetFlutterPlugin"))
 }

--- a/examples/starknet_counter/pubspec.yaml
+++ b/examples/starknet_counter/pubspec.yaml
@@ -26,7 +26,6 @@ dependencies:
     sdk: flutter
   cupertino_icons: ^1.0.2
   starknet:
-  starknet_flutter:
   flutter_lints: ^2.0.0
   build_runner: ^2.4.6
   starknet_provider:


### PR DESCRIPTION
- Fix `starknet_counter` example android build with java 21
- Remove obsolete `starknet_flutter` from starknet_counter pubspec.yaml example


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added GitHub Actions workflow step to build Starknet Counter Android example

- **Dependency Updates**
	- Removed `starknet_flutter` dependency
	- Updated Gradle version to 8.3
	- Added new dependencies for Starknet integration

- **Build Configuration**
	- Restructured Android build and settings configurations
	- Updated plugin and repository settings

- **Documentation**
	- Enhanced documentation for Starknet Counter Flutter project

<!-- end of auto-generated comment: release notes by coderabbit.ai -->