### PR TITLE
test(starknet_provider): reenable some tests disabled due to bug in devnet 0.0.7

### DIFF
--- a/packages/starknet_provider/test/integration/read_provider_test.dart
+++ b/packages/starknet_provider/test/integration/read_provider_test.dart
@@ -193,9 +193,7 @@ void main() {
             result: (result) {
               expect(result, Felt.fromHexString("0x455448")); // ETH
             });
-      },
-          skip:
-              true); // FIXME after devnet 0.0.8 release: https://github.com/0xSpaceShard/starknet-devnet-rs/issues/544
+      }, skip: false);
 
       test('returns the value of the storage at the given address and key',
           () async {
@@ -630,9 +628,7 @@ void main() {
           result: (result) => fail("Should fail"),
         );
       });
-    },
-        skip:
-            true); // FIXME after devnet 0.0.8 release: https://github.com/0xSpaceShard/starknet-devnet-rs/issues/496
+    }, skip: false);
 
     group('starknet_getClass', () {
       test('returns contract class definition for a known class hash (cairo 0)',
@@ -941,9 +937,7 @@ void main() {
           },
         );
       });
-    },
-        skip:
-            true); // FIXME after devnet 0.0.8 release https://github.com/0xSpaceShard/starknet-devnet-rs/issues/498
+    }, skip: false);
 
     group('starknet_pendingTransactions', () {
       test('returns not supported error for pendingTransactions', () async {


### PR DESCRIPTION
Some tests were disabled due to bug in starknet-devnet 0.0.7 implementation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Re-enabled tests that were previously skipped to ensure complete verification of storage retrieval, transaction details, and class validations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->