### PR TITLE
fix(starknet_provider): add missing JSON RPC error code 41 

### DIFF
--- a/packages/starknet_provider/lib/src/model/json_rpc_api_error.dart
+++ b/packages/starknet_provider/lib/src/model/json_rpc_api_error.dart
@@ -48,6 +48,8 @@ enum JsonRpcApiErrorCode {
   TOO_MANY_KEYS_IN_FILTER, // new in spec 0.3.0
   @JsonValue(40)
   CONTRACT_ERROR,
+  @JsonValue(41)
+  TRANSACTION_EXECUTION_ERROR,
   @JsonValue(50)
   INVALID_CONTRACT_CLASS, // from pathfinder code
   @JsonValue(51)

--- a/packages/starknet_provider/lib/src/model/json_rpc_api_error.g.dart
+++ b/packages/starknet_provider/lib/src/model/json_rpc_api_error.g.dart
@@ -36,6 +36,7 @@ const _$JsonRpcApiErrorCodeEnumMap = {
   JsonRpcApiErrorCode.INVALID_CONTINUATION_TOKEN: 33,
   JsonRpcApiErrorCode.TOO_MANY_KEYS_IN_FILTER: 34,
   JsonRpcApiErrorCode.CONTRACT_ERROR: 40,
+  JsonRpcApiErrorCode.TRANSACTION_EXECUTION_ERROR: 41,
   JsonRpcApiErrorCode.INVALID_CONTRACT_CLASS: 50,
   JsonRpcApiErrorCode.CLASS_ALREADY_DECLARED: 51,
   JsonRpcApiErrorCode.INVALID_TRANSACTION_NONCE: 52,


### PR DESCRIPTION
- JSON RPC error code 41 (TRANSACTION_EXECUTION_ERROR) was missing

[JSON RPC spec](https://github.com/starkware-libs/starknet-specs/blob/v0.7.0/api/starknet_api_openrpc.json#L3964)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced error handling by introducing a dedicated indicator for transaction execution failures. This improvement provides clearer feedback when a transaction issue occurs, helping to diagnose and resolve problems more effectively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->