### PR TITLE
docs: remove 'get paid' mention

### DIFF
--- a/docs/how-to-contribute.mdx
+++ b/docs/how-to-contribute.mdx
@@ -1,4 +1,4 @@
-# How to contribute (and get paid)
+# How to contribute
 
 **starknet.dart** is a dart package allowing any dart program (mainly Flutter apps) to communicate with the [Starknet](https://starknet.io/docs/) blockchain.
 
@@ -16,13 +16,13 @@ If you want to contribute to the web3 adoption and more specifically Starknet on
 
 ### To become a core contributor
 
-After a few qualitative contributions, we'll probably offer you to join the core team to become a maintainer of the project and get paid for your work.
+After a few qualitative contributions, we'll probably offer you to join the core team to become a maintainer of the project.
 
 If you want to contribute to the project, you can follow the steps below:
 
 1. Join our [telegram group](https://t.me/+CWezjfLIRYc0MDY0) and introduce yourself.
 2. We'll let you know what are good issues to start with.
-3. Create your account on [Only Dust](https://app.onlydust.com/p/starknetdart) and receive your first payment.
+3. Create your account on [Only Dust](https://app.onlydust.com/p/starknetdart).
 
 ## How to set up your dev env
 


### PR DESCRIPTION
I have removed the 'get paid' mention since contributions will not always be rewarded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Removed references to financial compensation in the contribution guidelines, emphasizing the opportunity to become a maintainer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->