### PR TITLE
test: add missing test for TRANSACTION_EXECUTION_ERROR in starknet_provider

### DIFF
--- a/packages/starknet_provider/test/integration/read_provider_test.dart
+++ b/packages/starknet_provider/test/integration/read_provider_test.dart
@@ -1130,6 +1130,32 @@ void main() {
           },
         );
       });
+
+      test('returns TRANSACTION_EXECUTION_ERROR with invalid nonce', () async {
+        final invalidBroadcastedInvokeTxnV3 =
+            broadcastedInvokeTxnV3.copyWith(nonce: Felt.fromHexString('0x0'));
+        EstimateFeeRequest estimateFeeRequest = EstimateFeeRequest(
+            request: [invalidBroadcastedInvokeTxnV3],
+            blockId: parentBlockId,
+            simulation_flags: []);
+
+        final response = await provider.estimateFee(estimateFeeRequest);
+
+        response.when(
+          error: (error) {
+            expect(error.code, JsonRpcApiErrorCode.TRANSACTION_EXECUTION_ERROR);
+            expect(error.message, 'Transaction execution error');
+            expect(error.errorData, isA<TransactionExecutionError>());
+            final errorData = error.errorData as TransactionExecutionError;
+            expect(errorData.data.transactionIndex, 0);
+            expect(errorData.data.executionError,
+                contains('Transaction validation has failed'));
+          },
+          result: (result) {
+            fail('Should fail.');
+          },
+        );
+      }, tags: ['integration']);
     });
 
     group('starknet_specVersion', () {

--- a/packages/starknet_provider/test/integration/read_provider_test.dart
+++ b/packages/starknet_provider/test/integration/read_provider_test.dart
@@ -1131,14 +1131,20 @@ void main() {
         );
       });
 
-      test('returns TRANSACTION_EXECUTION_ERROR with invalid nonce', () async {
+      test(
+          'returns TRANSACTION_EXECUTION_ERROR with invalid contract on sepolia',
+          () async {
         final invalidBroadcastedInvokeTxnV3 =
             broadcastedInvokeTxnV3.copyWith(nonce: Felt.fromHexString('0x0'));
         EstimateFeeRequest estimateFeeRequest = EstimateFeeRequest(
             request: [invalidBroadcastedInvokeTxnV3],
             blockId: parentBlockId,
             simulation_flags: []);
-
+        final providerHost = (provider as JsonRpcReadProvider).nodeUri.host;
+        if (['0.0.0.0', 'localhost', '127.0.0.1'].contains(providerHost)) {
+          print('This test is not available on localhost');
+          return true;
+        }
         final response = await provider.estimateFee(estimateFeeRequest);
 
         response.when(


### PR DESCRIPTION
Add missing test for TRANSACTION_EXECUTION_ERROR
Related PR: #502 
Close #484 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added an integration test to verify error handling when estimating the fee for a V3 invoke transaction with an invalid nonce.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->