### PR TITLE
docs: update JSON RPC 0.7.1 support

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -8,50 +8,11 @@ The goal of this SDK is to be able to interact with StarkNet smart contracts in 
 ## StarkNet Features Compatibility
 
 ### Transaction
-
 | Feature        | State              | Version |
 | -------------- | ------------------ | ------- |
 | invoke         | ✅ | 0, 1, 3    |
 | declare        | ✅ | 1, 2, 3    |
 | deploy_account | ✅ | 1, 3       |
 
-### Supported RPC methods for JSON RPC v0.7.1
-
-| Feature                                  | State              |
-| ---------------------------------------- | ------------------ |
-| **Read**                                 |
-| starknet_getBlockWithTxHashes            | ✅ |
-| starknet_getBlockWithTxs                 | ✅ |
-| starknet_getStateUpdate                  | ✅ |
-| starknet_getStorageAt                    | ✅ |
-| starknet_getTransactionByHash            | ✅ |
-| starknet_getTransactionByBlockIdAndIndex | ✅ |
-| starknet_getTransactionReceipt           | ✅ |
-| starknet_getClass                        | ✅ |
-| starknet_getClassHashAt                  | ✅ |
-| starknet_getClassAt                      | ✅ |
-| starknet_getBlockTransactionCount        | ✅ |
-| starknet_call                            | ✅ |
-| starknet_estimateFee                     | ✅ |
-| starknet_blockNumber                     | ✅ |
-| starknet_blockHashAndNumber              | ✅ |
-| starknet_chainId                         | ✅ |
-| starknet_pendingTransactions             | ✅ |
-| starknet_syncing                         | ✅ |
-| starknet_getEvents                       | ✅ |
-| starknet_getNonce                        | ✅ |
-| **Write**                                |
-| starknet_addInvokeTransaction            | ✅ |
-| starknet_addDeclareTransaction           | ✅ |
-| starknet_addDeployAccountTransaction     | ✅ |
-
-### Source code generation from contract ABI 
-
-| Feature      | Cairo 0 (legacy)   | Cairo 1            | Cairo 2            |
-|--------------|--------------------|--------------------|--------------------|
-| call         |  ✅                |  ✅                | ❌                 |
-| invoke       |  ✅                |  ✅                | ❌                 |
-| core types   |  ✅                |  🚧                | ❌                 |
-| custom types |  ✅                |  🚧                | ❌                 |
-| event        |  ❌                |  ❌                | ❌                 |
-
+### Supported JSON RPC version: 0.7.1
+[See Starknet Provider supported methods](/packages/starknet-provider#supported-json-rpc-methods)

--- a/docs/packages/starknet-builder.mdx
+++ b/docs/packages/starknet-builder.mdx
@@ -1,3 +1,14 @@
 # Starknet Builder Package
 
 **DEPRECATED PACKAGE**
+
+### Source code generation from contract ABI 
+
+| Feature      | Cairo 0 (legacy)   | Cairo 1            | Cairo 2            |
+|--------------|--------------------|--------------------|--------------------|
+| call         |  ✅                |  ✅                | ❌                 |
+| invoke       |  ✅                |  ✅                | ❌                 |
+| core types   |  ✅                |  🚧                | ❌                 |
+| custom types |  ✅                |  🚧                | ❌                 |
+| event        |  ❌                |  ❌                | ❌                 |
+

--- a/docs/packages/starknet-provider.mdx
+++ b/docs/packages/starknet-provider.mdx
@@ -1,4 +1,69 @@
-# Call read-only method
+# Starknet Provider
+
+A Dart package for interacting with Starknet node using JSON-RPC, following the [Starknet JSON-RPC specification](https://github.com/starkware-libs/starknet-specs.git).
+
+[Package documentation](https://pub.dev/documentation/starknet_provider/latest/)
+
+## Transaction support
+
+| Feature        | State              | Version |
+| -------------- | ------------------ | ------- |
+| invoke         | ✅                 | 0, 1, 3    |
+| declare        | ✅                 | 1, 2, 3    |
+| deploy_account | ✅                 | 1, 3       |
+
+## Supported JSON RPC methods
+
+### Version: 0.7.1
+
+### Read methods
+
+Name of methods have been extracted from [starknet-specs](https://github.com/starkware-libs/starknet-specs.git) with the following command:
+```bash
+jq .methods[].name ../starknet-specs/api/starknet_api_openrpc.json
+```
+| Name                                       | Implemented  |              
+| ------------------------------------------ | ------------ |
+| starknet_specVersion                       | ❌           |
+| starknet_getBlockWithTxHashes              | ✅           |
+| starknet_getBlockWithTxs                   | ✅           |
+| starknet_getBlockWithReceipts              | ❌           |
+| starknet_getStateUpdate                    | ✅           |
+| starknet_getStorageAt                      | ✅           |
+| starknet_getTransactionStatus              | ❌           |
+| starknet_getTransactionByHash              | ✅           |
+| starknet_getTransactionByBlockIdAndIndex   | ✅           |
+| starknet_getTransactionReceipt             | ✅           |
+| starknet_getClass                          | ✅           |
+| starknet_getClassHashAt                    | ✅           |
+| starknet_getClassAt                        | ✅           |
+| starknet_getBlockTransactionCount          | ✅           |
+| starknet_call                              | ✅           |
+| starknet_estimateFee                       | ✅           |
+| starknet_estimateMessageFee                | ❌           |
+| starknet_blockNumber                       | ✅           |
+| starknet_blockHashAndNumber                | ✅           |
+| starknet_chainId                           | ✅           |
+| starknet_syncing                           | ✅           |
+| starknet_getEvents                         | ✅           |
+| starknet_getNonce                          | ✅           |
+
+### Write methods
+
+Name of methods have been extracted from [starknet-specs](https://github.com/starkware-libs/starknet-specs.git) with the following command:
+```bash
+jq .methods[].name ../starknet-specs/api/starknet_write_api.json
+```
+
+| Name                                       | Implemented  |              
+|--------------------------------------------|--------------|
+| starknet_addInvokeTransaction              | ✅           |
+| starknet_addDeclareTransaction             | ✅           |
+| starknet_addDeployAccountTransaction       | ✅           |
+
+
+## Usage
+### Call read-only method
 
 ```dart
 import 'package:starknet/starknet.dart';

--- a/packages/starknet_provider/README.md
+++ b/packages/starknet_provider/README.md
@@ -1,11 +1,60 @@
-# Starknet provider
+# Starknet Provider
 
-Starknet provider for Dart and Flutter applications
+A Dart package for interacting with Starknet node using JSON-RPC, following the [Starknet JSON-RPC specification](https://github.com/starkware-libs/starknet-specs.git).
 
-### Transaction support
+
+## Transaction support
 
 | Feature        | State              | Version |
 | -------------- | ------------------ | ------- |
-| invoke         | ✅ | 0, 1, 3    |
-| declare        | ✅ | 1, 2, 3    |
-| deploy_account | ✅ | 1, 3       |
+| invoke         | ✅                 | 0, 1, 3    |
+| declare        | ✅                 | 1, 2, 3    |
+| deploy_account | ✅                 | 1, 3       |
+
+## Supported JSON RPC version: 0.7.1
+
+### Read methods
+
+Name of methods have been extracted from [starknet-specs](https://github.com/starkware-libs/starknet-specs.git) with the following command:
+```bash
+jq .methods[].name ../starknet-specs/api/starknet_api_openrpc.json
+```
+| Name                                       | Implemented  |              
+| ------------------------------------------ | ------------ |
+| starknet_specVersion                       | ❌           |
+| starknet_getBlockWithTxHashes              | ✅           |
+| starknet_getBlockWithTxs                   | ✅           |
+| starknet_getBlockWithReceipts              | ❌           |
+| starknet_getStateUpdate                    | ✅           |
+| starknet_getStorageAt                      | ✅           |
+| starknet_getTransactionStatus              | ❌           |
+| starknet_getTransactionByHash              | ✅           |
+| starknet_getTransactionByBlockIdAndIndex   | ✅           |
+| starknet_getTransactionReceipt             | ✅           |
+| starknet_getClass                          | ✅           |
+| starknet_getClassHashAt                    | ✅           |
+| starknet_getClassAt                        | ✅           |
+| starknet_getBlockTransactionCount          | ✅           |
+| starknet_call                              | ✅           |
+| starknet_estimateFee                       | ✅           |
+| starknet_estimateMessageFee                | ❌           |
+| starknet_blockNumber                       | ✅           |
+| starknet_blockHashAndNumber                | ✅           |
+| starknet_chainId                           | ✅           |
+| starknet_syncing                           | ✅           |
+| starknet_getEvents                         | ✅           |
+| starknet_getNonce                          | ✅           |
+
+### Write methods
+
+Name of methods have been extracted from [starknet-specs](https://github.com/starkware-libs/starknet-specs.git) with the following command:
+```bash
+jq .methods[].name ../starknet-specs/api/starknet_write_api.json
+```
+
+| Name                                       | Implemented  |              
+|--------------------------------------------|--------------|
+| starknet_addInvokeTransaction              | ✅           |
+| starknet_addDeclareTransaction             | ✅           |
+| starknet_addDeployAccountTransaction       | ✅           |
+


### PR DESCRIPTION
- Update documentation with JSON RPC 0.7.1 supported methods
- Close #463 
- Add link to starknet_provider pub.dev documentation: #460 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated JSON RPC support details by replacing a detailed methods table with a concise reference and link.
  - Added a new section on contract ABI source code generation with a comparative feature table across Cairo versions.
  - Enhanced the provider documentation with detailed transaction support information and practical usage examples.
  - Improved the README with a refined title, expanded description, and clearer guidance on supported JSON-RPC features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->