### PR TITLE
fix: Ensure maxGasTokenAmount is computed with current gas price

### DIFF
--- a/packages/avnu_provider/pubspec.yaml
+++ b/packages/avnu_provider/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   http: ^1.3.0
   json_annotation: ^4.9.0
   pointycastle: ^3.9.1
+  starknet_provider: ^0.1.2+1
 
 dev_dependencies:
   build_runner: ^2.4.15

--- a/packages/avnu_provider/test/integration/provider_test.dart
+++ b/packages/avnu_provider/test/integration/provider_test.dart
@@ -2,6 +2,7 @@ import 'package:starknet/starknet.dart';
 import 'package:avnu_provider/avnu_provider.dart';
 import 'package:test/test.dart';
 import 'dart:convert';
+import 'package:starknet_provider/starknet_provider.dart';
 
 import '../utils.dart';
 
@@ -34,6 +35,9 @@ void main() {
     final sepoliaAccount0 = getAccount(
       accountAddress: sepoliaAccount0Address,
       privateKey: sepoliaAccount0PrivateKey,
+      nodeUri:
+          Uri.parse('https://starknet-sepolia.public.blastapi.io/rpc/v0_7'),
+      chainId: Felt.fromString('SN_SEPOLIA'),
     );
 
     setUp(() {
@@ -59,9 +63,30 @@ void main() {
             ]
           }
         ];
+
+        final functionCalls = calls
+            .map((call) => FunctionCall(
+                  contractAddress:
+                      Felt.fromHexString(call['contractAddress'] as String),
+                  entryPointSelector:
+                      getSelectorByName(call['entrypoint'] as String),
+                  calldata: (call['calldata'] as List<String>)
+                      .map((data) => Felt.fromHexString(data))
+                      .toList(),
+                ))
+            .toList();
+
         final gasTokenAddress =
             '0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d';
-        final maxGasTokenAmount = '0xFC3F02C221B000';
+        // Get maxFee as hex string
+        final maxGasTokenAmount =
+            (await sepoliaAccount0.getEstimateMaxFeeForInvokeTx(
+          functionCalls: functionCalls,
+          useSTRKFee: true,
+        ))
+                .maxFee
+                .toHexString();
+
         //just for testing, we hardcode the account class hash to the ArgentX account class hash
         //in a real scenario, we would get the account class hash from the Starknetprovider
         final accountClassHash =
@@ -326,6 +351,9 @@ void main() {
     final sepoliaAccount0 = getAccount(
       accountAddress: sepoliaAccount0Address,
       privateKey: sepoliaAccount0PrivateKey,
+      nodeUri:
+          Uri.parse('https://starknet-sepolia.public.blastapi.io/rpc/v0_7'),
+      chainId: Felt.fromString('SN_SEPOLIA'),
     );
 
     setUpAll(() {
@@ -352,6 +380,8 @@ void main() {
       ];
       final gasTokenAddress =
           '0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d';
+      // we set a fix amount of gas to be paid for the transaction just for testing
+      // invalid contractAddress error.
       final maxGasTokenAmount = '0xFC3F02C221B000';
       //just for testing, we hardcode the account class hash to the ArgentX account class hash
       //in a real scenario, we would get the account class hash from the Starknetprovider
@@ -383,9 +413,27 @@ void main() {
           ]
         }
       ];
+      final functionCalls = calls
+          .map((call) => FunctionCall(
+                contractAddress:
+                    Felt.fromHexString(call['contractAddress'] as String),
+                entryPointSelector:
+                    getSelectorByName(call['entrypoint'] as String),
+                calldata: (call['calldata'] as List<String>)
+                    .map((data) => Felt.fromHexString(data))
+                    .toList(),
+              ))
+          .toList();
       final gasTokenAddress =
           '0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d';
-      final maxGasTokenAmount = '0xFC3F02C221B000';
+      // Get maxFee as hex string
+      final maxGasTokenAmount =
+          (await sepoliaAccount0.getEstimateMaxFeeForInvokeTx(
+        functionCalls: functionCalls,
+        useSTRKFee: true,
+      ))
+              .maxFee
+              .toHexString();
       //just for testing, we hardcode the account class hash to the ArgentX account class hash
       //in a real scenario, we would get the account class hash from the Starknetprovider
       final accountClassHash =


### PR DESCRIPTION
Fix avnu package failing test when hardcoded maxGasTokenAmount is lower then gas price. Now, we estimated gas price with getEstimateMaxFeeForInvokeTx function.

Close issue #474 

Please, before commit read Issue #474 comments related to list data types.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - **Blockchain Integration:** A new dependency has been introduced to bolster network connectivity, resulting in a more seamless blockchain experience.
  - **Dynamic Fee Estimation:** Transaction processing now benefits from real-time fee calculations instead of fixed values, ensuring more accurate and reliable fee assessments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->