### PR TITLE
Wallet_kit should check if account is deployed at startup

### DIFF
--- a/packages/wallet_kit/lib/utils/persisted_notifier_state.dart
+++ b/packages/wallet_kit/lib/utils/persisted_notifier_state.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:easy_debounce/easy_debounce.dart';
 import 'package:hive/hive.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:wallet_kit/utils/debug_print.dart';
 
 mixin PersistedState<T extends PersistableState> on AutoDisposeNotifier<T> {
   String get boxName;
@@ -14,13 +15,30 @@ mixin PersistedState<T extends PersistableState> on AutoDisposeNotifier<T> {
     persistState();
   }
 
+  /// Hook called after state is loaded from persistence but before it's set.
+  /// Override this to perform validation or migration logic.
+  /// Return `null` to prevent the loaded state from being applied.
+  Future<T?> onStateLoaded(T loadedState) async {
+    return loadedState;
+  }
+
   loadPersistedState() async {
     final box = await Hive.openBox<String>(boxName);
     final jsonString = box.get(boxName);
     if (jsonString == null) {
-      return null;
+      return;
     }
-    state = fromJson(jsonDecode(jsonString));
+    try {
+      T loadedState = fromJson(jsonDecode(jsonString));
+      T? validatedState = await onStateLoaded(loadedState);
+
+      if (validatedState != null) {
+        super.state = validatedState;
+      }
+    } catch (e, stackTrace) {
+      debugPrint(
+          "Error loading or validating persisted state for $boxName: $e\n$stackTrace");
+    }
   }
 
   persistState() async {

--- a/packages/wallet_provider/.gitignore
+++ b/packages/wallet_provider/.gitignore
@@ -1,0 +1,7 @@
+# https://dart.dev/guides/libraries/private-files
+# Created by `dart pub`
+.dart_tool/
+
+# Avoid committing pubspec.lock for library packages; see
+# https://dart.dev/guides/libraries/private-files#pubspeclock.
+pubspec.lock

--- a/packages/wallet_provider/.tool-versions
+++ b/packages/wallet_provider/.tool-versions
@@ -1,0 +1,1 @@
+starknet-devnet 0.1.2

--- a/packages/wallet_provider/CHANGELOG.md
+++ b/packages/wallet_provider/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 0.0.1+1
+
+- Initial version.

--- a/packages/wallet_provider/Implementation_notes.md
+++ b/packages/wallet_provider/Implementation_notes.md
@@ -1,0 +1,31 @@
+# Notes on Starknet Wallet API Implementation for starknet.dart
+
+## 1. Objective
+
+The goal was to study the Starknet Wallet API specification (based on `wallet_rpc.json`) and propose an implementation as a distinct Dart package (`wallet_provider`), usable within the `starknet.dart` ecosystem. This package should allow Dart applications to interact with a compatible Starknet wallet.
+
+## 2. Implementation Approach
+
+*   **Dedicated Package:** A new package, `wallet_provider`, was created by duplicating then modifying `starknet_provider` to isolate the logic specific to the Wallet API.
+*   **Data Models:** Data structures (requests, responses) defined in `wallet_rpc.json` were implemented in Dart using the `freezed` package to generate immutable and serializable classes (files in `lib/src/model/`).
+*   **Provider Class:** A `WalletProvider` class (`lib/src/provider.dart`) was created. It exposes typed methods corresponding to the Wallet API RPC calls (`wallet_supportedWalletApi`, `wallet_addInvokeTransaction`, etc.).
+*   **RPC Client:** A simple `JsonRpcClient` was implemented in `provider.dart` to handle sending JSON-RPC POST requests and basic deserialization of responses and errors.
+*   **Dependencies:** The package depends on `package:starknet` for fundamental types (`Felt`) and some shared complex types (`EntryPointsByType`). It also uses `package:http` for network calls.
+*   **Cleanup:** Models, providers, and tests related to the *standard* Starknet JSON-RPC API were removed from the `wallet_provider` package to focus it solely on the Wallet API.
+
+## 3. Discoveries and Key Points
+
+*   **Wallet API vs. Standard RPC API Distinction:** The Wallet API is a distinct set of JSON-RPC methods that does not replace the standard RPC API but complements it for interactions requiring user wallet action or information.
+*   **Model Generation:** The OpenRPC specification (`wallet_rpc.json`) is structured enough to allow for the generation (here, manually assisted) of type-safe Dart data models using `freezed`.
+*   **Dependency on External Types:** The implementation heavily relies on types defined in `package:starknet` (`Felt`, `EntryPointsByType`, etc.). Version compatibility and the clarity of exports from this package are crucial.
+*   **RPC Parameter Ambiguity:** The exact expected structure for parameters (`params` in the JSON-RPC request) is not always explicitly defined in the spec as being a positional list or a single object. The current implementation makes assumptions based on the order and apparent structure in `wallet_rpc.json`, but this might require adjustments based on actual wallet implementations.
+*   **`signTypedData` Complexity:** Signing typed data requires careful construction of the `TypedData` object, especially converting all message and domain values into their corresponding `Felt` type (short string encoding, integer/hex conversion, etc.) to match the types defined in the `types` structure.
+
+## 4. Challenges Encountered
+
+*   **Identifying Required Types (`ContractClass`):** There was initial confusion about the origin and correct definition of `ContractClass`, requiring determination of whether to use a local definition (from the old `starknet_provider`) or the one from the `starknet` package. Ultimately, a local definition based on the schema was created.
+
+## 5. Recommendations
+
+*   **Spec Clarification:** If possible, encourage clarification in the Wallet API specification regarding the expected structure of `params` for each method (positional list vs. object).
+*   **`TypedData` Utilities:** Consider adding utility functions (potentially in `package:starknet` or `wallet_provider`) to facilitate the correct construction of `TypedData` objects, especially for String -> Felt conversion according to EIP-712/Starknet rules.

--- a/packages/wallet_provider/LICENSE
+++ b/packages/wallet_provider/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Gabin Marignier
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/wallet_provider/README.md
+++ b/packages/wallet_provider/README.md
@@ -1,0 +1,119 @@
+# Starknet Wallet Provider
+
+This package is based on the official JSON-RPC specification available at: https://github.com/starkware-libs/starknet-specs/tree/master/wallet-api
+
+A Dart package for interacting with Starknet wallets, implementing the [Starknet Wallet API specification](https://github.com/starkware-libs/starknet-specs/tree/master/wallet-api).
+
+This package allows Dart applications (including Flutter) to request actions from a Starknet wallet installed by the user, such as requesting accounts, signing transactions, switching networks, etc.
+
+## Features
+
+Provides methods corresponding to the Starknet Wallet API specification, including:
+
+*   **Information & Permissions:**
+    *   `supportedWalletApi()`: Get supported Wallet API versions.
+    *   `supportedSpecs()`: Get supported Starknet JSON-RPC spec versions.
+    *   `getPermissions()`: Get existing permissions for the Dapp.
+    *   `requestAccounts()`: Request wallet account addresses.
+    *   `requestChainId()`: Request the current chain ID from the wallet.
+*   **Account & Network Management:**
+    *   `deploymentData()`: Request data needed to deploy the connected account.
+    *   `switchStarknetChain()`: Request to switch the wallet's active Starknet network.
+    *   `addStarknetChain()`: Request to add a new Starknet network configuration to the wallet.
+    *   `watchAsset()`: Request to add an ERC20 token to the wallet's tracked assets.
+*   **Transaction Submission:**
+    *   `addInvokeTransaction()`: Request the wallet to sign and submit an invoke transaction.
+    *   `addDeclareTransaction()`: Request the wallet to sign and submit a declare transaction.
+*   **Signing:**
+    *   `signTypedData()`: Request the wallet to sign typed data according to EIP-712 (Starknet variant).
+
+## Usage
+
+Import the package and create an instance of `WalletProvider`. The URI should point to the wallet's RPC endpoint (this typically requires wallet-specific discovery or injection, e.g., via a browser extension).
+
+```dart
+import 'package:wallet_provider/wallet_provider.dart';
+import 'package:starknet/starknet.dart'; // For Felt, etc.
+
+// Wallet endpoint URI - This needs to be provided by the wallet environment
+// Example placeholder:
+// final walletUri = Uri.parse('http://localhost:some_port'); // Or injected URI
+
+// Assuming walletUri is available
+// final provider = WalletProvider(walletUri);
+
+void main() async {
+  // Example: Get basic info (if wallet is available and Dapp is permitted)
+  // These might fail if called without a proper wallet connection context.
+  try {
+    // Replace with actual wallet URI when available
+    final provider = WalletProvider(Uri.parse('http://localhost:1234')); // Placeholder
+
+    final accounts = await provider.requestAccounts();
+    print('Connected accounts: $accounts');
+
+    if (accounts.isNotEmpty) {
+        final chainId = await provider.requestChainId();
+        print('Current chain ID: ${chainId.toHexString()}');
+
+        final permissions = await provider.getPermissions();
+        print('Dapp permissions: $permissions');
+    }
+
+    final supportedApis = await provider.supportedWalletApi();
+    print('Supported Wallet APIs: $supportedApis');
+
+     final supportedSpecs = await provider.supportedSpecs();
+    print('Supported Starknet RPC Specs: $supportedSpecs');
+
+    provider.close();
+  } catch (e) {
+    print('An error occurred: $e');
+  }
+}
+```
+
+**Note:** Interacting with a wallet usually involves a specific setup depending on the environment (browser extension, mobile wallet app). This package provides the low-level API calls; integrating it into a Dapp requires handling the connection and URI provision from the wallet.
+
+## Development Status
+
+This package is under development and follows the evolving Starknet Wallet API specification. Methods and models might change according to spec updates.
+
+## Technical Considerations
+
+### Type Safety
+
+This provider implementation adheres strongly to Dart's type-safety principles:
+
+*   **Typed Models:** All request parameters and response objects related to the Wallet API (e.g., `Asset`, `InvokeCall`, `TypedData`, `AccountDeploymentData`, `WalletError`) are defined using `freezed`. This ensures immutability and provides compile-time type checking, along with generated `fromJson`/`toJson` methods.
+*   **Enums:** Where applicable (e.g., `Permission`, `WalletErrorCode`), enums are used instead of raw strings or integers to improve code clarity and prevent typos.
+*   **Typed Methods:** The `WalletProvider` methods have clear, strongly-typed signatures for both input parameters and return values (e.g., `Future<List<Felt>>`, `Future<bool>`, `Future<AddInvokeTransactionResult>`).
+*   **Controlled `dynamic`:** The use of `dynamic` is primarily confined to the `JsonRpcClient` when receiving the raw JSON-RPC response. This `dynamic` result is immediately cast or parsed into a specific, typed object within the corresponding `WalletProvider` method, minimizing the risks associated with dynamic typing.
+
+### Interaction with Standard Starknet JSON-RPC
+
+The Wallet API and the standard Starknet JSON-RPC API (used for querying node data like block details, contract state, or submitting pre-signed transactions) serve distinct but complementary purposes:
+
+*   **Standard JSON-RPC API:** Primarily used by Dapps (or SDKs like `starknet.dart`'s `JsonRpcProvider`) to **read blockchain state** (`starknet_call`, `starknet_getStorageAt`, etc.) and **submit transactions that are already signed** (`starknet_addInvokeTransaction`). It connects to a Starknet node endpoint.
+*   **Wallet API (this provider):** Primarily used by Dapps to **request actions from the user's wallet**. This includes requesting account access (`wallet_requestAccounts`), asking the wallet to sign and submit transactions (`wallet_addInvokeTransaction`, `wallet_addDeclareTransaction`), signing typed data (`wallet_signTypedData`), or managing wallet state like switching chains (`wallet_switchStarknetChain`). It **delegates the signing process** to the wallet, which holds the user's private keys. It connects to an RPC endpoint exposed by the wallet itself.
+
+In a typical Dapp, both providers are often used: the standard provider for reading data and the wallet provider for initiating actions that require user interaction or signatures.
+
+### Error Handling
+
+The provider facilitates robust error handling:
+
+*   **Network & RPC Errors:** The underlying `JsonRpcClient` handles basic HTTP errors and JSON-RPC format errors by throwing generic `Exception`s.
+*   **Wallet-Specific Errors:** If the wallet returns a JSON-RPC error response (e.g., user rejected an operation, method not supported, invalid parameters), the `JsonRpcClient` parses this into a typed `WalletError` object (containing a `code` like `WalletErrorCode.userRefusedOp` and a `message`) and throws it.
+*   **Type Errors:** If the wallet's response structure doesn't match the expected format for a successful call (e.g., returning an integer where a list of strings is expected), a `TypeError` might be thrown during parsing/casting within the `WalletProvider` methods.
+*   **Dapp Responsibility:** The `WalletProvider` propagates these exceptions. It is the **responsibility of the consuming Dapp** to implement `try-catch` blocks around provider calls. Inside the `catch` block, the Dapp should inspect the exception type (`WalletError`, `TypeError`, `Exception`) and potentially the `WalletError.code` to determine the cause of the failure and implement appropriate user feedback or fallback logic (e.g., informing the user why an operation failed, disabling unsupported features). The provider itself does not implement complex internal fallback mechanisms.
+
+## Future Implementation Recommendations
+
+Based on the initial implementation and the nature of wallet interactions, here are potential areas for future development and improvement:
+
+*   **Wallet Connection/Discovery:** The current provider requires the wallet's RPC endpoint URI. Future work could involve integrating standard wallet discovery mechanisms (like WalletConnect, if applicable, or platform-specific solutions for browser extensions/mobile apps) to simplify the Dapp connection process.
+*   **Wallet Event Handling:** The Starknet Wallet API specification currently lacks standardized event notifications (e.g., for account or network changes). Monitoring the spec for updates and potentially supporting wallet-specific event mechanisms could enhance Dapp reactivity.
+*   **Enhanced Testing Strategies:** Providing utilities or guidance for mocking the `WalletProvider` (e.g., a `MockWalletProvider` class or mock server examples) would simplify unit and integration testing for Dapps.
+*   **Higher-Level Abstractions (Potential):** Consider creating a higher-level interface (e.g., `Signer` or `AccountInterface`) that could be implemented by both this `WalletProvider` (for delegated operations) and the existing `Account` class (for local private key operations). This could allow Dapps to write more generic code for interacting with Starknet, regardless of whether the user is using an external wallet or a local key.
+

--- a/packages/wallet_provider/analysis_options.yaml
+++ b/packages/wallet_provider/analysis_options.yaml
@@ -1,0 +1,6 @@
+include: package:lints/recommended.yaml
+
+analyzer:
+  errors:
+    invalid_annotation_target: ignore
+    non_constant_identifier_names: ignore

--- a/packages/wallet_provider/build.yaml
+++ b/packages/wallet_provider/build.yaml
@@ -1,0 +1,10 @@
+targets:
+  $default:
+    builders:
+      freezed:
+        options:
+          union_key: starkNetRuntimeTypeToRemove
+      json_serializable:
+        options:
+          explicit_to_json: true
+          field_rename: snake

--- a/packages/wallet_provider/dart_test.yaml
+++ b/packages/wallet_provider/dart_test.yaml
@@ -1,0 +1,2 @@
+tags:
+  unit:

--- a/packages/wallet_provider/example/wallet_provider_example.dart
+++ b/packages/wallet_provider/example/wallet_provider_example.dart
@@ -1,0 +1,181 @@
+import 'package:wallet_provider/wallet_provider.dart';
+// Hide StarkNet's TypedData to use the one defined in this package for wallet interactions
+import 'package:starknet/starknet.dart' hide TypedData;
+
+// IMPORTANT: To run this example, you need a running Starknet wallet
+// providing the Wallet API RPC endpoint. The URI below is a placeholder.
+// In a real Dapp, this URI would be injected by the wallet extension/environment.
+final walletUri =
+    Uri.parse('http://localhost:1234'); // REPLACE WITH ACTUAL WALLET URI
+
+// Helper to create a dummy Felt (replace with real values in practice)
+Felt felt(String hex) => Felt.fromHexString(hex);
+
+// Sepolia Chain ID
+final sepoliaChainId = Felt.fromHexString('0x534e5f5345504f4c4941');
+
+// Helper to create a dummy ContractClass (replace with actual data)
+ContractClass createDummyContractClass() {
+  // This is just a placeholder structure. In reality, you'd load this
+  // from a compiled contract JSON file.
+  return ContractClass(
+    sierraProgram: [felt('0x1'), felt('0x2')], // Dummy Sierra code
+    contractClassVersion: '0.1.0',
+    entryPointsByType: EntryPointsByType(
+      constructor: [SierraEntryPoint(selector: felt('0x11'), functionIdx: 0)],
+      external: [SierraEntryPoint(selector: felt('0x22'), functionIdx: 1)],
+      l1Handler: [],
+    ),
+    abi:
+        '[{"type": "function", "name": "dummy", "inputs": [], "outputs": []}]', // Dummy ABI
+  );
+}
+
+void main() async {
+  final provider = WalletProvider(walletUri);
+
+  print('--- Wallet Provider Example Scenario ---');
+
+  try {
+    // --- Step 1: Request Accounts ---
+    print('\n--- Step 1: Requesting Accounts ---');
+    List<Felt> accounts = [];
+    try {
+      // This usually triggers a wallet popup if not already approved
+      accounts = await provider.requestAccounts();
+      print('Available Accounts: $accounts');
+      if (accounts.isEmpty) {
+        print(
+            'No accounts returned by wallet. Cannot proceed with account-specific actions.');
+      }
+    } catch (e) {
+      print('Error requesting accounts: $e');
+      print('Cannot proceed without accounts.');
+      return; // Exit if accounts cannot be obtained
+    }
+
+    // --- Step 2: Get Info if Accounts are Available ---
+    if (accounts.isNotEmpty) {
+      print('\n--- Step 2: Getting Account & Network Info ---');
+      try {
+        final chainId = await provider.requestChainId();
+        print('Current Chain ID: ${chainId.toHexString()}');
+        // Add checks here if your Dapp only supports specific chains
+        if (chainId != sepoliaChainId) {
+          print('Warning: Connected to an unexpected chain ID!');
+          // Potentially try to switch chain using provider.switchStarknetChain(sepoliaChainId)
+        }
+      } catch (e) {
+        print('Error requesting Chain ID: $e');
+      }
+      try {
+        final permissions = await provider.getPermissions();
+        print('Current Dapp Permissions: $permissions');
+      } catch (e) {
+        print('Error getting permissions: $e');
+      }
+    }
+
+    // --- Step 3: Attempt Invoke Transaction (Requires Wallet Interaction) ---
+    if (accounts.isNotEmpty) {
+      print(
+          '\n--- Step 3: Attempting Invoke Transaction (Will require Wallet UI) ---');
+      try {
+        final calls = [
+          InvokeCall(
+              // Replace with a known contract address on Sepolia (e.g., an ERC20 contract)
+              contractAddress: felt(
+                  '0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7'),
+              entryPoint: 'transfer', // Assuming ERC20 transfer
+              calldata: [
+                // Replace with a valid recipient address on Sepolia
+                felt(
+                    '0x01234567890abcdef1234567890abcdef1234567890abcdef1234567890abcde'),
+                // Replace with actual amount low/high parts (e.g., 1 token with 18 decimals)
+                felt('0xDE0B6B3A7640000'), // 1 * 10^18
+                felt('0x0'), // High part is 0
+              ])
+        ];
+        print('Requesting invoke transaction submission...');
+        final invokeResult = await provider.addInvokeTransaction(calls);
+        print(
+            'Invoke Transaction submitted. Tx Hash: ${invokeResult.transactionHash}');
+      } catch (e) {
+        print('Error submitting invoke transaction: $e');
+      }
+    }
+
+    // --- Step 4: Attempt Sign Typed Data (Requires Wallet Interaction) ---
+    if (accounts.isNotEmpty) {
+      print(
+          '\n--- Step 4: Attempting Sign Typed Data (Will require Wallet UI) ---');
+      try {
+        print('Preparing typed data...');
+        final typedData = TypedData(
+            types: {
+              "StarknetDomain": [
+                {"name": "name", "type": "shortstring"},
+                {"name": "version", "type": "felt"},
+                {"name": "chainId", "type": "felt"},
+              ],
+              "Person": [
+                {"name": "name", "type": "shortstring"},
+                {"name": "wallet", "type": "felt"}
+              ],
+              "Mail": [
+                {"name": "from", "type": "Person"},
+                {"name": "to", "type": "Person"},
+                {"name": "contents", "type": "shortstring"}
+              ]
+            },
+            primaryType: "Mail",
+            domain: StarknetDomain(
+                name: Felt.fromString("Example DApp"),
+                version: Felt.fromInt(1),
+                chainId: sepoliaChainId),
+            message: {
+              "from": {
+                "name": Felt.fromString("Alice"),
+                "wallet": felt(
+                    "0x0111111111111111111111111111111111111111111111111111111111111111")
+              },
+              "to": {
+                "name": Felt.fromString("Bob"),
+                "wallet": felt(
+                    "0x0222222222222222222222222222222222222222222222222222222222222222")
+              },
+              "contents": Felt.fromString("Hello Bob!")
+            });
+
+        print('Requesting signature...');
+        final signature = await provider.signTypedData(typedData);
+        print('Data signed. Signature: $signature');
+      } catch (e) {
+        print('Error signing typed data: $e');
+      }
+    }
+
+    // --- Step 5: General Wallet Info ---
+    print('\n--- Step 5: Getting General Wallet Info ---');
+    try {
+      final supportedApis = await provider.supportedWalletApi();
+      print('Supported Wallet APIs: $supportedApis');
+    } catch (e) {
+      print('Error getting supported Wallet APIs: $e');
+    }
+    try {
+      final supportedSpecs = await provider.supportedSpecs();
+      print('Supported Starknet RPC Specs: $supportedSpecs');
+    } catch (e) {
+      print('Error getting supported Starknet RPC Specs: $e');
+    }
+
+    // Other methods like addDeclareTransaction, addStarknetChain, watchAsset etc.
+    // could be added in similar conditional blocks depending on the Dapp flow.
+  } catch (e) {
+    print('\nA critical error occurred outside the main flow: $e');
+  } finally {
+    provider.close();
+    print('\n--- Example Scenario Finished ---');
+  }
+}

--- a/packages/wallet_provider/lib/src/index.dart
+++ b/packages/wallet_provider/lib/src/index.dart
@@ -1,0 +1,2 @@
+export 'model/index.dart';
+export 'provider.dart';

--- a/packages/wallet_provider/lib/src/model/account_deployment_data.dart
+++ b/packages/wallet_provider/lib/src/model/account_deployment_data.dart
@@ -1,0 +1,23 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:starknet/starknet.dart';
+import 'deployment_version.dart'; // Import the new enum
+
+part 'account_deployment_data.freezed.dart';
+part 'account_deployment_data.g.dart';
+
+/// Title: Account Deployment Data
+/// Description: Data required to deploy an account at and address
+@freezed
+class AccountDeploymentData with _$AccountDeploymentData {
+  const factory AccountDeploymentData({
+    required Felt address,
+    @JsonKey(name: 'class_hash') required Felt classHash,
+    required Felt salt,
+    required List<Felt> calldata,
+    List<Felt>? sigdata,
+    required DeploymentVersion version,
+  }) = _AccountDeploymentData;
+
+  factory AccountDeploymentData.fromJson(Map<String, Object?> json) =>
+      _$AccountDeploymentDataFromJson(json);
+}

--- a/packages/wallet_provider/lib/src/model/account_deployment_data.freezed.dart
+++ b/packages/wallet_provider/lib/src/model/account_deployment_data.freezed.dart
@@ -1,0 +1,300 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'account_deployment_data.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+AccountDeploymentData _$AccountDeploymentDataFromJson(
+    Map<String, dynamic> json) {
+  return _AccountDeploymentData.fromJson(json);
+}
+
+/// @nodoc
+mixin _$AccountDeploymentData {
+  Felt get address => throw _privateConstructorUsedError;
+  @JsonKey(name: 'class_hash')
+  Felt get classHash => throw _privateConstructorUsedError;
+  Felt get salt => throw _privateConstructorUsedError;
+  List<Felt> get calldata => throw _privateConstructorUsedError;
+  List<Felt>? get sigdata => throw _privateConstructorUsedError;
+  DeploymentVersion get version => throw _privateConstructorUsedError;
+
+  /// Serializes this AccountDeploymentData to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of AccountDeploymentData
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $AccountDeploymentDataCopyWith<AccountDeploymentData> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $AccountDeploymentDataCopyWith<$Res> {
+  factory $AccountDeploymentDataCopyWith(AccountDeploymentData value,
+          $Res Function(AccountDeploymentData) then) =
+      _$AccountDeploymentDataCopyWithImpl<$Res, AccountDeploymentData>;
+  @useResult
+  $Res call(
+      {Felt address,
+      @JsonKey(name: 'class_hash') Felt classHash,
+      Felt salt,
+      List<Felt> calldata,
+      List<Felt>? sigdata,
+      DeploymentVersion version});
+}
+
+/// @nodoc
+class _$AccountDeploymentDataCopyWithImpl<$Res,
+        $Val extends AccountDeploymentData>
+    implements $AccountDeploymentDataCopyWith<$Res> {
+  _$AccountDeploymentDataCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of AccountDeploymentData
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? address = null,
+    Object? classHash = null,
+    Object? salt = null,
+    Object? calldata = null,
+    Object? sigdata = freezed,
+    Object? version = null,
+  }) {
+    return _then(_value.copyWith(
+      address: null == address
+          ? _value.address
+          : address // ignore: cast_nullable_to_non_nullable
+              as Felt,
+      classHash: null == classHash
+          ? _value.classHash
+          : classHash // ignore: cast_nullable_to_non_nullable
+              as Felt,
+      salt: null == salt
+          ? _value.salt
+          : salt // ignore: cast_nullable_to_non_nullable
+              as Felt,
+      calldata: null == calldata
+          ? _value.calldata
+          : calldata // ignore: cast_nullable_to_non_nullable
+              as List<Felt>,
+      sigdata: freezed == sigdata
+          ? _value.sigdata
+          : sigdata // ignore: cast_nullable_to_non_nullable
+              as List<Felt>?,
+      version: null == version
+          ? _value.version
+          : version // ignore: cast_nullable_to_non_nullable
+              as DeploymentVersion,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$AccountDeploymentDataImplCopyWith<$Res>
+    implements $AccountDeploymentDataCopyWith<$Res> {
+  factory _$$AccountDeploymentDataImplCopyWith(
+          _$AccountDeploymentDataImpl value,
+          $Res Function(_$AccountDeploymentDataImpl) then) =
+      __$$AccountDeploymentDataImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {Felt address,
+      @JsonKey(name: 'class_hash') Felt classHash,
+      Felt salt,
+      List<Felt> calldata,
+      List<Felt>? sigdata,
+      DeploymentVersion version});
+}
+
+/// @nodoc
+class __$$AccountDeploymentDataImplCopyWithImpl<$Res>
+    extends _$AccountDeploymentDataCopyWithImpl<$Res,
+        _$AccountDeploymentDataImpl>
+    implements _$$AccountDeploymentDataImplCopyWith<$Res> {
+  __$$AccountDeploymentDataImplCopyWithImpl(_$AccountDeploymentDataImpl _value,
+      $Res Function(_$AccountDeploymentDataImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of AccountDeploymentData
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? address = null,
+    Object? classHash = null,
+    Object? salt = null,
+    Object? calldata = null,
+    Object? sigdata = freezed,
+    Object? version = null,
+  }) {
+    return _then(_$AccountDeploymentDataImpl(
+      address: null == address
+          ? _value.address
+          : address // ignore: cast_nullable_to_non_nullable
+              as Felt,
+      classHash: null == classHash
+          ? _value.classHash
+          : classHash // ignore: cast_nullable_to_non_nullable
+              as Felt,
+      salt: null == salt
+          ? _value.salt
+          : salt // ignore: cast_nullable_to_non_nullable
+              as Felt,
+      calldata: null == calldata
+          ? _value._calldata
+          : calldata // ignore: cast_nullable_to_non_nullable
+              as List<Felt>,
+      sigdata: freezed == sigdata
+          ? _value._sigdata
+          : sigdata // ignore: cast_nullable_to_non_nullable
+              as List<Felt>?,
+      version: null == version
+          ? _value.version
+          : version // ignore: cast_nullable_to_non_nullable
+              as DeploymentVersion,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$AccountDeploymentDataImpl implements _AccountDeploymentData {
+  const _$AccountDeploymentDataImpl(
+      {required this.address,
+      @JsonKey(name: 'class_hash') required this.classHash,
+      required this.salt,
+      required final List<Felt> calldata,
+      final List<Felt>? sigdata,
+      required this.version})
+      : _calldata = calldata,
+        _sigdata = sigdata;
+
+  factory _$AccountDeploymentDataImpl.fromJson(Map<String, dynamic> json) =>
+      _$$AccountDeploymentDataImplFromJson(json);
+
+  @override
+  final Felt address;
+  @override
+  @JsonKey(name: 'class_hash')
+  final Felt classHash;
+  @override
+  final Felt salt;
+  final List<Felt> _calldata;
+  @override
+  List<Felt> get calldata {
+    if (_calldata is EqualUnmodifiableListView) return _calldata;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_calldata);
+  }
+
+  final List<Felt>? _sigdata;
+  @override
+  List<Felt>? get sigdata {
+    final value = _sigdata;
+    if (value == null) return null;
+    if (_sigdata is EqualUnmodifiableListView) return _sigdata;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(value);
+  }
+
+  @override
+  final DeploymentVersion version;
+
+  @override
+  String toString() {
+    return 'AccountDeploymentData(address: $address, classHash: $classHash, salt: $salt, calldata: $calldata, sigdata: $sigdata, version: $version)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$AccountDeploymentDataImpl &&
+            (identical(other.address, address) || other.address == address) &&
+            (identical(other.classHash, classHash) ||
+                other.classHash == classHash) &&
+            (identical(other.salt, salt) || other.salt == salt) &&
+            const DeepCollectionEquality().equals(other._calldata, _calldata) &&
+            const DeepCollectionEquality().equals(other._sigdata, _sigdata) &&
+            (identical(other.version, version) || other.version == version));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      address,
+      classHash,
+      salt,
+      const DeepCollectionEquality().hash(_calldata),
+      const DeepCollectionEquality().hash(_sigdata),
+      version);
+
+  /// Create a copy of AccountDeploymentData
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$AccountDeploymentDataImplCopyWith<_$AccountDeploymentDataImpl>
+      get copyWith => __$$AccountDeploymentDataImplCopyWithImpl<
+          _$AccountDeploymentDataImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$AccountDeploymentDataImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _AccountDeploymentData implements AccountDeploymentData {
+  const factory _AccountDeploymentData(
+      {required final Felt address,
+      @JsonKey(name: 'class_hash') required final Felt classHash,
+      required final Felt salt,
+      required final List<Felt> calldata,
+      final List<Felt>? sigdata,
+      required final DeploymentVersion version}) = _$AccountDeploymentDataImpl;
+
+  factory _AccountDeploymentData.fromJson(Map<String, dynamic> json) =
+      _$AccountDeploymentDataImpl.fromJson;
+
+  @override
+  Felt get address;
+  @override
+  @JsonKey(name: 'class_hash')
+  Felt get classHash;
+  @override
+  Felt get salt;
+  @override
+  List<Felt> get calldata;
+  @override
+  List<Felt>? get sigdata;
+  @override
+  DeploymentVersion get version;
+
+  /// Create a copy of AccountDeploymentData
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$AccountDeploymentDataImplCopyWith<_$AccountDeploymentDataImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}

--- a/packages/wallet_provider/lib/src/model/account_deployment_data.g.dart
+++ b/packages/wallet_provider/lib/src/model/account_deployment_data.g.dart
@@ -1,0 +1,38 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'account_deployment_data.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$AccountDeploymentDataImpl _$$AccountDeploymentDataImplFromJson(
+        Map<String, dynamic> json) =>
+    _$AccountDeploymentDataImpl(
+      address: Felt.fromJson(json['address'] as String),
+      classHash: Felt.fromJson(json['class_hash'] as String),
+      salt: Felt.fromJson(json['salt'] as String),
+      calldata: (json['calldata'] as List<dynamic>)
+          .map((e) => Felt.fromJson(e as String))
+          .toList(),
+      sigdata: (json['sigdata'] as List<dynamic>?)
+          ?.map((e) => Felt.fromJson(e as String))
+          .toList(),
+      version: $enumDecode(_$DeploymentVersionEnumMap, json['version']),
+    );
+
+Map<String, dynamic> _$$AccountDeploymentDataImplToJson(
+        _$AccountDeploymentDataImpl instance) =>
+    <String, dynamic>{
+      'address': instance.address.toJson(),
+      'class_hash': instance.classHash.toJson(),
+      'salt': instance.salt.toJson(),
+      'calldata': instance.calldata.map((e) => e.toJson()).toList(),
+      'sigdata': instance.sigdata?.map((e) => e.toJson()).toList(),
+      'version': _$DeploymentVersionEnumMap[instance.version]!,
+    };
+
+const _$DeploymentVersionEnumMap = {
+  DeploymentVersion.v0: 0,
+  DeploymentVersion.v1: 1,
+};

--- a/packages/wallet_provider/lib/src/model/add_declare_transaction_result.dart
+++ b/packages/wallet_provider/lib/src/model/add_declare_transaction_result.dart
@@ -1,0 +1,19 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:starknet/starknet.dart';
+
+part 'add_declare_transaction_result.freezed.dart';
+part 'add_declare_transaction_result.g.dart';
+
+/// Description: The result of the transaction submission (wallet_addDeclareTransaction)
+@freezed
+class AddDeclareTransactionResult with _$AddDeclareTransactionResult {
+  const factory AddDeclareTransactionResult({
+    @JsonKey(name: 'transaction_hash')
+    required Felt transactionHash, // Assuming Felt for PADDED_TXN_HASH
+    @JsonKey(name: 'class_hash')
+    required Felt classHash, // Assuming Felt for PADDED_FELT
+  }) = _AddDeclareTransactionResult;
+
+  factory AddDeclareTransactionResult.fromJson(Map<String, Object?> json) =>
+      _$AddDeclareTransactionResultFromJson(json);
+}

--- a/packages/wallet_provider/lib/src/model/add_declare_transaction_result.freezed.dart
+++ b/packages/wallet_provider/lib/src/model/add_declare_transaction_result.freezed.dart
@@ -1,0 +1,210 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'add_declare_transaction_result.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+AddDeclareTransactionResult _$AddDeclareTransactionResultFromJson(
+    Map<String, dynamic> json) {
+  return _AddDeclareTransactionResult.fromJson(json);
+}
+
+/// @nodoc
+mixin _$AddDeclareTransactionResult {
+  @JsonKey(name: 'transaction_hash')
+  Felt get transactionHash =>
+      throw _privateConstructorUsedError; // Assuming Felt for PADDED_TXN_HASH
+  @JsonKey(name: 'class_hash')
+  Felt get classHash => throw _privateConstructorUsedError;
+
+  /// Serializes this AddDeclareTransactionResult to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of AddDeclareTransactionResult
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $AddDeclareTransactionResultCopyWith<AddDeclareTransactionResult>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $AddDeclareTransactionResultCopyWith<$Res> {
+  factory $AddDeclareTransactionResultCopyWith(
+          AddDeclareTransactionResult value,
+          $Res Function(AddDeclareTransactionResult) then) =
+      _$AddDeclareTransactionResultCopyWithImpl<$Res,
+          AddDeclareTransactionResult>;
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'transaction_hash') Felt transactionHash,
+      @JsonKey(name: 'class_hash') Felt classHash});
+}
+
+/// @nodoc
+class _$AddDeclareTransactionResultCopyWithImpl<$Res,
+        $Val extends AddDeclareTransactionResult>
+    implements $AddDeclareTransactionResultCopyWith<$Res> {
+  _$AddDeclareTransactionResultCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of AddDeclareTransactionResult
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? transactionHash = null,
+    Object? classHash = null,
+  }) {
+    return _then(_value.copyWith(
+      transactionHash: null == transactionHash
+          ? _value.transactionHash
+          : transactionHash // ignore: cast_nullable_to_non_nullable
+              as Felt,
+      classHash: null == classHash
+          ? _value.classHash
+          : classHash // ignore: cast_nullable_to_non_nullable
+              as Felt,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$AddDeclareTransactionResultImplCopyWith<$Res>
+    implements $AddDeclareTransactionResultCopyWith<$Res> {
+  factory _$$AddDeclareTransactionResultImplCopyWith(
+          _$AddDeclareTransactionResultImpl value,
+          $Res Function(_$AddDeclareTransactionResultImpl) then) =
+      __$$AddDeclareTransactionResultImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'transaction_hash') Felt transactionHash,
+      @JsonKey(name: 'class_hash') Felt classHash});
+}
+
+/// @nodoc
+class __$$AddDeclareTransactionResultImplCopyWithImpl<$Res>
+    extends _$AddDeclareTransactionResultCopyWithImpl<$Res,
+        _$AddDeclareTransactionResultImpl>
+    implements _$$AddDeclareTransactionResultImplCopyWith<$Res> {
+  __$$AddDeclareTransactionResultImplCopyWithImpl(
+      _$AddDeclareTransactionResultImpl _value,
+      $Res Function(_$AddDeclareTransactionResultImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of AddDeclareTransactionResult
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? transactionHash = null,
+    Object? classHash = null,
+  }) {
+    return _then(_$AddDeclareTransactionResultImpl(
+      transactionHash: null == transactionHash
+          ? _value.transactionHash
+          : transactionHash // ignore: cast_nullable_to_non_nullable
+              as Felt,
+      classHash: null == classHash
+          ? _value.classHash
+          : classHash // ignore: cast_nullable_to_non_nullable
+              as Felt,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$AddDeclareTransactionResultImpl
+    implements _AddDeclareTransactionResult {
+  const _$AddDeclareTransactionResultImpl(
+      {@JsonKey(name: 'transaction_hash') required this.transactionHash,
+      @JsonKey(name: 'class_hash') required this.classHash});
+
+  factory _$AddDeclareTransactionResultImpl.fromJson(
+          Map<String, dynamic> json) =>
+      _$$AddDeclareTransactionResultImplFromJson(json);
+
+  @override
+  @JsonKey(name: 'transaction_hash')
+  final Felt transactionHash;
+// Assuming Felt for PADDED_TXN_HASH
+  @override
+  @JsonKey(name: 'class_hash')
+  final Felt classHash;
+
+  @override
+  String toString() {
+    return 'AddDeclareTransactionResult(transactionHash: $transactionHash, classHash: $classHash)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$AddDeclareTransactionResultImpl &&
+            (identical(other.transactionHash, transactionHash) ||
+                other.transactionHash == transactionHash) &&
+            (identical(other.classHash, classHash) ||
+                other.classHash == classHash));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, transactionHash, classHash);
+
+  /// Create a copy of AddDeclareTransactionResult
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$AddDeclareTransactionResultImplCopyWith<_$AddDeclareTransactionResultImpl>
+      get copyWith => __$$AddDeclareTransactionResultImplCopyWithImpl<
+          _$AddDeclareTransactionResultImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$AddDeclareTransactionResultImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _AddDeclareTransactionResult
+    implements AddDeclareTransactionResult {
+  const factory _AddDeclareTransactionResult(
+      {@JsonKey(name: 'transaction_hash') required final Felt transactionHash,
+      @JsonKey(name: 'class_hash')
+      required final Felt classHash}) = _$AddDeclareTransactionResultImpl;
+
+  factory _AddDeclareTransactionResult.fromJson(Map<String, dynamic> json) =
+      _$AddDeclareTransactionResultImpl.fromJson;
+
+  @override
+  @JsonKey(name: 'transaction_hash')
+  Felt get transactionHash; // Assuming Felt for PADDED_TXN_HASH
+  @override
+  @JsonKey(name: 'class_hash')
+  Felt get classHash;
+
+  /// Create a copy of AddDeclareTransactionResult
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$AddDeclareTransactionResultImplCopyWith<_$AddDeclareTransactionResultImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}

--- a/packages/wallet_provider/lib/src/model/add_declare_transaction_result.g.dart
+++ b/packages/wallet_provider/lib/src/model/add_declare_transaction_result.g.dart
@@ -1,0 +1,21 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'add_declare_transaction_result.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$AddDeclareTransactionResultImpl _$$AddDeclareTransactionResultImplFromJson(
+        Map<String, dynamic> json) =>
+    _$AddDeclareTransactionResultImpl(
+      transactionHash: Felt.fromJson(json['transaction_hash'] as String),
+      classHash: Felt.fromJson(json['class_hash'] as String),
+    );
+
+Map<String, dynamic> _$$AddDeclareTransactionResultImplToJson(
+        _$AddDeclareTransactionResultImpl instance) =>
+    <String, dynamic>{
+      'transaction_hash': instance.transactionHash.toJson(),
+      'class_hash': instance.classHash.toJson(),
+    };

--- a/packages/wallet_provider/lib/src/model/add_invoke_transaction_result.dart
+++ b/packages/wallet_provider/lib/src/model/add_invoke_transaction_result.dart
@@ -1,0 +1,17 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:starknet/starknet.dart';
+
+part 'add_invoke_transaction_result.freezed.dart';
+part 'add_invoke_transaction_result.g.dart';
+
+/// Description: The result of the transaction submission (wallet_addInvokeTransaction)
+@freezed
+class AddInvokeTransactionResult with _$AddInvokeTransactionResult {
+  const factory AddInvokeTransactionResult({
+    @JsonKey(name: 'transaction_hash')
+    required Felt transactionHash, // Assuming Felt for PADDED_TXN_HASH
+  }) = _AddInvokeTransactionResult;
+
+  factory AddInvokeTransactionResult.fromJson(Map<String, Object?> json) =>
+      _$AddInvokeTransactionResultFromJson(json);
+}

--- a/packages/wallet_provider/lib/src/model/add_invoke_transaction_result.freezed.dart
+++ b/packages/wallet_provider/lib/src/model/add_invoke_transaction_result.freezed.dart
@@ -1,0 +1,180 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'add_invoke_transaction_result.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+AddInvokeTransactionResult _$AddInvokeTransactionResultFromJson(
+    Map<String, dynamic> json) {
+  return _AddInvokeTransactionResult.fromJson(json);
+}
+
+/// @nodoc
+mixin _$AddInvokeTransactionResult {
+  @JsonKey(name: 'transaction_hash')
+  Felt get transactionHash => throw _privateConstructorUsedError;
+
+  /// Serializes this AddInvokeTransactionResult to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of AddInvokeTransactionResult
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $AddInvokeTransactionResultCopyWith<AddInvokeTransactionResult>
+      get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $AddInvokeTransactionResultCopyWith<$Res> {
+  factory $AddInvokeTransactionResultCopyWith(AddInvokeTransactionResult value,
+          $Res Function(AddInvokeTransactionResult) then) =
+      _$AddInvokeTransactionResultCopyWithImpl<$Res,
+          AddInvokeTransactionResult>;
+  @useResult
+  $Res call({@JsonKey(name: 'transaction_hash') Felt transactionHash});
+}
+
+/// @nodoc
+class _$AddInvokeTransactionResultCopyWithImpl<$Res,
+        $Val extends AddInvokeTransactionResult>
+    implements $AddInvokeTransactionResultCopyWith<$Res> {
+  _$AddInvokeTransactionResultCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of AddInvokeTransactionResult
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? transactionHash = null,
+  }) {
+    return _then(_value.copyWith(
+      transactionHash: null == transactionHash
+          ? _value.transactionHash
+          : transactionHash // ignore: cast_nullable_to_non_nullable
+              as Felt,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$AddInvokeTransactionResultImplCopyWith<$Res>
+    implements $AddInvokeTransactionResultCopyWith<$Res> {
+  factory _$$AddInvokeTransactionResultImplCopyWith(
+          _$AddInvokeTransactionResultImpl value,
+          $Res Function(_$AddInvokeTransactionResultImpl) then) =
+      __$$AddInvokeTransactionResultImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({@JsonKey(name: 'transaction_hash') Felt transactionHash});
+}
+
+/// @nodoc
+class __$$AddInvokeTransactionResultImplCopyWithImpl<$Res>
+    extends _$AddInvokeTransactionResultCopyWithImpl<$Res,
+        _$AddInvokeTransactionResultImpl>
+    implements _$$AddInvokeTransactionResultImplCopyWith<$Res> {
+  __$$AddInvokeTransactionResultImplCopyWithImpl(
+      _$AddInvokeTransactionResultImpl _value,
+      $Res Function(_$AddInvokeTransactionResultImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of AddInvokeTransactionResult
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? transactionHash = null,
+  }) {
+    return _then(_$AddInvokeTransactionResultImpl(
+      transactionHash: null == transactionHash
+          ? _value.transactionHash
+          : transactionHash // ignore: cast_nullable_to_non_nullable
+              as Felt,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$AddInvokeTransactionResultImpl implements _AddInvokeTransactionResult {
+  const _$AddInvokeTransactionResultImpl(
+      {@JsonKey(name: 'transaction_hash') required this.transactionHash});
+
+  factory _$AddInvokeTransactionResultImpl.fromJson(
+          Map<String, dynamic> json) =>
+      _$$AddInvokeTransactionResultImplFromJson(json);
+
+  @override
+  @JsonKey(name: 'transaction_hash')
+  final Felt transactionHash;
+
+  @override
+  String toString() {
+    return 'AddInvokeTransactionResult(transactionHash: $transactionHash)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$AddInvokeTransactionResultImpl &&
+            (identical(other.transactionHash, transactionHash) ||
+                other.transactionHash == transactionHash));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, transactionHash);
+
+  /// Create a copy of AddInvokeTransactionResult
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$AddInvokeTransactionResultImplCopyWith<_$AddInvokeTransactionResultImpl>
+      get copyWith => __$$AddInvokeTransactionResultImplCopyWithImpl<
+          _$AddInvokeTransactionResultImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$AddInvokeTransactionResultImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _AddInvokeTransactionResult
+    implements AddInvokeTransactionResult {
+  const factory _AddInvokeTransactionResult(
+      {@JsonKey(name: 'transaction_hash')
+      required final Felt transactionHash}) = _$AddInvokeTransactionResultImpl;
+
+  factory _AddInvokeTransactionResult.fromJson(Map<String, dynamic> json) =
+      _$AddInvokeTransactionResultImpl.fromJson;
+
+  @override
+  @JsonKey(name: 'transaction_hash')
+  Felt get transactionHash;
+
+  /// Create a copy of AddInvokeTransactionResult
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$AddInvokeTransactionResultImplCopyWith<_$AddInvokeTransactionResultImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}

--- a/packages/wallet_provider/lib/src/model/add_invoke_transaction_result.g.dart
+++ b/packages/wallet_provider/lib/src/model/add_invoke_transaction_result.g.dart
@@ -1,0 +1,19 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'add_invoke_transaction_result.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$AddInvokeTransactionResultImpl _$$AddInvokeTransactionResultImplFromJson(
+        Map<String, dynamic> json) =>
+    _$AddInvokeTransactionResultImpl(
+      transactionHash: Felt.fromJson(json['transaction_hash'] as String),
+    );
+
+Map<String, dynamic> _$$AddInvokeTransactionResultImplToJson(
+        _$AddInvokeTransactionResultImpl instance) =>
+    <String, dynamic>{
+      'transaction_hash': instance.transactionHash.toJson(),
+    };

--- a/packages/wallet_provider/lib/src/model/api_version.dart
+++ b/packages/wallet_provider/lib/src/model/api_version.dart
@@ -1,0 +1,4 @@
+/// Title: Wallet API version
+/// Description: The version of wallet API expected by the request. If not specified, the latest is assumed
+typedef ApiVersion
+    = String; // Using String for now, pattern validation can be added if needed

--- a/packages/wallet_provider/lib/src/model/asset.dart
+++ b/packages/wallet_provider/lib/src/model/asset.dart
@@ -1,0 +1,32 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:starknet/starknet.dart';
+
+part 'asset.freezed.dart';
+part 'asset.g.dart';
+
+/// Title: Starknet Token
+/// Description: Details of an onchain Starknet ERC20 token
+@freezed
+sealed class Asset with _$Asset {
+  const factory Asset.erc20({
+    required AssetOptions options,
+    @Default("ERC20") String type,
+  }) = ERC20Asset;
+
+  factory Asset.fromJson(Map<String, Object?> json) => _$AssetFromJson(json);
+}
+
+@freezed
+class AssetOptions with _$AssetOptions {
+  const factory AssetOptions({
+    required Felt address,
+    String?
+        symbol, // TOKEN_SYMBOL constraints (pattern/length) not enforced by type system
+    num? decimals,
+    String? image, // TODO: Should be Uri?
+    String? name,
+  }) = _AssetOptions;
+
+  factory AssetOptions.fromJson(Map<String, Object?> json) =>
+      _$AssetOptionsFromJson(json);
+}

--- a/packages/wallet_provider/lib/src/model/asset.freezed.dart
+++ b/packages/wallet_provider/lib/src/model/asset.freezed.dart
@@ -1,0 +1,523 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'asset.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+Asset _$AssetFromJson(Map<String, dynamic> json) {
+  return ERC20Asset.fromJson(json);
+}
+
+/// @nodoc
+mixin _$Asset {
+  AssetOptions get options => throw _privateConstructorUsedError;
+  String get type => throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(AssetOptions options, String type) erc20,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(AssetOptions options, String type)? erc20,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(AssetOptions options, String type)? erc20,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(ERC20Asset value) erc20,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(ERC20Asset value)? erc20,
+  }) =>
+      throw _privateConstructorUsedError;
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(ERC20Asset value)? erc20,
+    required TResult orElse(),
+  }) =>
+      throw _privateConstructorUsedError;
+
+  /// Serializes this Asset to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of Asset
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $AssetCopyWith<Asset> get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $AssetCopyWith<$Res> {
+  factory $AssetCopyWith(Asset value, $Res Function(Asset) then) =
+      _$AssetCopyWithImpl<$Res, Asset>;
+  @useResult
+  $Res call({AssetOptions options, String type});
+
+  $AssetOptionsCopyWith<$Res> get options;
+}
+
+/// @nodoc
+class _$AssetCopyWithImpl<$Res, $Val extends Asset>
+    implements $AssetCopyWith<$Res> {
+  _$AssetCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of Asset
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? options = null,
+    Object? type = null,
+  }) {
+    return _then(_value.copyWith(
+      options: null == options
+          ? _value.options
+          : options // ignore: cast_nullable_to_non_nullable
+              as AssetOptions,
+      type: null == type
+          ? _value.type
+          : type // ignore: cast_nullable_to_non_nullable
+              as String,
+    ) as $Val);
+  }
+
+  /// Create a copy of Asset
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $AssetOptionsCopyWith<$Res> get options {
+    return $AssetOptionsCopyWith<$Res>(_value.options, (value) {
+      return _then(_value.copyWith(options: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$ERC20AssetImplCopyWith<$Res> implements $AssetCopyWith<$Res> {
+  factory _$$ERC20AssetImplCopyWith(
+          _$ERC20AssetImpl value, $Res Function(_$ERC20AssetImpl) then) =
+      __$$ERC20AssetImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({AssetOptions options, String type});
+
+  @override
+  $AssetOptionsCopyWith<$Res> get options;
+}
+
+/// @nodoc
+class __$$ERC20AssetImplCopyWithImpl<$Res>
+    extends _$AssetCopyWithImpl<$Res, _$ERC20AssetImpl>
+    implements _$$ERC20AssetImplCopyWith<$Res> {
+  __$$ERC20AssetImplCopyWithImpl(
+      _$ERC20AssetImpl _value, $Res Function(_$ERC20AssetImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of Asset
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? options = null,
+    Object? type = null,
+  }) {
+    return _then(_$ERC20AssetImpl(
+      options: null == options
+          ? _value.options
+          : options // ignore: cast_nullable_to_non_nullable
+              as AssetOptions,
+      type: null == type
+          ? _value.type
+          : type // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$ERC20AssetImpl implements ERC20Asset {
+  const _$ERC20AssetImpl({required this.options, this.type = "ERC20"});
+
+  factory _$ERC20AssetImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ERC20AssetImplFromJson(json);
+
+  @override
+  final AssetOptions options;
+  @override
+  @JsonKey()
+  final String type;
+
+  @override
+  String toString() {
+    return 'Asset.erc20(options: $options, type: $type)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ERC20AssetImpl &&
+            (identical(other.options, options) || other.options == options) &&
+            (identical(other.type, type) || other.type == type));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, options, type);
+
+  /// Create a copy of Asset
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ERC20AssetImplCopyWith<_$ERC20AssetImpl> get copyWith =>
+      __$$ERC20AssetImplCopyWithImpl<_$ERC20AssetImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(AssetOptions options, String type) erc20,
+  }) {
+    return erc20(options, type);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(AssetOptions options, String type)? erc20,
+  }) {
+    return erc20?.call(options, type);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(AssetOptions options, String type)? erc20,
+    required TResult orElse(),
+  }) {
+    if (erc20 != null) {
+      return erc20(options, type);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(ERC20Asset value) erc20,
+  }) {
+    return erc20(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(ERC20Asset value)? erc20,
+  }) {
+    return erc20?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(ERC20Asset value)? erc20,
+    required TResult orElse(),
+  }) {
+    if (erc20 != null) {
+      return erc20(this);
+    }
+    return orElse();
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$ERC20AssetImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class ERC20Asset implements Asset {
+  const factory ERC20Asset(
+      {required final AssetOptions options,
+      final String type}) = _$ERC20AssetImpl;
+
+  factory ERC20Asset.fromJson(Map<String, dynamic> json) =
+      _$ERC20AssetImpl.fromJson;
+
+  @override
+  AssetOptions get options;
+  @override
+  String get type;
+
+  /// Create a copy of Asset
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$ERC20AssetImplCopyWith<_$ERC20AssetImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+AssetOptions _$AssetOptionsFromJson(Map<String, dynamic> json) {
+  return _AssetOptions.fromJson(json);
+}
+
+/// @nodoc
+mixin _$AssetOptions {
+  Felt get address => throw _privateConstructorUsedError;
+  String? get symbol =>
+      throw _privateConstructorUsedError; // TOKEN_SYMBOL constraints (pattern/length) not enforced by type system
+  num? get decimals => throw _privateConstructorUsedError;
+  String? get image =>
+      throw _privateConstructorUsedError; // TODO: Should be Uri?
+  String? get name => throw _privateConstructorUsedError;
+
+  /// Serializes this AssetOptions to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of AssetOptions
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $AssetOptionsCopyWith<AssetOptions> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $AssetOptionsCopyWith<$Res> {
+  factory $AssetOptionsCopyWith(
+          AssetOptions value, $Res Function(AssetOptions) then) =
+      _$AssetOptionsCopyWithImpl<$Res, AssetOptions>;
+  @useResult
+  $Res call(
+      {Felt address,
+      String? symbol,
+      num? decimals,
+      String? image,
+      String? name});
+}
+
+/// @nodoc
+class _$AssetOptionsCopyWithImpl<$Res, $Val extends AssetOptions>
+    implements $AssetOptionsCopyWith<$Res> {
+  _$AssetOptionsCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of AssetOptions
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? address = null,
+    Object? symbol = freezed,
+    Object? decimals = freezed,
+    Object? image = freezed,
+    Object? name = freezed,
+  }) {
+    return _then(_value.copyWith(
+      address: null == address
+          ? _value.address
+          : address // ignore: cast_nullable_to_non_nullable
+              as Felt,
+      symbol: freezed == symbol
+          ? _value.symbol
+          : symbol // ignore: cast_nullable_to_non_nullable
+              as String?,
+      decimals: freezed == decimals
+          ? _value.decimals
+          : decimals // ignore: cast_nullable_to_non_nullable
+              as num?,
+      image: freezed == image
+          ? _value.image
+          : image // ignore: cast_nullable_to_non_nullable
+              as String?,
+      name: freezed == name
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$AssetOptionsImplCopyWith<$Res>
+    implements $AssetOptionsCopyWith<$Res> {
+  factory _$$AssetOptionsImplCopyWith(
+          _$AssetOptionsImpl value, $Res Function(_$AssetOptionsImpl) then) =
+      __$$AssetOptionsImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {Felt address,
+      String? symbol,
+      num? decimals,
+      String? image,
+      String? name});
+}
+
+/// @nodoc
+class __$$AssetOptionsImplCopyWithImpl<$Res>
+    extends _$AssetOptionsCopyWithImpl<$Res, _$AssetOptionsImpl>
+    implements _$$AssetOptionsImplCopyWith<$Res> {
+  __$$AssetOptionsImplCopyWithImpl(
+      _$AssetOptionsImpl _value, $Res Function(_$AssetOptionsImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of AssetOptions
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? address = null,
+    Object? symbol = freezed,
+    Object? decimals = freezed,
+    Object? image = freezed,
+    Object? name = freezed,
+  }) {
+    return _then(_$AssetOptionsImpl(
+      address: null == address
+          ? _value.address
+          : address // ignore: cast_nullable_to_non_nullable
+              as Felt,
+      symbol: freezed == symbol
+          ? _value.symbol
+          : symbol // ignore: cast_nullable_to_non_nullable
+              as String?,
+      decimals: freezed == decimals
+          ? _value.decimals
+          : decimals // ignore: cast_nullable_to_non_nullable
+              as num?,
+      image: freezed == image
+          ? _value.image
+          : image // ignore: cast_nullable_to_non_nullable
+              as String?,
+      name: freezed == name
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$AssetOptionsImpl implements _AssetOptions {
+  const _$AssetOptionsImpl(
+      {required this.address,
+      this.symbol,
+      this.decimals,
+      this.image,
+      this.name});
+
+  factory _$AssetOptionsImpl.fromJson(Map<String, dynamic> json) =>
+      _$$AssetOptionsImplFromJson(json);
+
+  @override
+  final Felt address;
+  @override
+  final String? symbol;
+// TOKEN_SYMBOL constraints (pattern/length) not enforced by type system
+  @override
+  final num? decimals;
+  @override
+  final String? image;
+// TODO: Should be Uri?
+  @override
+  final String? name;
+
+  @override
+  String toString() {
+    return 'AssetOptions(address: $address, symbol: $symbol, decimals: $decimals, image: $image, name: $name)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$AssetOptionsImpl &&
+            (identical(other.address, address) || other.address == address) &&
+            (identical(other.symbol, symbol) || other.symbol == symbol) &&
+            (identical(other.decimals, decimals) ||
+                other.decimals == decimals) &&
+            (identical(other.image, image) || other.image == image) &&
+            (identical(other.name, name) || other.name == name));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, address, symbol, decimals, image, name);
+
+  /// Create a copy of AssetOptions
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$AssetOptionsImplCopyWith<_$AssetOptionsImpl> get copyWith =>
+      __$$AssetOptionsImplCopyWithImpl<_$AssetOptionsImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$AssetOptionsImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _AssetOptions implements AssetOptions {
+  const factory _AssetOptions(
+      {required final Felt address,
+      final String? symbol,
+      final num? decimals,
+      final String? image,
+      final String? name}) = _$AssetOptionsImpl;
+
+  factory _AssetOptions.fromJson(Map<String, dynamic> json) =
+      _$AssetOptionsImpl.fromJson;
+
+  @override
+  Felt get address;
+  @override
+  String?
+      get symbol; // TOKEN_SYMBOL constraints (pattern/length) not enforced by type system
+  @override
+  num? get decimals;
+  @override
+  String? get image; // TODO: Should be Uri?
+  @override
+  String? get name;
+
+  /// Create a copy of AssetOptions
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$AssetOptionsImplCopyWith<_$AssetOptionsImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/packages/wallet_provider/lib/src/model/asset.g.dart
+++ b/packages/wallet_provider/lib/src/model/asset.g.dart
@@ -1,0 +1,37 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'asset.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$ERC20AssetImpl _$$ERC20AssetImplFromJson(Map<String, dynamic> json) =>
+    _$ERC20AssetImpl(
+      options: AssetOptions.fromJson(json['options'] as Map<String, dynamic>),
+      type: json['type'] as String? ?? "ERC20",
+    );
+
+Map<String, dynamic> _$$ERC20AssetImplToJson(_$ERC20AssetImpl instance) =>
+    <String, dynamic>{
+      'options': instance.options.toJson(),
+      'type': instance.type,
+    };
+
+_$AssetOptionsImpl _$$AssetOptionsImplFromJson(Map<String, dynamic> json) =>
+    _$AssetOptionsImpl(
+      address: Felt.fromJson(json['address'] as String),
+      symbol: json['symbol'] as String?,
+      decimals: json['decimals'] as num?,
+      image: json['image'] as String?,
+      name: json['name'] as String?,
+    );
+
+Map<String, dynamic> _$$AssetOptionsImplToJson(_$AssetOptionsImpl instance) =>
+    <String, dynamic>{
+      'address': instance.address.toJson(),
+      'symbol': instance.symbol,
+      'decimals': instance.decimals,
+      'image': instance.image,
+      'name': instance.name,
+    };

--- a/packages/wallet_provider/lib/src/model/contract_class.dart
+++ b/packages/wallet_provider/lib/src/model/contract_class.dart
@@ -1,0 +1,64 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:starknet/starknet.dart';
+
+part 'contract_class.freezed.dart';
+part 'contract_class.g.dart';
+
+abstract class IContractClass {
+  factory IContractClass.fromJson(Map<String, Object?> json) =>
+      json.containsKey('sierra_program')
+          ? SierraContractClass.fromJson(json)
+          : DeprecatedContractClass.fromJson(json);
+  Map<String, Object?> toJson();
+}
+
+/// Title: Contract class
+/// Description: The definition of a Starknet contract class (Sierra).
+@freezed
+class ContractClass with _$ContractClass {
+  const factory ContractClass({
+    /// The list of Sierra instructions of which the program consists.
+    @JsonKey(name: 'sierra_program') required List<Felt> sierraProgram,
+
+    /// The version of the contract class object.
+    @JsonKey(name: 'contract_class_version')
+    required String contractClassVersion,
+
+    /// The entry points of the contract class, categorized by type.
+    @JsonKey(name: 'entry_points_by_type')
+    required EntryPointsByType entryPointsByType,
+
+    /// The class ABI, as supplied by the user declaring the class (optional in schema, but often present).
+    String? abi,
+  }) = _ContractClass;
+
+  factory ContractClass.fromJson(Map<String, Object?> json) =>
+      _$ContractClassFromJson(json);
+}
+
+@freezed
+class SierraContractClass with _$SierraContractClass implements IContractClass {
+  const factory SierraContractClass({
+    required List<Felt> sierraProgram,
+    required String contractClassVersion,
+    required EntryPointsByType entryPointsByType,
+    String? abi,
+  }) = _SierraContractClass;
+
+  factory SierraContractClass.fromJson(Map<String, Object?> json) =>
+      _$SierraContractClassFromJson(json);
+}
+
+@freezed
+class DeprecatedContractClass
+    with _$DeprecatedContractClass
+    implements IContractClass {
+  const factory DeprecatedContractClass({
+    required String program,
+    required DeprecatedCairoEntryPointsByType entryPointsByType,
+    List<DeprecatedContractAbiEntry>? abi,
+  }) = _DeprecatedContractClass;
+
+  factory DeprecatedContractClass.fromJson(Map<String, Object?> json) =>
+      _$DeprecatedContractClassFromJson(json);
+}

--- a/packages/wallet_provider/lib/src/model/contract_class.freezed.dart
+++ b/packages/wallet_provider/lib/src/model/contract_class.freezed.dart
@@ -1,0 +1,766 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'contract_class.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+ContractClass _$ContractClassFromJson(Map<String, dynamic> json) {
+  return _ContractClass.fromJson(json);
+}
+
+/// @nodoc
+mixin _$ContractClass {
+  /// The list of Sierra instructions of which the program consists.
+  @JsonKey(name: 'sierra_program')
+  List<Felt> get sierraProgram => throw _privateConstructorUsedError;
+
+  /// The version of the contract class object.
+  @JsonKey(name: 'contract_class_version')
+  String get contractClassVersion => throw _privateConstructorUsedError;
+
+  /// The entry points of the contract class, categorized by type.
+  @JsonKey(name: 'entry_points_by_type')
+  EntryPointsByType get entryPointsByType => throw _privateConstructorUsedError;
+
+  /// The class ABI, as supplied by the user declaring the class (optional in schema, but often present).
+  String? get abi => throw _privateConstructorUsedError;
+
+  /// Serializes this ContractClass to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of ContractClass
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $ContractClassCopyWith<ContractClass> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $ContractClassCopyWith<$Res> {
+  factory $ContractClassCopyWith(
+          ContractClass value, $Res Function(ContractClass) then) =
+      _$ContractClassCopyWithImpl<$Res, ContractClass>;
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'sierra_program') List<Felt> sierraProgram,
+      @JsonKey(name: 'contract_class_version') String contractClassVersion,
+      @JsonKey(name: 'entry_points_by_type')
+      EntryPointsByType entryPointsByType,
+      String? abi});
+
+  $EntryPointsByTypeCopyWith<$Res> get entryPointsByType;
+}
+
+/// @nodoc
+class _$ContractClassCopyWithImpl<$Res, $Val extends ContractClass>
+    implements $ContractClassCopyWith<$Res> {
+  _$ContractClassCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of ContractClass
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? sierraProgram = null,
+    Object? contractClassVersion = null,
+    Object? entryPointsByType = null,
+    Object? abi = freezed,
+  }) {
+    return _then(_value.copyWith(
+      sierraProgram: null == sierraProgram
+          ? _value.sierraProgram
+          : sierraProgram // ignore: cast_nullable_to_non_nullable
+              as List<Felt>,
+      contractClassVersion: null == contractClassVersion
+          ? _value.contractClassVersion
+          : contractClassVersion // ignore: cast_nullable_to_non_nullable
+              as String,
+      entryPointsByType: null == entryPointsByType
+          ? _value.entryPointsByType
+          : entryPointsByType // ignore: cast_nullable_to_non_nullable
+              as EntryPointsByType,
+      abi: freezed == abi
+          ? _value.abi
+          : abi // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ) as $Val);
+  }
+
+  /// Create a copy of ContractClass
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $EntryPointsByTypeCopyWith<$Res> get entryPointsByType {
+    return $EntryPointsByTypeCopyWith<$Res>(_value.entryPointsByType, (value) {
+      return _then(_value.copyWith(entryPointsByType: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$ContractClassImplCopyWith<$Res>
+    implements $ContractClassCopyWith<$Res> {
+  factory _$$ContractClassImplCopyWith(
+          _$ContractClassImpl value, $Res Function(_$ContractClassImpl) then) =
+      __$$ContractClassImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'sierra_program') List<Felt> sierraProgram,
+      @JsonKey(name: 'contract_class_version') String contractClassVersion,
+      @JsonKey(name: 'entry_points_by_type')
+      EntryPointsByType entryPointsByType,
+      String? abi});
+
+  @override
+  $EntryPointsByTypeCopyWith<$Res> get entryPointsByType;
+}
+
+/// @nodoc
+class __$$ContractClassImplCopyWithImpl<$Res>
+    extends _$ContractClassCopyWithImpl<$Res, _$ContractClassImpl>
+    implements _$$ContractClassImplCopyWith<$Res> {
+  __$$ContractClassImplCopyWithImpl(
+      _$ContractClassImpl _value, $Res Function(_$ContractClassImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of ContractClass
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? sierraProgram = null,
+    Object? contractClassVersion = null,
+    Object? entryPointsByType = null,
+    Object? abi = freezed,
+  }) {
+    return _then(_$ContractClassImpl(
+      sierraProgram: null == sierraProgram
+          ? _value._sierraProgram
+          : sierraProgram // ignore: cast_nullable_to_non_nullable
+              as List<Felt>,
+      contractClassVersion: null == contractClassVersion
+          ? _value.contractClassVersion
+          : contractClassVersion // ignore: cast_nullable_to_non_nullable
+              as String,
+      entryPointsByType: null == entryPointsByType
+          ? _value.entryPointsByType
+          : entryPointsByType // ignore: cast_nullable_to_non_nullable
+              as EntryPointsByType,
+      abi: freezed == abi
+          ? _value.abi
+          : abi // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$ContractClassImpl implements _ContractClass {
+  const _$ContractClassImpl(
+      {@JsonKey(name: 'sierra_program') required final List<Felt> sierraProgram,
+      @JsonKey(name: 'contract_class_version')
+      required this.contractClassVersion,
+      @JsonKey(name: 'entry_points_by_type') required this.entryPointsByType,
+      this.abi})
+      : _sierraProgram = sierraProgram;
+
+  factory _$ContractClassImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ContractClassImplFromJson(json);
+
+  /// The list of Sierra instructions of which the program consists.
+  final List<Felt> _sierraProgram;
+
+  /// The list of Sierra instructions of which the program consists.
+  @override
+  @JsonKey(name: 'sierra_program')
+  List<Felt> get sierraProgram {
+    if (_sierraProgram is EqualUnmodifiableListView) return _sierraProgram;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_sierraProgram);
+  }
+
+  /// The version of the contract class object.
+  @override
+  @JsonKey(name: 'contract_class_version')
+  final String contractClassVersion;
+
+  /// The entry points of the contract class, categorized by type.
+  @override
+  @JsonKey(name: 'entry_points_by_type')
+  final EntryPointsByType entryPointsByType;
+
+  /// The class ABI, as supplied by the user declaring the class (optional in schema, but often present).
+  @override
+  final String? abi;
+
+  @override
+  String toString() {
+    return 'ContractClass(sierraProgram: $sierraProgram, contractClassVersion: $contractClassVersion, entryPointsByType: $entryPointsByType, abi: $abi)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$ContractClassImpl &&
+            const DeepCollectionEquality()
+                .equals(other._sierraProgram, _sierraProgram) &&
+            (identical(other.contractClassVersion, contractClassVersion) ||
+                other.contractClassVersion == contractClassVersion) &&
+            (identical(other.entryPointsByType, entryPointsByType) ||
+                other.entryPointsByType == entryPointsByType) &&
+            (identical(other.abi, abi) || other.abi == abi));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(_sierraProgram),
+      contractClassVersion,
+      entryPointsByType,
+      abi);
+
+  /// Create a copy of ContractClass
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$ContractClassImplCopyWith<_$ContractClassImpl> get copyWith =>
+      __$$ContractClassImplCopyWithImpl<_$ContractClassImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$ContractClassImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _ContractClass implements ContractClass {
+  const factory _ContractClass(
+      {@JsonKey(name: 'sierra_program') required final List<Felt> sierraProgram,
+      @JsonKey(name: 'contract_class_version')
+      required final String contractClassVersion,
+      @JsonKey(name: 'entry_points_by_type')
+      required final EntryPointsByType entryPointsByType,
+      final String? abi}) = _$ContractClassImpl;
+
+  factory _ContractClass.fromJson(Map<String, dynamic> json) =
+      _$ContractClassImpl.fromJson;
+
+  /// The list of Sierra instructions of which the program consists.
+  @override
+  @JsonKey(name: 'sierra_program')
+  List<Felt> get sierraProgram;
+
+  /// The version of the contract class object.
+  @override
+  @JsonKey(name: 'contract_class_version')
+  String get contractClassVersion;
+
+  /// The entry points of the contract class, categorized by type.
+  @override
+  @JsonKey(name: 'entry_points_by_type')
+  EntryPointsByType get entryPointsByType;
+
+  /// The class ABI, as supplied by the user declaring the class (optional in schema, but often present).
+  @override
+  String? get abi;
+
+  /// Create a copy of ContractClass
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$ContractClassImplCopyWith<_$ContractClassImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+SierraContractClass _$SierraContractClassFromJson(Map<String, dynamic> json) {
+  return _SierraContractClass.fromJson(json);
+}
+
+/// @nodoc
+mixin _$SierraContractClass {
+  List<Felt> get sierraProgram => throw _privateConstructorUsedError;
+  String get contractClassVersion => throw _privateConstructorUsedError;
+  EntryPointsByType get entryPointsByType => throw _privateConstructorUsedError;
+  String? get abi => throw _privateConstructorUsedError;
+
+  /// Serializes this SierraContractClass to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of SierraContractClass
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $SierraContractClassCopyWith<SierraContractClass> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $SierraContractClassCopyWith<$Res> {
+  factory $SierraContractClassCopyWith(
+          SierraContractClass value, $Res Function(SierraContractClass) then) =
+      _$SierraContractClassCopyWithImpl<$Res, SierraContractClass>;
+  @useResult
+  $Res call(
+      {List<Felt> sierraProgram,
+      String contractClassVersion,
+      EntryPointsByType entryPointsByType,
+      String? abi});
+
+  $EntryPointsByTypeCopyWith<$Res> get entryPointsByType;
+}
+
+/// @nodoc
+class _$SierraContractClassCopyWithImpl<$Res, $Val extends SierraContractClass>
+    implements $SierraContractClassCopyWith<$Res> {
+  _$SierraContractClassCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of SierraContractClass
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? sierraProgram = null,
+    Object? contractClassVersion = null,
+    Object? entryPointsByType = null,
+    Object? abi = freezed,
+  }) {
+    return _then(_value.copyWith(
+      sierraProgram: null == sierraProgram
+          ? _value.sierraProgram
+          : sierraProgram // ignore: cast_nullable_to_non_nullable
+              as List<Felt>,
+      contractClassVersion: null == contractClassVersion
+          ? _value.contractClassVersion
+          : contractClassVersion // ignore: cast_nullable_to_non_nullable
+              as String,
+      entryPointsByType: null == entryPointsByType
+          ? _value.entryPointsByType
+          : entryPointsByType // ignore: cast_nullable_to_non_nullable
+              as EntryPointsByType,
+      abi: freezed == abi
+          ? _value.abi
+          : abi // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ) as $Val);
+  }
+
+  /// Create a copy of SierraContractClass
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $EntryPointsByTypeCopyWith<$Res> get entryPointsByType {
+    return $EntryPointsByTypeCopyWith<$Res>(_value.entryPointsByType, (value) {
+      return _then(_value.copyWith(entryPointsByType: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$SierraContractClassImplCopyWith<$Res>
+    implements $SierraContractClassCopyWith<$Res> {
+  factory _$$SierraContractClassImplCopyWith(_$SierraContractClassImpl value,
+          $Res Function(_$SierraContractClassImpl) then) =
+      __$$SierraContractClassImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {List<Felt> sierraProgram,
+      String contractClassVersion,
+      EntryPointsByType entryPointsByType,
+      String? abi});
+
+  @override
+  $EntryPointsByTypeCopyWith<$Res> get entryPointsByType;
+}
+
+/// @nodoc
+class __$$SierraContractClassImplCopyWithImpl<$Res>
+    extends _$SierraContractClassCopyWithImpl<$Res, _$SierraContractClassImpl>
+    implements _$$SierraContractClassImplCopyWith<$Res> {
+  __$$SierraContractClassImplCopyWithImpl(_$SierraContractClassImpl _value,
+      $Res Function(_$SierraContractClassImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of SierraContractClass
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? sierraProgram = null,
+    Object? contractClassVersion = null,
+    Object? entryPointsByType = null,
+    Object? abi = freezed,
+  }) {
+    return _then(_$SierraContractClassImpl(
+      sierraProgram: null == sierraProgram
+          ? _value._sierraProgram
+          : sierraProgram // ignore: cast_nullable_to_non_nullable
+              as List<Felt>,
+      contractClassVersion: null == contractClassVersion
+          ? _value.contractClassVersion
+          : contractClassVersion // ignore: cast_nullable_to_non_nullable
+              as String,
+      entryPointsByType: null == entryPointsByType
+          ? _value.entryPointsByType
+          : entryPointsByType // ignore: cast_nullable_to_non_nullable
+              as EntryPointsByType,
+      abi: freezed == abi
+          ? _value.abi
+          : abi // ignore: cast_nullable_to_non_nullable
+              as String?,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$SierraContractClassImpl implements _SierraContractClass {
+  const _$SierraContractClassImpl(
+      {required final List<Felt> sierraProgram,
+      required this.contractClassVersion,
+      required this.entryPointsByType,
+      this.abi})
+      : _sierraProgram = sierraProgram;
+
+  factory _$SierraContractClassImpl.fromJson(Map<String, dynamic> json) =>
+      _$$SierraContractClassImplFromJson(json);
+
+  final List<Felt> _sierraProgram;
+  @override
+  List<Felt> get sierraProgram {
+    if (_sierraProgram is EqualUnmodifiableListView) return _sierraProgram;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_sierraProgram);
+  }
+
+  @override
+  final String contractClassVersion;
+  @override
+  final EntryPointsByType entryPointsByType;
+  @override
+  final String? abi;
+
+  @override
+  String toString() {
+    return 'SierraContractClass(sierraProgram: $sierraProgram, contractClassVersion: $contractClassVersion, entryPointsByType: $entryPointsByType, abi: $abi)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$SierraContractClassImpl &&
+            const DeepCollectionEquality()
+                .equals(other._sierraProgram, _sierraProgram) &&
+            (identical(other.contractClassVersion, contractClassVersion) ||
+                other.contractClassVersion == contractClassVersion) &&
+            (identical(other.entryPointsByType, entryPointsByType) ||
+                other.entryPointsByType == entryPointsByType) &&
+            (identical(other.abi, abi) || other.abi == abi));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(_sierraProgram),
+      contractClassVersion,
+      entryPointsByType,
+      abi);
+
+  /// Create a copy of SierraContractClass
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$SierraContractClassImplCopyWith<_$SierraContractClassImpl> get copyWith =>
+      __$$SierraContractClassImplCopyWithImpl<_$SierraContractClassImpl>(
+          this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$SierraContractClassImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _SierraContractClass implements SierraContractClass {
+  const factory _SierraContractClass(
+      {required final List<Felt> sierraProgram,
+      required final String contractClassVersion,
+      required final EntryPointsByType entryPointsByType,
+      final String? abi}) = _$SierraContractClassImpl;
+
+  factory _SierraContractClass.fromJson(Map<String, dynamic> json) =
+      _$SierraContractClassImpl.fromJson;
+
+  @override
+  List<Felt> get sierraProgram;
+  @override
+  String get contractClassVersion;
+  @override
+  EntryPointsByType get entryPointsByType;
+  @override
+  String? get abi;
+
+  /// Create a copy of SierraContractClass
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$SierraContractClassImplCopyWith<_$SierraContractClassImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+DeprecatedContractClass _$DeprecatedContractClassFromJson(
+    Map<String, dynamic> json) {
+  return _DeprecatedContractClass.fromJson(json);
+}
+
+/// @nodoc
+mixin _$DeprecatedContractClass {
+  String get program => throw _privateConstructorUsedError;
+  DeprecatedCairoEntryPointsByType get entryPointsByType =>
+      throw _privateConstructorUsedError;
+  List<DeprecatedContractAbiEntry>? get abi =>
+      throw _privateConstructorUsedError;
+
+  /// Serializes this DeprecatedContractClass to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of DeprecatedContractClass
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $DeprecatedContractClassCopyWith<DeprecatedContractClass> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $DeprecatedContractClassCopyWith<$Res> {
+  factory $DeprecatedContractClassCopyWith(DeprecatedContractClass value,
+          $Res Function(DeprecatedContractClass) then) =
+      _$DeprecatedContractClassCopyWithImpl<$Res, DeprecatedContractClass>;
+  @useResult
+  $Res call(
+      {String program,
+      DeprecatedCairoEntryPointsByType entryPointsByType,
+      List<DeprecatedContractAbiEntry>? abi});
+
+  $DeprecatedCairoEntryPointsByTypeCopyWith<$Res> get entryPointsByType;
+}
+
+/// @nodoc
+class _$DeprecatedContractClassCopyWithImpl<$Res,
+        $Val extends DeprecatedContractClass>
+    implements $DeprecatedContractClassCopyWith<$Res> {
+  _$DeprecatedContractClassCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of DeprecatedContractClass
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? program = null,
+    Object? entryPointsByType = null,
+    Object? abi = freezed,
+  }) {
+    return _then(_value.copyWith(
+      program: null == program
+          ? _value.program
+          : program // ignore: cast_nullable_to_non_nullable
+              as String,
+      entryPointsByType: null == entryPointsByType
+          ? _value.entryPointsByType
+          : entryPointsByType // ignore: cast_nullable_to_non_nullable
+              as DeprecatedCairoEntryPointsByType,
+      abi: freezed == abi
+          ? _value.abi
+          : abi // ignore: cast_nullable_to_non_nullable
+              as List<DeprecatedContractAbiEntry>?,
+    ) as $Val);
+  }
+
+  /// Create a copy of DeprecatedContractClass
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $DeprecatedCairoEntryPointsByTypeCopyWith<$Res> get entryPointsByType {
+    return $DeprecatedCairoEntryPointsByTypeCopyWith<$Res>(
+        _value.entryPointsByType, (value) {
+      return _then(_value.copyWith(entryPointsByType: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$DeprecatedContractClassImplCopyWith<$Res>
+    implements $DeprecatedContractClassCopyWith<$Res> {
+  factory _$$DeprecatedContractClassImplCopyWith(
+          _$DeprecatedContractClassImpl value,
+          $Res Function(_$DeprecatedContractClassImpl) then) =
+      __$$DeprecatedContractClassImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {String program,
+      DeprecatedCairoEntryPointsByType entryPointsByType,
+      List<DeprecatedContractAbiEntry>? abi});
+
+  @override
+  $DeprecatedCairoEntryPointsByTypeCopyWith<$Res> get entryPointsByType;
+}
+
+/// @nodoc
+class __$$DeprecatedContractClassImplCopyWithImpl<$Res>
+    extends _$DeprecatedContractClassCopyWithImpl<$Res,
+        _$DeprecatedContractClassImpl>
+    implements _$$DeprecatedContractClassImplCopyWith<$Res> {
+  __$$DeprecatedContractClassImplCopyWithImpl(
+      _$DeprecatedContractClassImpl _value,
+      $Res Function(_$DeprecatedContractClassImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of DeprecatedContractClass
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? program = null,
+    Object? entryPointsByType = null,
+    Object? abi = freezed,
+  }) {
+    return _then(_$DeprecatedContractClassImpl(
+      program: null == program
+          ? _value.program
+          : program // ignore: cast_nullable_to_non_nullable
+              as String,
+      entryPointsByType: null == entryPointsByType
+          ? _value.entryPointsByType
+          : entryPointsByType // ignore: cast_nullable_to_non_nullable
+              as DeprecatedCairoEntryPointsByType,
+      abi: freezed == abi
+          ? _value._abi
+          : abi // ignore: cast_nullable_to_non_nullable
+              as List<DeprecatedContractAbiEntry>?,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$DeprecatedContractClassImpl implements _DeprecatedContractClass {
+  const _$DeprecatedContractClassImpl(
+      {required this.program,
+      required this.entryPointsByType,
+      final List<DeprecatedContractAbiEntry>? abi})
+      : _abi = abi;
+
+  factory _$DeprecatedContractClassImpl.fromJson(Map<String, dynamic> json) =>
+      _$$DeprecatedContractClassImplFromJson(json);
+
+  @override
+  final String program;
+  @override
+  final DeprecatedCairoEntryPointsByType entryPointsByType;
+  final List<DeprecatedContractAbiEntry>? _abi;
+  @override
+  List<DeprecatedContractAbiEntry>? get abi {
+    final value = _abi;
+    if (value == null) return null;
+    if (_abi is EqualUnmodifiableListView) return _abi;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(value);
+  }
+
+  @override
+  String toString() {
+    return 'DeprecatedContractClass(program: $program, entryPointsByType: $entryPointsByType, abi: $abi)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$DeprecatedContractClassImpl &&
+            (identical(other.program, program) || other.program == program) &&
+            (identical(other.entryPointsByType, entryPointsByType) ||
+                other.entryPointsByType == entryPointsByType) &&
+            const DeepCollectionEquality().equals(other._abi, _abi));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, program, entryPointsByType,
+      const DeepCollectionEquality().hash(_abi));
+
+  /// Create a copy of DeprecatedContractClass
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$DeprecatedContractClassImplCopyWith<_$DeprecatedContractClassImpl>
+      get copyWith => __$$DeprecatedContractClassImplCopyWithImpl<
+          _$DeprecatedContractClassImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$DeprecatedContractClassImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _DeprecatedContractClass implements DeprecatedContractClass {
+  const factory _DeprecatedContractClass(
+          {required final String program,
+          required final DeprecatedCairoEntryPointsByType entryPointsByType,
+          final List<DeprecatedContractAbiEntry>? abi}) =
+      _$DeprecatedContractClassImpl;
+
+  factory _DeprecatedContractClass.fromJson(Map<String, dynamic> json) =
+      _$DeprecatedContractClassImpl.fromJson;
+
+  @override
+  String get program;
+  @override
+  DeprecatedCairoEntryPointsByType get entryPointsByType;
+  @override
+  List<DeprecatedContractAbiEntry>? get abi;
+
+  /// Create a copy of DeprecatedContractClass
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$DeprecatedContractClassImplCopyWith<_$DeprecatedContractClassImpl>
+      get copyWith => throw _privateConstructorUsedError;
+}

--- a/packages/wallet_provider/lib/src/model/contract_class.g.dart
+++ b/packages/wallet_provider/lib/src/model/contract_class.g.dart
@@ -1,0 +1,67 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'contract_class.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$ContractClassImpl _$$ContractClassImplFromJson(Map<String, dynamic> json) =>
+    _$ContractClassImpl(
+      sierraProgram: (json['sierra_program'] as List<dynamic>)
+          .map((e) => Felt.fromJson(e as String))
+          .toList(),
+      contractClassVersion: json['contract_class_version'] as String,
+      entryPointsByType: EntryPointsByType.fromJson(
+          json['entry_points_by_type'] as Map<String, dynamic>),
+      abi: json['abi'] as String?,
+    );
+
+Map<String, dynamic> _$$ContractClassImplToJson(_$ContractClassImpl instance) =>
+    <String, dynamic>{
+      'sierra_program': instance.sierraProgram.map((e) => e.toJson()).toList(),
+      'contract_class_version': instance.contractClassVersion,
+      'entry_points_by_type': instance.entryPointsByType.toJson(),
+      'abi': instance.abi,
+    };
+
+_$SierraContractClassImpl _$$SierraContractClassImplFromJson(
+        Map<String, dynamic> json) =>
+    _$SierraContractClassImpl(
+      sierraProgram: (json['sierra_program'] as List<dynamic>)
+          .map((e) => Felt.fromJson(e as String))
+          .toList(),
+      contractClassVersion: json['contract_class_version'] as String,
+      entryPointsByType: EntryPointsByType.fromJson(
+          json['entry_points_by_type'] as Map<String, dynamic>),
+      abi: json['abi'] as String?,
+    );
+
+Map<String, dynamic> _$$SierraContractClassImplToJson(
+        _$SierraContractClassImpl instance) =>
+    <String, dynamic>{
+      'sierra_program': instance.sierraProgram.map((e) => e.toJson()).toList(),
+      'contract_class_version': instance.contractClassVersion,
+      'entry_points_by_type': instance.entryPointsByType.toJson(),
+      'abi': instance.abi,
+    };
+
+_$DeprecatedContractClassImpl _$$DeprecatedContractClassImplFromJson(
+        Map<String, dynamic> json) =>
+    _$DeprecatedContractClassImpl(
+      program: json['program'] as String,
+      entryPointsByType: DeprecatedCairoEntryPointsByType.fromJson(
+          json['entry_points_by_type'] as Map<String, dynamic>),
+      abi: (json['abi'] as List<dynamic>?)
+          ?.map((e) =>
+              DeprecatedContractAbiEntry.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+
+Map<String, dynamic> _$$DeprecatedContractClassImplToJson(
+        _$DeprecatedContractClassImpl instance) =>
+    <String, dynamic>{
+      'program': instance.program,
+      'entry_points_by_type': instance.entryPointsByType.toJson(),
+      'abi': instance.abi?.map((e) => e.toJson()).toList(),
+    };

--- a/packages/wallet_provider/lib/src/model/declare_txn_wallet.dart
+++ b/packages/wallet_provider/lib/src/model/declare_txn_wallet.dart
@@ -1,0 +1,20 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:starknet/starknet.dart';
+import 'contract_class.dart';
+
+part 'declare_txn_wallet.freezed.dart';
+part 'declare_txn_wallet.g.dart';
+
+/// Title: Declare Transaction
+/// Description: Declare Contract Transaction
+@freezed
+class DeclareTxnWallet with _$DeclareTxnWallet {
+  const factory DeclareTxnWallet({
+    @JsonKey(name: 'compiled_class_hash') required Felt compiledClassHash,
+    @JsonKey(name: 'class_hash') required Felt classHash,
+    @JsonKey(name: 'contract_class') required ContractClass contractClass,
+  }) = _DeclareTxnWallet;
+
+  factory DeclareTxnWallet.fromJson(Map<String, Object?> json) =>
+      _$DeclareTxnWalletFromJson(json);
+}

--- a/packages/wallet_provider/lib/src/model/declare_txn_wallet.freezed.dart
+++ b/packages/wallet_provider/lib/src/model/declare_txn_wallet.freezed.dart
@@ -1,0 +1,239 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'declare_txn_wallet.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+DeclareTxnWallet _$DeclareTxnWalletFromJson(Map<String, dynamic> json) {
+  return _DeclareTxnWallet.fromJson(json);
+}
+
+/// @nodoc
+mixin _$DeclareTxnWallet {
+  @JsonKey(name: 'compiled_class_hash')
+  Felt get compiledClassHash => throw _privateConstructorUsedError;
+  @JsonKey(name: 'class_hash')
+  Felt get classHash => throw _privateConstructorUsedError;
+  @JsonKey(name: 'contract_class')
+  ContractClass get contractClass => throw _privateConstructorUsedError;
+
+  /// Serializes this DeclareTxnWallet to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of DeclareTxnWallet
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $DeclareTxnWalletCopyWith<DeclareTxnWallet> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $DeclareTxnWalletCopyWith<$Res> {
+  factory $DeclareTxnWalletCopyWith(
+          DeclareTxnWallet value, $Res Function(DeclareTxnWallet) then) =
+      _$DeclareTxnWalletCopyWithImpl<$Res, DeclareTxnWallet>;
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'compiled_class_hash') Felt compiledClassHash,
+      @JsonKey(name: 'class_hash') Felt classHash,
+      @JsonKey(name: 'contract_class') ContractClass contractClass});
+
+  $ContractClassCopyWith<$Res> get contractClass;
+}
+
+/// @nodoc
+class _$DeclareTxnWalletCopyWithImpl<$Res, $Val extends DeclareTxnWallet>
+    implements $DeclareTxnWalletCopyWith<$Res> {
+  _$DeclareTxnWalletCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of DeclareTxnWallet
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? compiledClassHash = null,
+    Object? classHash = null,
+    Object? contractClass = null,
+  }) {
+    return _then(_value.copyWith(
+      compiledClassHash: null == compiledClassHash
+          ? _value.compiledClassHash
+          : compiledClassHash // ignore: cast_nullable_to_non_nullable
+              as Felt,
+      classHash: null == classHash
+          ? _value.classHash
+          : classHash // ignore: cast_nullable_to_non_nullable
+              as Felt,
+      contractClass: null == contractClass
+          ? _value.contractClass
+          : contractClass // ignore: cast_nullable_to_non_nullable
+              as ContractClass,
+    ) as $Val);
+  }
+
+  /// Create a copy of DeclareTxnWallet
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $ContractClassCopyWith<$Res> get contractClass {
+    return $ContractClassCopyWith<$Res>(_value.contractClass, (value) {
+      return _then(_value.copyWith(contractClass: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$DeclareTxnWalletImplCopyWith<$Res>
+    implements $DeclareTxnWalletCopyWith<$Res> {
+  factory _$$DeclareTxnWalletImplCopyWith(_$DeclareTxnWalletImpl value,
+          $Res Function(_$DeclareTxnWalletImpl) then) =
+      __$$DeclareTxnWalletImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'compiled_class_hash') Felt compiledClassHash,
+      @JsonKey(name: 'class_hash') Felt classHash,
+      @JsonKey(name: 'contract_class') ContractClass contractClass});
+
+  @override
+  $ContractClassCopyWith<$Res> get contractClass;
+}
+
+/// @nodoc
+class __$$DeclareTxnWalletImplCopyWithImpl<$Res>
+    extends _$DeclareTxnWalletCopyWithImpl<$Res, _$DeclareTxnWalletImpl>
+    implements _$$DeclareTxnWalletImplCopyWith<$Res> {
+  __$$DeclareTxnWalletImplCopyWithImpl(_$DeclareTxnWalletImpl _value,
+      $Res Function(_$DeclareTxnWalletImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of DeclareTxnWallet
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? compiledClassHash = null,
+    Object? classHash = null,
+    Object? contractClass = null,
+  }) {
+    return _then(_$DeclareTxnWalletImpl(
+      compiledClassHash: null == compiledClassHash
+          ? _value.compiledClassHash
+          : compiledClassHash // ignore: cast_nullable_to_non_nullable
+              as Felt,
+      classHash: null == classHash
+          ? _value.classHash
+          : classHash // ignore: cast_nullable_to_non_nullable
+              as Felt,
+      contractClass: null == contractClass
+          ? _value.contractClass
+          : contractClass // ignore: cast_nullable_to_non_nullable
+              as ContractClass,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$DeclareTxnWalletImpl implements _DeclareTxnWallet {
+  const _$DeclareTxnWalletImpl(
+      {@JsonKey(name: 'compiled_class_hash') required this.compiledClassHash,
+      @JsonKey(name: 'class_hash') required this.classHash,
+      @JsonKey(name: 'contract_class') required this.contractClass});
+
+  factory _$DeclareTxnWalletImpl.fromJson(Map<String, dynamic> json) =>
+      _$$DeclareTxnWalletImplFromJson(json);
+
+  @override
+  @JsonKey(name: 'compiled_class_hash')
+  final Felt compiledClassHash;
+  @override
+  @JsonKey(name: 'class_hash')
+  final Felt classHash;
+  @override
+  @JsonKey(name: 'contract_class')
+  final ContractClass contractClass;
+
+  @override
+  String toString() {
+    return 'DeclareTxnWallet(compiledClassHash: $compiledClassHash, classHash: $classHash, contractClass: $contractClass)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$DeclareTxnWalletImpl &&
+            (identical(other.compiledClassHash, compiledClassHash) ||
+                other.compiledClassHash == compiledClassHash) &&
+            (identical(other.classHash, classHash) ||
+                other.classHash == classHash) &&
+            (identical(other.contractClass, contractClass) ||
+                other.contractClass == contractClass));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, compiledClassHash, classHash, contractClass);
+
+  /// Create a copy of DeclareTxnWallet
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$DeclareTxnWalletImplCopyWith<_$DeclareTxnWalletImpl> get copyWith =>
+      __$$DeclareTxnWalletImplCopyWithImpl<_$DeclareTxnWalletImpl>(
+          this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$DeclareTxnWalletImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _DeclareTxnWallet implements DeclareTxnWallet {
+  const factory _DeclareTxnWallet(
+      {@JsonKey(name: 'compiled_class_hash')
+      required final Felt compiledClassHash,
+      @JsonKey(name: 'class_hash') required final Felt classHash,
+      @JsonKey(name: 'contract_class')
+      required final ContractClass contractClass}) = _$DeclareTxnWalletImpl;
+
+  factory _DeclareTxnWallet.fromJson(Map<String, dynamic> json) =
+      _$DeclareTxnWalletImpl.fromJson;
+
+  @override
+  @JsonKey(name: 'compiled_class_hash')
+  Felt get compiledClassHash;
+  @override
+  @JsonKey(name: 'class_hash')
+  Felt get classHash;
+  @override
+  @JsonKey(name: 'contract_class')
+  ContractClass get contractClass;
+
+  /// Create a copy of DeclareTxnWallet
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$DeclareTxnWalletImplCopyWith<_$DeclareTxnWalletImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/packages/wallet_provider/lib/src/model/declare_txn_wallet.g.dart
+++ b/packages/wallet_provider/lib/src/model/declare_txn_wallet.g.dart
@@ -1,0 +1,24 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'declare_txn_wallet.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$DeclareTxnWalletImpl _$$DeclareTxnWalletImplFromJson(
+        Map<String, dynamic> json) =>
+    _$DeclareTxnWalletImpl(
+      compiledClassHash: Felt.fromJson(json['compiled_class_hash'] as String),
+      classHash: Felt.fromJson(json['class_hash'] as String),
+      contractClass: ContractClass.fromJson(
+          json['contract_class'] as Map<String, dynamic>),
+    );
+
+Map<String, dynamic> _$$DeclareTxnWalletImplToJson(
+        _$DeclareTxnWalletImpl instance) =>
+    <String, dynamic>{
+      'compiled_class_hash': instance.compiledClassHash.toJson(),
+      'class_hash': instance.classHash.toJson(),
+      'contract_class': instance.contractClass.toJson(),
+    };

--- a/packages/wallet_provider/lib/src/model/deployment_version.dart
+++ b/packages/wallet_provider/lib/src/model/deployment_version.dart
@@ -1,0 +1,9 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+/// The Cairo version of the contract (0 or 1) for deployment data.
+enum DeploymentVersion {
+  @JsonValue(0)
+  v0,
+  @JsonValue(1)
+  v1,
+}

--- a/packages/wallet_provider/lib/src/model/index.dart
+++ b/packages/wallet_provider/lib/src/model/index.dart
@@ -1,0 +1,14 @@
+// Exports for Wallet API specific models
+export 'account_deployment_data.dart';
+export 'add_declare_transaction_result.dart';
+export 'add_invoke_transaction_result.dart';
+export 'api_version.dart';
+export 'asset.dart';
+export 'contract_class.dart';
+export 'declare_txn_wallet.dart';
+export 'invoke_call.dart';
+export 'permission.dart';
+export 'starknet_chain.dart';
+export 'typed_data.dart';
+export 'wallet_error.dart';
+export 'deployment_version.dart';

--- a/packages/wallet_provider/lib/src/model/invoke_call.dart
+++ b/packages/wallet_provider/lib/src/model/invoke_call.dart
@@ -1,0 +1,20 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:starknet/starknet.dart';
+
+part 'invoke_call.freezed.dart';
+part 'invoke_call.g.dart';
+
+/// Title: Invoke transaction
+/// Description: initiates a transaction from a given account
+@freezed
+class InvokeCall with _$InvokeCall {
+  const factory InvokeCall({
+    @JsonKey(name: 'contract_address') required Felt contractAddress,
+    @JsonKey(name: 'entry_point') required String entryPoint,
+    List<Felt>?
+        calldata, // TODO: Marked optional in spec, but usually needed? Defaulting to empty list if missing.
+  }) = _InvokeCall;
+
+  factory InvokeCall.fromJson(Map<String, Object?> json) =>
+      _$InvokeCallFromJson(json);
+}

--- a/packages/wallet_provider/lib/src/model/invoke_call.freezed.dart
+++ b/packages/wallet_provider/lib/src/model/invoke_call.freezed.dart
@@ -1,0 +1,225 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'invoke_call.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+InvokeCall _$InvokeCallFromJson(Map<String, dynamic> json) {
+  return _InvokeCall.fromJson(json);
+}
+
+/// @nodoc
+mixin _$InvokeCall {
+  @JsonKey(name: 'contract_address')
+  Felt get contractAddress => throw _privateConstructorUsedError;
+  @JsonKey(name: 'entry_point')
+  String get entryPoint => throw _privateConstructorUsedError;
+  List<Felt>? get calldata => throw _privateConstructorUsedError;
+
+  /// Serializes this InvokeCall to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of InvokeCall
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $InvokeCallCopyWith<InvokeCall> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $InvokeCallCopyWith<$Res> {
+  factory $InvokeCallCopyWith(
+          InvokeCall value, $Res Function(InvokeCall) then) =
+      _$InvokeCallCopyWithImpl<$Res, InvokeCall>;
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'contract_address') Felt contractAddress,
+      @JsonKey(name: 'entry_point') String entryPoint,
+      List<Felt>? calldata});
+}
+
+/// @nodoc
+class _$InvokeCallCopyWithImpl<$Res, $Val extends InvokeCall>
+    implements $InvokeCallCopyWith<$Res> {
+  _$InvokeCallCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of InvokeCall
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? contractAddress = null,
+    Object? entryPoint = null,
+    Object? calldata = freezed,
+  }) {
+    return _then(_value.copyWith(
+      contractAddress: null == contractAddress
+          ? _value.contractAddress
+          : contractAddress // ignore: cast_nullable_to_non_nullable
+              as Felt,
+      entryPoint: null == entryPoint
+          ? _value.entryPoint
+          : entryPoint // ignore: cast_nullable_to_non_nullable
+              as String,
+      calldata: freezed == calldata
+          ? _value.calldata
+          : calldata // ignore: cast_nullable_to_non_nullable
+              as List<Felt>?,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$InvokeCallImplCopyWith<$Res>
+    implements $InvokeCallCopyWith<$Res> {
+  factory _$$InvokeCallImplCopyWith(
+          _$InvokeCallImpl value, $Res Function(_$InvokeCallImpl) then) =
+      __$$InvokeCallImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {@JsonKey(name: 'contract_address') Felt contractAddress,
+      @JsonKey(name: 'entry_point') String entryPoint,
+      List<Felt>? calldata});
+}
+
+/// @nodoc
+class __$$InvokeCallImplCopyWithImpl<$Res>
+    extends _$InvokeCallCopyWithImpl<$Res, _$InvokeCallImpl>
+    implements _$$InvokeCallImplCopyWith<$Res> {
+  __$$InvokeCallImplCopyWithImpl(
+      _$InvokeCallImpl _value, $Res Function(_$InvokeCallImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of InvokeCall
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? contractAddress = null,
+    Object? entryPoint = null,
+    Object? calldata = freezed,
+  }) {
+    return _then(_$InvokeCallImpl(
+      contractAddress: null == contractAddress
+          ? _value.contractAddress
+          : contractAddress // ignore: cast_nullable_to_non_nullable
+              as Felt,
+      entryPoint: null == entryPoint
+          ? _value.entryPoint
+          : entryPoint // ignore: cast_nullable_to_non_nullable
+              as String,
+      calldata: freezed == calldata
+          ? _value._calldata
+          : calldata // ignore: cast_nullable_to_non_nullable
+              as List<Felt>?,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$InvokeCallImpl implements _InvokeCall {
+  const _$InvokeCallImpl(
+      {@JsonKey(name: 'contract_address') required this.contractAddress,
+      @JsonKey(name: 'entry_point') required this.entryPoint,
+      final List<Felt>? calldata})
+      : _calldata = calldata;
+
+  factory _$InvokeCallImpl.fromJson(Map<String, dynamic> json) =>
+      _$$InvokeCallImplFromJson(json);
+
+  @override
+  @JsonKey(name: 'contract_address')
+  final Felt contractAddress;
+  @override
+  @JsonKey(name: 'entry_point')
+  final String entryPoint;
+  final List<Felt>? _calldata;
+  @override
+  List<Felt>? get calldata {
+    final value = _calldata;
+    if (value == null) return null;
+    if (_calldata is EqualUnmodifiableListView) return _calldata;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(value);
+  }
+
+  @override
+  String toString() {
+    return 'InvokeCall(contractAddress: $contractAddress, entryPoint: $entryPoint, calldata: $calldata)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$InvokeCallImpl &&
+            (identical(other.contractAddress, contractAddress) ||
+                other.contractAddress == contractAddress) &&
+            (identical(other.entryPoint, entryPoint) ||
+                other.entryPoint == entryPoint) &&
+            const DeepCollectionEquality().equals(other._calldata, _calldata));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, contractAddress, entryPoint,
+      const DeepCollectionEquality().hash(_calldata));
+
+  /// Create a copy of InvokeCall
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$InvokeCallImplCopyWith<_$InvokeCallImpl> get copyWith =>
+      __$$InvokeCallImplCopyWithImpl<_$InvokeCallImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$InvokeCallImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _InvokeCall implements InvokeCall {
+  const factory _InvokeCall(
+      {@JsonKey(name: 'contract_address') required final Felt contractAddress,
+      @JsonKey(name: 'entry_point') required final String entryPoint,
+      final List<Felt>? calldata}) = _$InvokeCallImpl;
+
+  factory _InvokeCall.fromJson(Map<String, dynamic> json) =
+      _$InvokeCallImpl.fromJson;
+
+  @override
+  @JsonKey(name: 'contract_address')
+  Felt get contractAddress;
+  @override
+  @JsonKey(name: 'entry_point')
+  String get entryPoint;
+  @override
+  List<Felt>? get calldata;
+
+  /// Create a copy of InvokeCall
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$InvokeCallImplCopyWith<_$InvokeCallImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/packages/wallet_provider/lib/src/model/invoke_call.g.dart
+++ b/packages/wallet_provider/lib/src/model/invoke_call.g.dart
@@ -1,0 +1,23 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'invoke_call.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$InvokeCallImpl _$$InvokeCallImplFromJson(Map<String, dynamic> json) =>
+    _$InvokeCallImpl(
+      contractAddress: Felt.fromJson(json['contract_address'] as String),
+      entryPoint: json['entry_point'] as String,
+      calldata: (json['calldata'] as List<dynamic>?)
+          ?.map((e) => Felt.fromJson(e as String))
+          .toList(),
+    );
+
+Map<String, dynamic> _$$InvokeCallImplToJson(_$InvokeCallImpl instance) =>
+    <String, dynamic>{
+      'contract_address': instance.contractAddress.toJson(),
+      'entry_point': instance.entryPoint,
+      'calldata': instance.calldata?.map((e) => e.toJson()).toList(),
+    };

--- a/packages/wallet_provider/lib/src/model/permission.dart
+++ b/packages/wallet_provider/lib/src/model/permission.dart
@@ -1,0 +1,5 @@
+/// Title: Wallet permission
+/// Description: Optional wallet permissions
+enum Permission {
+  accounts,
+}

--- a/packages/wallet_provider/lib/src/model/starknet_chain.dart
+++ b/packages/wallet_provider/lib/src/model/starknet_chain.dart
@@ -1,0 +1,28 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:starknet/starknet.dart'; // Assuming Felt is here for CHAIN_ID alias
+import 'asset.dart'; // Import the Asset type we just defined
+
+part 'starknet_chain.freezed.dart';
+part 'starknet_chain.g.dart';
+
+/// Title: Starknet Chain
+/// Description: Information for the chain to add to the wallet (used in wallet_addStarknetChain)
+@freezed
+class StarknetChain with _$StarknetChain {
+  const factory StarknetChain({
+    required String id,
+    @JsonKey(name: 'chain_id')
+    required Felt chainId, // Assuming Felt for CHAIN_ID
+    @JsonKey(name: 'chain_name') required String chainName,
+    @JsonKey(name: 'rpc_urls')
+    List<String>? rpcUrls, // TODO: Should be List<Uri>?
+    @JsonKey(name: 'block_explorer_url')
+    List<String>? blockExplorerUrl, // TODO: Should be List<Uri>?
+    @JsonKey(name: 'native_currency') Asset? nativeCurrency,
+    @JsonKey(name: 'icon_urls')
+    List<String>? iconUrls, // TODO: Should be List<Uri>?
+  }) = _StarknetChain;
+
+  factory StarknetChain.fromJson(Map<String, Object?> json) =>
+      _$StarknetChainFromJson(json);
+}

--- a/packages/wallet_provider/lib/src/model/starknet_chain.freezed.dart
+++ b/packages/wallet_provider/lib/src/model/starknet_chain.freezed.dart
@@ -1,0 +1,371 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'starknet_chain.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+StarknetChain _$StarknetChainFromJson(Map<String, dynamic> json) {
+  return _StarknetChain.fromJson(json);
+}
+
+/// @nodoc
+mixin _$StarknetChain {
+  String get id => throw _privateConstructorUsedError;
+  @JsonKey(name: 'chain_id')
+  Felt get chainId =>
+      throw _privateConstructorUsedError; // Assuming Felt for CHAIN_ID
+  @JsonKey(name: 'chain_name')
+  String get chainName => throw _privateConstructorUsedError;
+  @JsonKey(name: 'rpc_urls')
+  List<String>? get rpcUrls =>
+      throw _privateConstructorUsedError; // TODO: Should be List<Uri>?
+  @JsonKey(name: 'block_explorer_url')
+  List<String>? get blockExplorerUrl =>
+      throw _privateConstructorUsedError; // TODO: Should be List<Uri>?
+  @JsonKey(name: 'native_currency')
+  Asset? get nativeCurrency => throw _privateConstructorUsedError;
+  @JsonKey(name: 'icon_urls')
+  List<String>? get iconUrls => throw _privateConstructorUsedError;
+
+  /// Serializes this StarknetChain to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of StarknetChain
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $StarknetChainCopyWith<StarknetChain> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $StarknetChainCopyWith<$Res> {
+  factory $StarknetChainCopyWith(
+          StarknetChain value, $Res Function(StarknetChain) then) =
+      _$StarknetChainCopyWithImpl<$Res, StarknetChain>;
+  @useResult
+  $Res call(
+      {String id,
+      @JsonKey(name: 'chain_id') Felt chainId,
+      @JsonKey(name: 'chain_name') String chainName,
+      @JsonKey(name: 'rpc_urls') List<String>? rpcUrls,
+      @JsonKey(name: 'block_explorer_url') List<String>? blockExplorerUrl,
+      @JsonKey(name: 'native_currency') Asset? nativeCurrency,
+      @JsonKey(name: 'icon_urls') List<String>? iconUrls});
+
+  $AssetCopyWith<$Res>? get nativeCurrency;
+}
+
+/// @nodoc
+class _$StarknetChainCopyWithImpl<$Res, $Val extends StarknetChain>
+    implements $StarknetChainCopyWith<$Res> {
+  _$StarknetChainCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of StarknetChain
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? chainId = null,
+    Object? chainName = null,
+    Object? rpcUrls = freezed,
+    Object? blockExplorerUrl = freezed,
+    Object? nativeCurrency = freezed,
+    Object? iconUrls = freezed,
+  }) {
+    return _then(_value.copyWith(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      chainId: null == chainId
+          ? _value.chainId
+          : chainId // ignore: cast_nullable_to_non_nullable
+              as Felt,
+      chainName: null == chainName
+          ? _value.chainName
+          : chainName // ignore: cast_nullable_to_non_nullable
+              as String,
+      rpcUrls: freezed == rpcUrls
+          ? _value.rpcUrls
+          : rpcUrls // ignore: cast_nullable_to_non_nullable
+              as List<String>?,
+      blockExplorerUrl: freezed == blockExplorerUrl
+          ? _value.blockExplorerUrl
+          : blockExplorerUrl // ignore: cast_nullable_to_non_nullable
+              as List<String>?,
+      nativeCurrency: freezed == nativeCurrency
+          ? _value.nativeCurrency
+          : nativeCurrency // ignore: cast_nullable_to_non_nullable
+              as Asset?,
+      iconUrls: freezed == iconUrls
+          ? _value.iconUrls
+          : iconUrls // ignore: cast_nullable_to_non_nullable
+              as List<String>?,
+    ) as $Val);
+  }
+
+  /// Create a copy of StarknetChain
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $AssetCopyWith<$Res>? get nativeCurrency {
+    if (_value.nativeCurrency == null) {
+      return null;
+    }
+
+    return $AssetCopyWith<$Res>(_value.nativeCurrency!, (value) {
+      return _then(_value.copyWith(nativeCurrency: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$StarknetChainImplCopyWith<$Res>
+    implements $StarknetChainCopyWith<$Res> {
+  factory _$$StarknetChainImplCopyWith(
+          _$StarknetChainImpl value, $Res Function(_$StarknetChainImpl) then) =
+      __$$StarknetChainImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {String id,
+      @JsonKey(name: 'chain_id') Felt chainId,
+      @JsonKey(name: 'chain_name') String chainName,
+      @JsonKey(name: 'rpc_urls') List<String>? rpcUrls,
+      @JsonKey(name: 'block_explorer_url') List<String>? blockExplorerUrl,
+      @JsonKey(name: 'native_currency') Asset? nativeCurrency,
+      @JsonKey(name: 'icon_urls') List<String>? iconUrls});
+
+  @override
+  $AssetCopyWith<$Res>? get nativeCurrency;
+}
+
+/// @nodoc
+class __$$StarknetChainImplCopyWithImpl<$Res>
+    extends _$StarknetChainCopyWithImpl<$Res, _$StarknetChainImpl>
+    implements _$$StarknetChainImplCopyWith<$Res> {
+  __$$StarknetChainImplCopyWithImpl(
+      _$StarknetChainImpl _value, $Res Function(_$StarknetChainImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of StarknetChain
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? id = null,
+    Object? chainId = null,
+    Object? chainName = null,
+    Object? rpcUrls = freezed,
+    Object? blockExplorerUrl = freezed,
+    Object? nativeCurrency = freezed,
+    Object? iconUrls = freezed,
+  }) {
+    return _then(_$StarknetChainImpl(
+      id: null == id
+          ? _value.id
+          : id // ignore: cast_nullable_to_non_nullable
+              as String,
+      chainId: null == chainId
+          ? _value.chainId
+          : chainId // ignore: cast_nullable_to_non_nullable
+              as Felt,
+      chainName: null == chainName
+          ? _value.chainName
+          : chainName // ignore: cast_nullable_to_non_nullable
+              as String,
+      rpcUrls: freezed == rpcUrls
+          ? _value._rpcUrls
+          : rpcUrls // ignore: cast_nullable_to_non_nullable
+              as List<String>?,
+      blockExplorerUrl: freezed == blockExplorerUrl
+          ? _value._blockExplorerUrl
+          : blockExplorerUrl // ignore: cast_nullable_to_non_nullable
+              as List<String>?,
+      nativeCurrency: freezed == nativeCurrency
+          ? _value.nativeCurrency
+          : nativeCurrency // ignore: cast_nullable_to_non_nullable
+              as Asset?,
+      iconUrls: freezed == iconUrls
+          ? _value._iconUrls
+          : iconUrls // ignore: cast_nullable_to_non_nullable
+              as List<String>?,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$StarknetChainImpl implements _StarknetChain {
+  const _$StarknetChainImpl(
+      {required this.id,
+      @JsonKey(name: 'chain_id') required this.chainId,
+      @JsonKey(name: 'chain_name') required this.chainName,
+      @JsonKey(name: 'rpc_urls') final List<String>? rpcUrls,
+      @JsonKey(name: 'block_explorer_url') final List<String>? blockExplorerUrl,
+      @JsonKey(name: 'native_currency') this.nativeCurrency,
+      @JsonKey(name: 'icon_urls') final List<String>? iconUrls})
+      : _rpcUrls = rpcUrls,
+        _blockExplorerUrl = blockExplorerUrl,
+        _iconUrls = iconUrls;
+
+  factory _$StarknetChainImpl.fromJson(Map<String, dynamic> json) =>
+      _$$StarknetChainImplFromJson(json);
+
+  @override
+  final String id;
+  @override
+  @JsonKey(name: 'chain_id')
+  final Felt chainId;
+// Assuming Felt for CHAIN_ID
+  @override
+  @JsonKey(name: 'chain_name')
+  final String chainName;
+  final List<String>? _rpcUrls;
+  @override
+  @JsonKey(name: 'rpc_urls')
+  List<String>? get rpcUrls {
+    final value = _rpcUrls;
+    if (value == null) return null;
+    if (_rpcUrls is EqualUnmodifiableListView) return _rpcUrls;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(value);
+  }
+
+// TODO: Should be List<Uri>?
+  final List<String>? _blockExplorerUrl;
+// TODO: Should be List<Uri>?
+  @override
+  @JsonKey(name: 'block_explorer_url')
+  List<String>? get blockExplorerUrl {
+    final value = _blockExplorerUrl;
+    if (value == null) return null;
+    if (_blockExplorerUrl is EqualUnmodifiableListView)
+      return _blockExplorerUrl;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(value);
+  }
+
+// TODO: Should be List<Uri>?
+  @override
+  @JsonKey(name: 'native_currency')
+  final Asset? nativeCurrency;
+  final List<String>? _iconUrls;
+  @override
+  @JsonKey(name: 'icon_urls')
+  List<String>? get iconUrls {
+    final value = _iconUrls;
+    if (value == null) return null;
+    if (_iconUrls is EqualUnmodifiableListView) return _iconUrls;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(value);
+  }
+
+  @override
+  String toString() {
+    return 'StarknetChain(id: $id, chainId: $chainId, chainName: $chainName, rpcUrls: $rpcUrls, blockExplorerUrl: $blockExplorerUrl, nativeCurrency: $nativeCurrency, iconUrls: $iconUrls)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$StarknetChainImpl &&
+            (identical(other.id, id) || other.id == id) &&
+            (identical(other.chainId, chainId) || other.chainId == chainId) &&
+            (identical(other.chainName, chainName) ||
+                other.chainName == chainName) &&
+            const DeepCollectionEquality().equals(other._rpcUrls, _rpcUrls) &&
+            const DeepCollectionEquality()
+                .equals(other._blockExplorerUrl, _blockExplorerUrl) &&
+            (identical(other.nativeCurrency, nativeCurrency) ||
+                other.nativeCurrency == nativeCurrency) &&
+            const DeepCollectionEquality().equals(other._iconUrls, _iconUrls));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      id,
+      chainId,
+      chainName,
+      const DeepCollectionEquality().hash(_rpcUrls),
+      const DeepCollectionEquality().hash(_blockExplorerUrl),
+      nativeCurrency,
+      const DeepCollectionEquality().hash(_iconUrls));
+
+  /// Create a copy of StarknetChain
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$StarknetChainImplCopyWith<_$StarknetChainImpl> get copyWith =>
+      __$$StarknetChainImplCopyWithImpl<_$StarknetChainImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$StarknetChainImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _StarknetChain implements StarknetChain {
+  const factory _StarknetChain(
+      {required final String id,
+      @JsonKey(name: 'chain_id') required final Felt chainId,
+      @JsonKey(name: 'chain_name') required final String chainName,
+      @JsonKey(name: 'rpc_urls') final List<String>? rpcUrls,
+      @JsonKey(name: 'block_explorer_url') final List<String>? blockExplorerUrl,
+      @JsonKey(name: 'native_currency') final Asset? nativeCurrency,
+      @JsonKey(name: 'icon_urls')
+      final List<String>? iconUrls}) = _$StarknetChainImpl;
+
+  factory _StarknetChain.fromJson(Map<String, dynamic> json) =
+      _$StarknetChainImpl.fromJson;
+
+  @override
+  String get id;
+  @override
+  @JsonKey(name: 'chain_id')
+  Felt get chainId; // Assuming Felt for CHAIN_ID
+  @override
+  @JsonKey(name: 'chain_name')
+  String get chainName;
+  @override
+  @JsonKey(name: 'rpc_urls')
+  List<String>? get rpcUrls; // TODO: Should be List<Uri>?
+  @override
+  @JsonKey(name: 'block_explorer_url')
+  List<String>? get blockExplorerUrl; // TODO: Should be List<Uri>?
+  @override
+  @JsonKey(name: 'native_currency')
+  Asset? get nativeCurrency;
+  @override
+  @JsonKey(name: 'icon_urls')
+  List<String>? get iconUrls;
+
+  /// Create a copy of StarknetChain
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$StarknetChainImplCopyWith<_$StarknetChainImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/packages/wallet_provider/lib/src/model/starknet_chain.g.dart
+++ b/packages/wallet_provider/lib/src/model/starknet_chain.g.dart
@@ -1,0 +1,37 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'starknet_chain.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$StarknetChainImpl _$$StarknetChainImplFromJson(Map<String, dynamic> json) =>
+    _$StarknetChainImpl(
+      id: json['id'] as String,
+      chainId: Felt.fromJson(json['chain_id'] as String),
+      chainName: json['chain_name'] as String,
+      rpcUrls: (json['rpc_urls'] as List<dynamic>?)
+          ?.map((e) => e as String)
+          .toList(),
+      blockExplorerUrl: (json['block_explorer_url'] as List<dynamic>?)
+          ?.map((e) => e as String)
+          .toList(),
+      nativeCurrency: json['native_currency'] == null
+          ? null
+          : Asset.fromJson(json['native_currency'] as Map<String, dynamic>),
+      iconUrls: (json['icon_urls'] as List<dynamic>?)
+          ?.map((e) => e as String)
+          .toList(),
+    );
+
+Map<String, dynamic> _$$StarknetChainImplToJson(_$StarknetChainImpl instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'chain_id': instance.chainId.toJson(),
+      'chain_name': instance.chainName,
+      'rpc_urls': instance.rpcUrls,
+      'block_explorer_url': instance.blockExplorerUrl,
+      'native_currency': instance.nativeCurrency?.toJson(),
+      'icon_urls': instance.iconUrls,
+    };

--- a/packages/wallet_provider/lib/src/model/typed_data.dart
+++ b/packages/wallet_provider/lib/src/model/typed_data.dart
@@ -1,0 +1,40 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:starknet/starknet.dart'; // Import Felt
+
+part 'typed_data.freezed.dart';
+part 'typed_data.g.dart';
+
+// TODO: Define StarknetType properly (object, merkletree, enum variants)
+// Using dynamic for now as placeholder
+typedef StarknetType = Map<String, dynamic>;
+
+/// Title: Typed Data
+/// Description: The typed data to sign (used in wallet_signTypedData)
+@freezed
+class TypedData with _$TypedData {
+  const factory TypedData({
+    required Map<String, List<StarknetType>> types,
+    required String primaryType,
+    required StarknetDomain domain,
+    required Map<String, dynamic> message,
+  }) = _TypedData;
+
+  factory TypedData.fromJson(Map<String, Object?> json) =>
+      _$TypedDataFromJson(json);
+}
+
+/// Title: Starknet Domain
+/// Description: The EIP712 domain struct used within TypedData. Must contain at least one field.
+@freezed
+class StarknetDomain with _$StarknetDomain {
+  const factory StarknetDomain({
+    // Use Felt for name and version according to common TypedData structures
+    Felt? name,
+    Felt? version,
+    Felt? chainId, // Already using Felt/dynamic, make it Felt?
+    Felt? revision, // Add revision as Felt?
+  }) = _StarknetDomain;
+
+  factory StarknetDomain.fromJson(Map<String, Object?> json) =>
+      _$StarknetDomainFromJson(json);
+}

--- a/packages/wallet_provider/lib/src/model/typed_data.freezed.dart
+++ b/packages/wallet_provider/lib/src/model/typed_data.freezed.dart
@@ -1,0 +1,472 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'typed_data.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+TypedData _$TypedDataFromJson(Map<String, dynamic> json) {
+  return _TypedData.fromJson(json);
+}
+
+/// @nodoc
+mixin _$TypedData {
+  Map<String, List<StarknetType>> get types =>
+      throw _privateConstructorUsedError;
+  String get primaryType => throw _privateConstructorUsedError;
+  StarknetDomain get domain => throw _privateConstructorUsedError;
+  Map<String, dynamic> get message => throw _privateConstructorUsedError;
+
+  /// Serializes this TypedData to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of TypedData
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $TypedDataCopyWith<TypedData> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $TypedDataCopyWith<$Res> {
+  factory $TypedDataCopyWith(TypedData value, $Res Function(TypedData) then) =
+      _$TypedDataCopyWithImpl<$Res, TypedData>;
+  @useResult
+  $Res call(
+      {Map<String, List<StarknetType>> types,
+      String primaryType,
+      StarknetDomain domain,
+      Map<String, dynamic> message});
+
+  $StarknetDomainCopyWith<$Res> get domain;
+}
+
+/// @nodoc
+class _$TypedDataCopyWithImpl<$Res, $Val extends TypedData>
+    implements $TypedDataCopyWith<$Res> {
+  _$TypedDataCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of TypedData
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? types = null,
+    Object? primaryType = null,
+    Object? domain = null,
+    Object? message = null,
+  }) {
+    return _then(_value.copyWith(
+      types: null == types
+          ? _value.types
+          : types // ignore: cast_nullable_to_non_nullable
+              as Map<String, List<StarknetType>>,
+      primaryType: null == primaryType
+          ? _value.primaryType
+          : primaryType // ignore: cast_nullable_to_non_nullable
+              as String,
+      domain: null == domain
+          ? _value.domain
+          : domain // ignore: cast_nullable_to_non_nullable
+              as StarknetDomain,
+      message: null == message
+          ? _value.message
+          : message // ignore: cast_nullable_to_non_nullable
+              as Map<String, dynamic>,
+    ) as $Val);
+  }
+
+  /// Create a copy of TypedData
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $StarknetDomainCopyWith<$Res> get domain {
+    return $StarknetDomainCopyWith<$Res>(_value.domain, (value) {
+      return _then(_value.copyWith(domain: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$TypedDataImplCopyWith<$Res>
+    implements $TypedDataCopyWith<$Res> {
+  factory _$$TypedDataImplCopyWith(
+          _$TypedDataImpl value, $Res Function(_$TypedDataImpl) then) =
+      __$$TypedDataImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {Map<String, List<StarknetType>> types,
+      String primaryType,
+      StarknetDomain domain,
+      Map<String, dynamic> message});
+
+  @override
+  $StarknetDomainCopyWith<$Res> get domain;
+}
+
+/// @nodoc
+class __$$TypedDataImplCopyWithImpl<$Res>
+    extends _$TypedDataCopyWithImpl<$Res, _$TypedDataImpl>
+    implements _$$TypedDataImplCopyWith<$Res> {
+  __$$TypedDataImplCopyWithImpl(
+      _$TypedDataImpl _value, $Res Function(_$TypedDataImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of TypedData
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? types = null,
+    Object? primaryType = null,
+    Object? domain = null,
+    Object? message = null,
+  }) {
+    return _then(_$TypedDataImpl(
+      types: null == types
+          ? _value._types
+          : types // ignore: cast_nullable_to_non_nullable
+              as Map<String, List<StarknetType>>,
+      primaryType: null == primaryType
+          ? _value.primaryType
+          : primaryType // ignore: cast_nullable_to_non_nullable
+              as String,
+      domain: null == domain
+          ? _value.domain
+          : domain // ignore: cast_nullable_to_non_nullable
+              as StarknetDomain,
+      message: null == message
+          ? _value._message
+          : message // ignore: cast_nullable_to_non_nullable
+              as Map<String, dynamic>,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$TypedDataImpl implements _TypedData {
+  const _$TypedDataImpl(
+      {required final Map<String, List<StarknetType>> types,
+      required this.primaryType,
+      required this.domain,
+      required final Map<String, dynamic> message})
+      : _types = types,
+        _message = message;
+
+  factory _$TypedDataImpl.fromJson(Map<String, dynamic> json) =>
+      _$$TypedDataImplFromJson(json);
+
+  final Map<String, List<StarknetType>> _types;
+  @override
+  Map<String, List<StarknetType>> get types {
+    if (_types is EqualUnmodifiableMapView) return _types;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableMapView(_types);
+  }
+
+  @override
+  final String primaryType;
+  @override
+  final StarknetDomain domain;
+  final Map<String, dynamic> _message;
+  @override
+  Map<String, dynamic> get message {
+    if (_message is EqualUnmodifiableMapView) return _message;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableMapView(_message);
+  }
+
+  @override
+  String toString() {
+    return 'TypedData(types: $types, primaryType: $primaryType, domain: $domain, message: $message)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$TypedDataImpl &&
+            const DeepCollectionEquality().equals(other._types, _types) &&
+            (identical(other.primaryType, primaryType) ||
+                other.primaryType == primaryType) &&
+            (identical(other.domain, domain) || other.domain == domain) &&
+            const DeepCollectionEquality().equals(other._message, _message));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType,
+      const DeepCollectionEquality().hash(_types),
+      primaryType,
+      domain,
+      const DeepCollectionEquality().hash(_message));
+
+  /// Create a copy of TypedData
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$TypedDataImplCopyWith<_$TypedDataImpl> get copyWith =>
+      __$$TypedDataImplCopyWithImpl<_$TypedDataImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$TypedDataImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _TypedData implements TypedData {
+  const factory _TypedData(
+      {required final Map<String, List<StarknetType>> types,
+      required final String primaryType,
+      required final StarknetDomain domain,
+      required final Map<String, dynamic> message}) = _$TypedDataImpl;
+
+  factory _TypedData.fromJson(Map<String, dynamic> json) =
+      _$TypedDataImpl.fromJson;
+
+  @override
+  Map<String, List<StarknetType>> get types;
+  @override
+  String get primaryType;
+  @override
+  StarknetDomain get domain;
+  @override
+  Map<String, dynamic> get message;
+
+  /// Create a copy of TypedData
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$TypedDataImplCopyWith<_$TypedDataImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+StarknetDomain _$StarknetDomainFromJson(Map<String, dynamic> json) {
+  return _StarknetDomain.fromJson(json);
+}
+
+/// @nodoc
+mixin _$StarknetDomain {
+// Use Felt for name and version according to common TypedData structures
+  Felt? get name => throw _privateConstructorUsedError;
+  Felt? get version => throw _privateConstructorUsedError;
+  Felt? get chainId =>
+      throw _privateConstructorUsedError; // Already using Felt/dynamic, make it Felt?
+  Felt? get revision => throw _privateConstructorUsedError;
+
+  /// Serializes this StarknetDomain to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of StarknetDomain
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $StarknetDomainCopyWith<StarknetDomain> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $StarknetDomainCopyWith<$Res> {
+  factory $StarknetDomainCopyWith(
+          StarknetDomain value, $Res Function(StarknetDomain) then) =
+      _$StarknetDomainCopyWithImpl<$Res, StarknetDomain>;
+  @useResult
+  $Res call({Felt? name, Felt? version, Felt? chainId, Felt? revision});
+}
+
+/// @nodoc
+class _$StarknetDomainCopyWithImpl<$Res, $Val extends StarknetDomain>
+    implements $StarknetDomainCopyWith<$Res> {
+  _$StarknetDomainCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of StarknetDomain
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? name = freezed,
+    Object? version = freezed,
+    Object? chainId = freezed,
+    Object? revision = freezed,
+  }) {
+    return _then(_value.copyWith(
+      name: freezed == name
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as Felt?,
+      version: freezed == version
+          ? _value.version
+          : version // ignore: cast_nullable_to_non_nullable
+              as Felt?,
+      chainId: freezed == chainId
+          ? _value.chainId
+          : chainId // ignore: cast_nullable_to_non_nullable
+              as Felt?,
+      revision: freezed == revision
+          ? _value.revision
+          : revision // ignore: cast_nullable_to_non_nullable
+              as Felt?,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$StarknetDomainImplCopyWith<$Res>
+    implements $StarknetDomainCopyWith<$Res> {
+  factory _$$StarknetDomainImplCopyWith(_$StarknetDomainImpl value,
+          $Res Function(_$StarknetDomainImpl) then) =
+      __$$StarknetDomainImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({Felt? name, Felt? version, Felt? chainId, Felt? revision});
+}
+
+/// @nodoc
+class __$$StarknetDomainImplCopyWithImpl<$Res>
+    extends _$StarknetDomainCopyWithImpl<$Res, _$StarknetDomainImpl>
+    implements _$$StarknetDomainImplCopyWith<$Res> {
+  __$$StarknetDomainImplCopyWithImpl(
+      _$StarknetDomainImpl _value, $Res Function(_$StarknetDomainImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of StarknetDomain
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? name = freezed,
+    Object? version = freezed,
+    Object? chainId = freezed,
+    Object? revision = freezed,
+  }) {
+    return _then(_$StarknetDomainImpl(
+      name: freezed == name
+          ? _value.name
+          : name // ignore: cast_nullable_to_non_nullable
+              as Felt?,
+      version: freezed == version
+          ? _value.version
+          : version // ignore: cast_nullable_to_non_nullable
+              as Felt?,
+      chainId: freezed == chainId
+          ? _value.chainId
+          : chainId // ignore: cast_nullable_to_non_nullable
+              as Felt?,
+      revision: freezed == revision
+          ? _value.revision
+          : revision // ignore: cast_nullable_to_non_nullable
+              as Felt?,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$StarknetDomainImpl implements _StarknetDomain {
+  const _$StarknetDomainImpl(
+      {this.name, this.version, this.chainId, this.revision});
+
+  factory _$StarknetDomainImpl.fromJson(Map<String, dynamic> json) =>
+      _$$StarknetDomainImplFromJson(json);
+
+// Use Felt for name and version according to common TypedData structures
+  @override
+  final Felt? name;
+  @override
+  final Felt? version;
+  @override
+  final Felt? chainId;
+// Already using Felt/dynamic, make it Felt?
+  @override
+  final Felt? revision;
+
+  @override
+  String toString() {
+    return 'StarknetDomain(name: $name, version: $version, chainId: $chainId, revision: $revision)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$StarknetDomainImpl &&
+            (identical(other.name, name) || other.name == name) &&
+            (identical(other.version, version) || other.version == version) &&
+            (identical(other.chainId, chainId) || other.chainId == chainId) &&
+            (identical(other.revision, revision) ||
+                other.revision == revision));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode =>
+      Object.hash(runtimeType, name, version, chainId, revision);
+
+  /// Create a copy of StarknetDomain
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$StarknetDomainImplCopyWith<_$StarknetDomainImpl> get copyWith =>
+      __$$StarknetDomainImplCopyWithImpl<_$StarknetDomainImpl>(
+          this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$StarknetDomainImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _StarknetDomain implements StarknetDomain {
+  const factory _StarknetDomain(
+      {final Felt? name,
+      final Felt? version,
+      final Felt? chainId,
+      final Felt? revision}) = _$StarknetDomainImpl;
+
+  factory _StarknetDomain.fromJson(Map<String, dynamic> json) =
+      _$StarknetDomainImpl.fromJson;
+
+// Use Felt for name and version according to common TypedData structures
+  @override
+  Felt? get name;
+  @override
+  Felt? get version;
+  @override
+  Felt? get chainId; // Already using Felt/dynamic, make it Felt?
+  @override
+  Felt? get revision;
+
+  /// Create a copy of StarknetDomain
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$StarknetDomainImplCopyWith<_$StarknetDomainImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/packages/wallet_provider/lib/src/model/typed_data.g.dart
+++ b/packages/wallet_provider/lib/src/model/typed_data.g.dart
@@ -1,0 +1,52 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'typed_data.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$TypedDataImpl _$$TypedDataImplFromJson(Map<String, dynamic> json) =>
+    _$TypedDataImpl(
+      types: (json['types'] as Map<String, dynamic>).map(
+        (k, e) => MapEntry(
+            k,
+            (e as List<dynamic>)
+                .map((e) => e as Map<String, dynamic>)
+                .toList()),
+      ),
+      primaryType: json['primary_type'] as String,
+      domain: StarknetDomain.fromJson(json['domain'] as Map<String, dynamic>),
+      message: json['message'] as Map<String, dynamic>,
+    );
+
+Map<String, dynamic> _$$TypedDataImplToJson(_$TypedDataImpl instance) =>
+    <String, dynamic>{
+      'types': instance.types,
+      'primary_type': instance.primaryType,
+      'domain': instance.domain.toJson(),
+      'message': instance.message,
+    };
+
+_$StarknetDomainImpl _$$StarknetDomainImplFromJson(Map<String, dynamic> json) =>
+    _$StarknetDomainImpl(
+      name: json['name'] == null ? null : Felt.fromJson(json['name'] as String),
+      version: json['version'] == null
+          ? null
+          : Felt.fromJson(json['version'] as String),
+      chainId: json['chain_id'] == null
+          ? null
+          : Felt.fromJson(json['chain_id'] as String),
+      revision: json['revision'] == null
+          ? null
+          : Felt.fromJson(json['revision'] as String),
+    );
+
+Map<String, dynamic> _$$StarknetDomainImplToJson(
+        _$StarknetDomainImpl instance) =>
+    <String, dynamic>{
+      'name': instance.name?.toJson(),
+      'version': instance.version?.toJson(),
+      'chain_id': instance.chainId?.toJson(),
+      'revision': instance.revision?.toJson(),
+    };

--- a/packages/wallet_provider/lib/src/model/wallet_error.dart
+++ b/packages/wallet_provider/lib/src/model/wallet_error.dart
@@ -1,0 +1,147 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'wallet_error.freezed.dart';
+part 'wallet_error.g.dart';
+
+/// Represents a specific error returned by the Starknet Wallet API.
+@freezed
+class WalletError with _$WalletError {
+  const factory WalletError({
+    required int code,
+    required String message,
+    dynamic data, // Optional data field seen in some errors
+  }) = _WalletError;
+
+  const WalletError._();
+
+  /// Tries to map the error code to a known [WalletErrorCode].
+  /// Returns null if the code is not recognized.
+  WalletErrorCode? get knownErrorCode {
+    try {
+      return WalletErrorCode.values.firstWhere((e) => e.code == code);
+    } catch (_) {
+      return null; // Not found
+    }
+  }
+
+  factory WalletError.fromJson(Map<String, Object?> json) =>
+      _$WalletErrorFromJson(json);
+}
+
+/// Enum for known wallet error codes based on Wallet API Spec.
+enum WalletErrorCode {
+  /// An error occurred (NOT_ERC20)
+  @JsonValue(111)
+  notERC20,
+
+  /// An error occurred (UNLISTED_NETWORK)
+  @JsonValue(112)
+  unlistedNetwork,
+
+  /// An error occurred (USER_REFUSED_OP)
+  /// Description: The user refused the operation in the wallet
+  @JsonValue(113)
+  userRefusedOp,
+
+  /// An error occurred (INVALID_REQUEST_PAYLOAD)
+  @JsonValue(114)
+  invalidRequestPayload,
+
+  /// An error occurred (ACCOUNT_ALREADY_DEPLOYED)
+  @JsonValue(115)
+  accountAlreadyDeployed,
+
+  /// An error occurred (DEPLOYMENT_DATA_NOT_AVAILABLE)
+  /// Description: The deployment data is not available or no supported
+  @JsonValue(116)
+  deploymentDataNotAvailable,
+
+  /// An error occurred (CHAIN_ID_NOT_SUPPORTED)
+  /// Description: The requested chain ID is not supported by the wallet
+  @JsonValue(117)
+  chainIdNotSupported,
+
+  /// An error occurred (API_VERSION_NOT_SUPPORTED)
+  @JsonValue(162)
+  apiVersionNotSupported,
+
+  /// An error occurred (UNKNOWN_ERROR)
+  @JsonValue(163)
+  unknownError;
+
+  /// Gets the integer code associated with the error enum value.
+  int get code {
+    // This relies on the JsonValue annotation holding the code.
+    // A more robust way might be needed if JsonValue isn't directly accessible,
+    // but for freezed enums with JsonValue, this usually works indirectly
+    // via the generated toJson() or manual mapping.
+    // Let's implement explicitly for clarity:
+    switch (this) {
+      case WalletErrorCode.notERC20:
+        return 111;
+      case WalletErrorCode.unlistedNetwork:
+        return 112;
+      case WalletErrorCode.userRefusedOp:
+        return 113;
+      case WalletErrorCode.invalidRequestPayload:
+        return 114;
+      case WalletErrorCode.accountAlreadyDeployed:
+        return 115;
+      case WalletErrorCode.deploymentDataNotAvailable:
+        return 116;
+      case WalletErrorCode.chainIdNotSupported:
+        return 117;
+      case WalletErrorCode.apiVersionNotSupported:
+        return 162;
+      case WalletErrorCode.unknownError:
+        return 163;
+    }
+  }
+}
+
+/// Extension providing standard messages and descriptions for [WalletErrorCode].
+extension WalletErrorCodeExtension on WalletErrorCode {
+  /// Gets the standard message associated with this error code from the spec.
+  String get standardMessage {
+    switch (this) {
+      case WalletErrorCode.notERC20:
+        return "An error occurred (NOT_ERC20)";
+      case WalletErrorCode.unlistedNetwork:
+        return "An error occurred (UNLISTED_NETWORK)";
+      case WalletErrorCode.userRefusedOp:
+        return "An error occurred (USER_REFUSED_OP)";
+      case WalletErrorCode.invalidRequestPayload:
+        return "An error occurred (INVALID_REQUEST_PAYLOAD)";
+      case WalletErrorCode.accountAlreadyDeployed:
+        return "An error occurred (ACCOUNT_ALREADY_DEPLOYED)";
+      case WalletErrorCode.deploymentDataNotAvailable:
+        return "An error occurred (DEPLOYMENT_DATA_NOT_AVAILABLE)";
+      case WalletErrorCode.chainIdNotSupported:
+        return "An error occurred (CHAIN_ID_NOT_SUPPORTED)";
+      case WalletErrorCode.apiVersionNotSupported:
+        return "An error occurred (API_VERSION_NOT_SUPPORTED)";
+      case WalletErrorCode.unknownError:
+        return "An error occurred (UNKNOWN_ERROR)";
+    }
+  }
+
+  /// Gets the standard description associated with this error code from the spec, if available.
+  String? get standardDescription {
+    switch (this) {
+      case WalletErrorCode.userRefusedOp:
+        return "The user refused the operation in the wallet";
+      case WalletErrorCode.deploymentDataNotAvailable:
+        return "The deployment data is not available or no supported";
+      case WalletErrorCode.chainIdNotSupported:
+        return "The requested chain ID is not supported by the wallet";
+      // Other codes don't have a description in the provided JSON snippet
+      case WalletErrorCode.notERC20:
+      case WalletErrorCode.unlistedNetwork:
+      case WalletErrorCode.invalidRequestPayload:
+      case WalletErrorCode.accountAlreadyDeployed:
+      case WalletErrorCode.apiVersionNotSupported:
+      case WalletErrorCode.unknownError:
+        return null;
+    }
+  }
+}

--- a/packages/wallet_provider/lib/src/model/wallet_error.freezed.dart
+++ b/packages/wallet_provider/lib/src/model/wallet_error.freezed.dart
@@ -1,0 +1,203 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'wallet_error.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+WalletError _$WalletErrorFromJson(Map<String, dynamic> json) {
+  return _WalletError.fromJson(json);
+}
+
+/// @nodoc
+mixin _$WalletError {
+  int get code => throw _privateConstructorUsedError;
+  String get message => throw _privateConstructorUsedError;
+  dynamic get data => throw _privateConstructorUsedError;
+
+  /// Serializes this WalletError to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of WalletError
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $WalletErrorCopyWith<WalletError> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $WalletErrorCopyWith<$Res> {
+  factory $WalletErrorCopyWith(
+          WalletError value, $Res Function(WalletError) then) =
+      _$WalletErrorCopyWithImpl<$Res, WalletError>;
+  @useResult
+  $Res call({int code, String message, dynamic data});
+}
+
+/// @nodoc
+class _$WalletErrorCopyWithImpl<$Res, $Val extends WalletError>
+    implements $WalletErrorCopyWith<$Res> {
+  _$WalletErrorCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of WalletError
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? code = null,
+    Object? message = null,
+    Object? data = freezed,
+  }) {
+    return _then(_value.copyWith(
+      code: null == code
+          ? _value.code
+          : code // ignore: cast_nullable_to_non_nullable
+              as int,
+      message: null == message
+          ? _value.message
+          : message // ignore: cast_nullable_to_non_nullable
+              as String,
+      data: freezed == data
+          ? _value.data
+          : data // ignore: cast_nullable_to_non_nullable
+              as dynamic,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$WalletErrorImplCopyWith<$Res>
+    implements $WalletErrorCopyWith<$Res> {
+  factory _$$WalletErrorImplCopyWith(
+          _$WalletErrorImpl value, $Res Function(_$WalletErrorImpl) then) =
+      __$$WalletErrorImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({int code, String message, dynamic data});
+}
+
+/// @nodoc
+class __$$WalletErrorImplCopyWithImpl<$Res>
+    extends _$WalletErrorCopyWithImpl<$Res, _$WalletErrorImpl>
+    implements _$$WalletErrorImplCopyWith<$Res> {
+  __$$WalletErrorImplCopyWithImpl(
+      _$WalletErrorImpl _value, $Res Function(_$WalletErrorImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of WalletError
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? code = null,
+    Object? message = null,
+    Object? data = freezed,
+  }) {
+    return _then(_$WalletErrorImpl(
+      code: null == code
+          ? _value.code
+          : code // ignore: cast_nullable_to_non_nullable
+              as int,
+      message: null == message
+          ? _value.message
+          : message // ignore: cast_nullable_to_non_nullable
+              as String,
+      data: freezed == data
+          ? _value.data
+          : data // ignore: cast_nullable_to_non_nullable
+              as dynamic,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$WalletErrorImpl extends _WalletError {
+  const _$WalletErrorImpl(
+      {required this.code, required this.message, this.data})
+      : super._();
+
+  factory _$WalletErrorImpl.fromJson(Map<String, dynamic> json) =>
+      _$$WalletErrorImplFromJson(json);
+
+  @override
+  final int code;
+  @override
+  final String message;
+  @override
+  final dynamic data;
+
+  @override
+  String toString() {
+    return 'WalletError(code: $code, message: $message, data: $data)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$WalletErrorImpl &&
+            (identical(other.code, code) || other.code == code) &&
+            (identical(other.message, message) || other.message == message) &&
+            const DeepCollectionEquality().equals(other.data, data));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(
+      runtimeType, code, message, const DeepCollectionEquality().hash(data));
+
+  /// Create a copy of WalletError
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$WalletErrorImplCopyWith<_$WalletErrorImpl> get copyWith =>
+      __$$WalletErrorImplCopyWithImpl<_$WalletErrorImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$WalletErrorImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _WalletError extends WalletError {
+  const factory _WalletError(
+      {required final int code,
+      required final String message,
+      final dynamic data}) = _$WalletErrorImpl;
+  const _WalletError._() : super._();
+
+  factory _WalletError.fromJson(Map<String, dynamic> json) =
+      _$WalletErrorImpl.fromJson;
+
+  @override
+  int get code;
+  @override
+  String get message;
+  @override
+  dynamic get data;
+
+  /// Create a copy of WalletError
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$WalletErrorImplCopyWith<_$WalletErrorImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/packages/wallet_provider/lib/src/model/wallet_error.g.dart
+++ b/packages/wallet_provider/lib/src/model/wallet_error.g.dart
@@ -1,0 +1,21 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'wallet_error.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$WalletErrorImpl _$$WalletErrorImplFromJson(Map<String, dynamic> json) =>
+    _$WalletErrorImpl(
+      code: (json['code'] as num).toInt(),
+      message: json['message'] as String,
+      data: json['data'],
+    );
+
+Map<String, dynamic> _$$WalletErrorImplToJson(_$WalletErrorImpl instance) =>
+    <String, dynamic>{
+      'code': instance.code,
+      'message': instance.message,
+      'data': instance.data,
+    };

--- a/packages/wallet_provider/lib/src/provider.dart
+++ b/packages/wallet_provider/lib/src/provider.dart
@@ -1,0 +1,219 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import 'package:starknet/starknet.dart'
+    hide TypedData; // For Felt, Signature etc. (Hide StarkNet TypedData)
+import 'model/index.dart';
+
+// A simple Json RPC Client
+class JsonRpcClient {
+  final Uri url;
+  final http.Client _httpClient;
+
+  JsonRpcClient(this.url, {http.Client? httpClient})
+      : _httpClient = httpClient ?? http.Client();
+
+  Future<dynamic> call(String method,
+      [List<dynamic>? params, int id = 1]) async {
+    final request = {
+      'jsonrpc': '2.0',
+      'method': method,
+      'params': params ?? [],
+      'id': id,
+    };
+
+    final response = await _httpClient.post(
+      url,
+      headers: {'Content-Type': 'application/json'},
+      body: jsonEncode(request),
+    );
+
+    if (response.statusCode == 200) {
+      final decoded = jsonDecode(response.body);
+      if (decoded is Map<String, dynamic>) {
+        if (decoded.containsKey('result')) {
+          return decoded['result']; // Return the actual result directly
+        } else if (decoded.containsKey('error')) {
+          // Handle JSON-RPC error structure
+          final errorData = decoded['error'] as Map<String, dynamic>;
+          // Check if code and message are present before creating WalletError
+          if (errorData.containsKey('code') &&
+              errorData.containsKey('message')) {
+            throw WalletError.fromJson(errorData);
+          } else {
+            throw Exception(
+                'Invalid JSON-RPC error format: ${jsonEncode(errorData)}');
+          }
+        } else {
+          throw Exception(
+              'Invalid JSON-RPC response format: ${jsonEncode(decoded)}');
+        }
+      } else {
+        throw Exception(
+            'Invalid JSON-RPC response format: Expected a Map but got ${decoded.runtimeType}');
+      }
+    } else {
+      throw Exception('HTTP Error ${response.statusCode}: ${response.body}');
+    }
+  }
+
+  void close() {
+    _httpClient.close();
+  }
+}
+
+/// Provider for interacting with the Starknet Wallet API.
+class WalletProvider {
+  final JsonRpcClient _client;
+
+  WalletProvider(Uri providerUrl) : _client = JsonRpcClient(providerUrl);
+
+  /// Returns a list of wallet api versions compatible with the wallet.
+  Future<List<String>> supportedWalletApi() async {
+    final result = await _client.call('wallet_supportedWalletApi');
+    // Result is directly List<dynamic> or similar
+    return List<String>.from(result as List);
+  }
+
+  /// Returns a list of rpc spec versions compatible with the wallet.
+  Future<List<String>> supportedSpecs() async {
+    final result = await _client.call('wallet_supportedSpecs');
+    return List<String>.from(result as List);
+  }
+
+  /// Get the existing permissions for the Dapp from the wallet.
+  Future<List<Permission>> getPermissions({ApiVersion? apiVersion}) async {
+    final params = apiVersion != null ? [apiVersion] : null;
+    final result = await _client.call('wallet_getPermissions', params);
+    final permissions = List<String>.from(result as List);
+    return permissions
+        .map((p) {
+          try {
+            return Permission.values.byName(p);
+          } catch (e) {
+            // Handle cases where the permission string is not in the enum
+            print('Warning: Unknown permission received: $p');
+            return null; // Or throw an error, depending on desired strictness
+          }
+        })
+        .whereType<Permission>()
+        .toList(); // Filter out nulls if any
+  }
+
+  /// Get the account addresses of the wallet active account.
+  Future<List<Felt>> requestAccounts(
+      {bool? silentMode, ApiVersion? apiVersion}) async {
+    final List<dynamic> paramList = [];
+    // Structure for params seems to be an optional object according to spec examples
+    if (silentMode != null || apiVersion != null) {
+      final objParam = <String, dynamic>{};
+      if (silentMode != null) objParam['silent_mode'] = silentMode;
+      if (apiVersion != null) objParam['api_version'] = apiVersion;
+      paramList.add(objParam);
+    } else {
+      // Ensure paramList is not empty if the method expects params
+      // Based on spec, params array itself is optional if empty []
+    }
+
+    final result = await _client.call(
+        'wallet_requestAccounts', paramList.isNotEmpty ? paramList : null);
+    final addresses = List<String>.from(result as List);
+    return addresses.map((addr) => Felt.fromHexString(addr)).toList();
+  }
+
+  /// Request the current Chain Id.
+  Future<Felt> requestChainId({ApiVersion? apiVersion}) async {
+    final params = apiVersion != null ? [apiVersion] : null;
+    final result = await _client.call('wallet_requestChainId', params);
+    return Felt.fromHexString(result as String); // Result is CHAIN_ID (string)
+  }
+
+  /// Request deployment data for the current account.
+  Future<AccountDeploymentData> deploymentData({ApiVersion? apiVersion}) async {
+    final params = apiVersion != null ? [apiVersion] : null;
+    final result = await _client.call('wallet_deploymentData', params);
+    // Result should be the JSON map for AccountDeploymentData
+    return AccountDeploymentData.fromJson(result as Map<String, dynamic>);
+  }
+
+  /// Change the current network of the wallet.
+  Future<bool> switchStarknetChain(Felt chainId,
+      {bool? silentMode, ApiVersion? apiVersion}) async {
+    // Sticking to pure positional: [chainId, silent_mode?, api_version?]
+    final List<dynamic> methodParams = [chainId.toHexString()];
+    // Only add subsequent parameters if they are provided
+    if (silentMode != null) {
+      methodParams.add(silentMode);
+      if (apiVersion != null) {
+        methodParams.add(apiVersion);
+      }
+    } else if (apiVersion != null) {
+      methodParams.add(null); // Add placeholder for silent_mode
+      methodParams.add(apiVersion);
+    }
+
+    final result =
+        await _client.call('wallet_switchStarknetChain', methodParams);
+    return result as bool; // Result is directly bool
+  }
+
+  /// Add a token to the list of assets displayed by the wallet.
+  Future<bool> watchAsset(Asset asset, {ApiVersion? apiVersion}) async {
+    final params = <dynamic>[asset.toJson()];
+    if (apiVersion != null) params.add(apiVersion);
+
+    final result = await _client.call('wallet_watchAsset', params);
+    return result as bool;
+  }
+
+  /// Add a new network to the list of networks of the wallet.
+  Future<bool> addStarknetChain(StarknetChain chain,
+      {ApiVersion? apiVersion}) async {
+    final params = <dynamic>[chain.toJson()];
+    if (apiVersion != null) params.add(apiVersion);
+
+    final result = await _client.call('wallet_addStarknetChain', params);
+    return result as bool;
+  }
+
+  /// Submit a new invoke transaction.
+  Future<AddInvokeTransactionResult> addInvokeTransaction(
+      List<InvokeCall> calls,
+      {ApiVersion? apiVersion}) async {
+    final callListJson = calls.map((c) => c.toJson()).toList();
+    final params = <dynamic>[callListJson];
+    if (apiVersion != null) params.add(apiVersion);
+
+    final result = await _client.call('wallet_addInvokeTransaction', params);
+    // Result is the JSON map for AddInvokeTransactionResult
+    return AddInvokeTransactionResult.fromJson(result as Map<String, dynamic>);
+  }
+
+  /// Submit a new declare transaction.
+  Future<AddDeclareTransactionResult> addDeclareTransaction(
+      DeclareTxnWallet declareTxn,
+      {ApiVersion? apiVersion}) async {
+    final params = <dynamic>[declareTxn.toJson()];
+    if (apiVersion != null) params.add(apiVersion);
+
+    final result = await _client.call('wallet_addDeclareTransaction', params);
+    // Result is the JSON map for AddDeclareTransactionResult
+    return AddDeclareTransactionResult.fromJson(result as Map<String, dynamic>);
+  }
+
+  /// Sign typed data using the wallet.
+  Future<List<Felt>> signTypedData(TypedData typedData,
+      {ApiVersion? apiVersion}) async {
+    final params = <dynamic>[typedData.toJson()];
+    if (apiVersion != null) params.add(apiVersion);
+
+    final result = await _client.call('wallet_signTypedData', params);
+    // Result is SIGNATURE (List<String> or List<dynamic>)
+    final signature = List<String>.from(result as List);
+    return signature.map((s) => Felt.fromHexString(s)).toList();
+  }
+
+  /// Closes the underlying HTTP client.
+  void close() {
+    _client.close();
+  }
+}

--- a/packages/wallet_provider/lib/wallet_provider.dart
+++ b/packages/wallet_provider/lib/wallet_provider.dart
@@ -1,0 +1,8 @@
+/// A Dart package for interacting with Starknet Wallet API.
+library;
+
+// Export the provider implementation
+export 'src/provider.dart';
+
+// Export necessary models (or use index.dart export if preferred)
+export 'src/model/index.dart';

--- a/packages/wallet_provider/pubspec.yaml
+++ b/packages/wallet_provider/pubspec.yaml
@@ -1,0 +1,20 @@
+name: wallet_provider
+description: A Dart package for interacting with Starknet wallets using the Starknet Wallet API specification.
+version: 0.0.1+1
+repository: https://github.com/focustree/starknet.dart
+
+environment:
+  sdk: ^3.0.5
+
+dependencies:
+  starknet: ^0.1.2+1
+  freezed_annotation: ^2.4.4
+  http: ^1.2.2
+  json_annotation: ^4.9.0
+
+dev_dependencies:
+  build_runner: ^2.4.13
+  freezed: ^2.5.7
+  json_serializable: ^6.8.0
+  lints: ^5.0.0
+  test: ^1.25.8

--- a/packages/wallet_provider/starknet_api_openrpc.json
+++ b/packages/wallet_provider/starknet_api_openrpc.json
@@ -1,0 +1,3819 @@
+{
+  "openrpc": "1.0.0-rc1",
+  "info": {
+    "version": "0.8.1",
+    "title": "StarkNet Node API",
+    "license": {}
+  },
+  "servers": [],
+  "methods": [
+    {
+      "name": "starknet_specVersion",
+      "summary": "Returns the version of the Starknet JSON-RPC specification being used",
+      "params": [],
+      "result": {
+        "name": "result",
+        "description": "Semver of Starknet's JSON-RPC spec being used",
+        "required": true,
+        "schema": {
+          "title": "JSON-RPC spec version",
+          "type": "string"
+        }
+      }
+    },
+    {
+      "name": "starknet_getBlockWithTxHashes",
+      "summary": "Get block information with transaction hashes given the block id",
+      "params": [
+        {
+          "name": "block_id",
+          "description": "The hash of the requested block, or number (height) of the requested block, or a block tag",
+          "required": true,
+          "schema": {
+            "title": "Block id",
+            "$ref": "#/components/schemas/BLOCK_ID"
+          }
+        }
+      ],
+      "result": {
+        "name": "result",
+        "description": "The resulting block information with transaction hashes",
+        "schema": {
+          "title": "Starknet get block hash with tx hashes result",
+          "oneOf": [
+            {
+              "title": "Block with transaction hashes",
+              "$ref": "#/components/schemas/BLOCK_WITH_TX_HASHES"
+            },
+            {
+              "title": "Pending block with transaction hashes",
+              "$ref": "#/components/schemas/PENDING_BLOCK_WITH_TX_HASHES"
+            }
+          ]
+        }
+      },
+      "errors": [
+        {
+          "$ref": "#/components/errors/BLOCK_NOT_FOUND"
+        }
+      ]
+    },
+    {
+      "name": "starknet_getBlockWithTxs",
+      "summary": "Get block information with full transactions given the block id",
+      "params": [
+        {
+          "name": "block_id",
+          "description": "The hash of the requested block, or number (height) of the requested block, or a block tag",
+          "required": true,
+          "schema": {
+            "title": "Block id",
+            "$ref": "#/components/schemas/BLOCK_ID"
+          }
+        }
+      ],
+      "result": {
+        "name": "result",
+        "description": "The resulting block information with full transactions",
+        "schema": {
+          "title": "Starknet get block with txs result",
+          "oneOf": [
+            {
+              "title": "Block with transactions",
+              "$ref": "#/components/schemas/BLOCK_WITH_TXS"
+            },
+            {
+              "title": "Pending block with transactions",
+              "$ref": "#/components/schemas/PENDING_BLOCK_WITH_TXS"
+            }
+          ]
+        }
+      },
+      "errors": [
+        {
+          "$ref": "#/components/errors/BLOCK_NOT_FOUND"
+        }
+      ]
+    },
+    {
+      "name": "starknet_getBlockWithReceipts",
+      "summary": "Get block information with full transactions and receipts given the block id",
+      "params": [
+        {
+          "name": "block_id",
+          "description": "The hash of the requested block, or number (height) of the requested block, or a block tag",
+          "required": true,
+          "schema": {
+            "title": "Block id",
+            "$ref": "#/components/schemas/BLOCK_ID"
+          }
+        }
+      ],
+      "result": {
+        "name": "result",
+        "description": "The resulting block information with full transactions",
+        "schema": {
+          "title": "Starknet get block with txs and receipts result",
+          "oneOf": [
+            {
+              "title": "Block with transactions",
+              "$ref": "#/components/schemas/BLOCK_WITH_RECEIPTS"
+            },
+            {
+              "title": "Pending block with transactions",
+              "$ref": "#/components/schemas/PENDING_BLOCK_WITH_RECEIPTS"
+            }
+          ]
+        }
+      },
+      "errors": [
+        {
+          "$ref": "#/components/errors/BLOCK_NOT_FOUND"
+        }
+      ]
+    },
+    {
+      "name": "starknet_getStateUpdate",
+      "summary": "Get the information about the result of executing the requested block",
+      "params": [
+        {
+          "name": "block_id",
+          "description": "The hash of the requested block, or number (height) of the requested block, or a block tag",
+          "required": true,
+          "schema": {
+            "title": "Block id",
+            "$ref": "#/components/schemas/BLOCK_ID"
+          }
+        }
+      ],
+      "result": {
+        "name": "result",
+        "description": "The information about the state update of the requested block",
+        "schema": {
+          "title": "Starknet get state update result",
+          "oneOf": [
+            {
+              "title": "State update",
+              "$ref": "#/components/schemas/STATE_UPDATE"
+            },
+            {
+              "title": "Pending state update",
+              "$ref": "#/components/schemas/PENDING_STATE_UPDATE"
+            }
+          ]
+        }
+      },
+      "errors": [
+        {
+          "$ref": "#/components/errors/BLOCK_NOT_FOUND"
+        }
+      ]
+    },
+    {
+      "name": "starknet_getStorageAt",
+      "summary": "Get the value of the storage at the given address and key",
+      "params": [
+        {
+          "name": "contract_address",
+          "description": "The address of the contract to read from",
+          "summary": "The address of the contract to read from",
+          "required": true,
+          "schema": {
+            "title": "Address",
+            "$ref": "#/components/schemas/ADDRESS"
+          }
+        },
+        {
+          "name": "key",
+          "description": "The key to the storage value for the given contract",
+          "summary": "The key to the storage value for the given contract",
+          "required": true,
+          "schema": {
+            "title": "Storage key",
+            "$ref": "#/components/schemas/STORAGE_KEY"
+          }
+        },
+        {
+          "name": "block_id",
+          "description": "The hash of the requested block, or number (height) of the requested block, or a block tag",
+          "required": true,
+          "schema": {
+            "title": "Block id",
+            "$ref": "#/components/schemas/BLOCK_ID"
+          }
+        }
+      ],
+      "result": {
+        "name": "result",
+        "description": "The value at the given key for the given contract. 0 if no value is found",
+        "summary": "The value at the given key for the given contract.",
+        "schema": {
+          "title": "Field element",
+          "$ref": "#/components/schemas/FELT"
+        }
+      },
+      "errors": [
+        {
+          "$ref": "#/components/errors/CONTRACT_NOT_FOUND"
+        },
+        {
+          "$ref": "#/components/errors/BLOCK_NOT_FOUND"
+        }
+      ]
+    },
+    {
+      "name": "starknet_getTransactionStatus",
+      "summary": "Gets the transaction status (possibly reflecting that the tx is still in the mempool, or dropped from it)",
+      "paramStructure": "by-name",
+      "params": [
+        {
+          "name": "transaction_hash",
+          "summary": "The hash of the requested transaction",
+          "required": true,
+          "schema": {
+            "title": "Transaction hash",
+            "$ref": "#/components/schemas/TXN_HASH"
+          }
+        }
+      ],
+      "result": {
+        "name": "result",
+        "schema": {
+          "$ref": "#/components/schemas/TXN_STATUS_RESULT"
+        }
+      },
+      "errors": [
+        {
+          "$ref": "#/components/errors/TXN_HASH_NOT_FOUND"
+        }
+      ]
+    },
+    {
+      "name": "starknet_getMessagesStatus",
+      "summary": "Given an l1 tx hash, returns the associated l1_handler tx hashes and statuses for all L1 -> L2 messages sent by the l1 transaction, ordered by the l1 tx sending order",
+      "paramStructure": "by-name",
+      "params": [
+        {
+          "name": "transaction_hash",
+          "summary": "The hash of the L1 transaction that sent L1->L2 messages",
+          "required": true,
+          "schema": {
+            "title": "Transaction hash",
+            "$ref": "#/components/schemas/L1_TXN_HASH"
+          }
+        }
+      ],
+      "result": {
+        "name": "result",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "title": "status",
+            "properties": {
+              "transaction_hash": {
+                "$ref": "#/components/schemas/TXN_HASH"
+              },
+              "finality_status": {
+                "title": "finality status",
+                "$ref": "#/components/schemas/TXN_STATUS"
+              },
+              "failure_reason": {
+                "title": "failure reason",
+                "description": "the failure reason, only appears if finality_status is REJECTED",
+                "type": "string"
+              }
+            },
+            "required": ["transaction_hash", "finality_status"]
+          }
+        }
+      },
+      "errors": [
+        {
+          "$ref": "#/components/errors/TXN_HASH_NOT_FOUND"
+        }
+      ]
+    },
+    {
+      "name": "starknet_getTransactionByHash",
+      "summary": "Get the details and status of a submitted transaction",
+      "paramStructure": "by-name",
+      "params": [
+        {
+          "name": "transaction_hash",
+          "summary": "The hash of the requested transaction",
+          "required": true,
+          "schema": {
+            "title": "Transaction hash",
+            "$ref": "#/components/schemas/TXN_HASH"
+          }
+        }
+      ],
+      "result": {
+        "name": "result",
+        "schema": {
+          "$ref": "#/components/schemas/TXN_WITH_HASH"
+        }
+      },
+      "errors": [
+        {
+          "$ref": "#/components/errors/TXN_HASH_NOT_FOUND"
+        }
+      ]
+    },
+    {
+      "name": "starknet_getTransactionByBlockIdAndIndex",
+      "summary": "Get the details of a transaction by a given block id and index",
+      "description": "Get the details of the transaction given by the identified block and index in that block. If no transaction is found, null is returned.",
+      "params": [
+        {
+          "name": "block_id",
+          "description": "The hash of the requested block, or number (height) of the requested block, or a block tag",
+          "required": true,
+          "schema": {
+            "title": "Block id",
+            "$ref": "#/components/schemas/BLOCK_ID"
+          }
+        },
+        {
+          "name": "index",
+          "summary": "The index in the block to search for the transaction",
+          "required": true,
+          "schema": {
+            "title": "Index",
+            "type": "integer",
+            "minimum": 0
+          }
+        }
+      ],
+      "result": {
+        "name": "transactionResult",
+        "schema": {
+          "$ref": "#/components/schemas/TXN_WITH_HASH"
+        }
+      },
+      "errors": [
+        {
+          "$ref": "#/components/errors/BLOCK_NOT_FOUND"
+        },
+        {
+          "$ref": "#/components/errors/INVALID_TXN_INDEX"
+        }
+      ]
+    },
+    {
+      "name": "starknet_getTransactionReceipt",
+      "summary": "Get the transaction receipt by the transaction hash",
+      "paramStructure": "by-name",
+      "params": [
+        {
+          "name": "transaction_hash",
+          "summary": "The hash of the requested transaction",
+          "required": true,
+          "schema": {
+            "title": "Transaction hash",
+            "$ref": "#/components/schemas/TXN_HASH"
+          }
+        }
+      ],
+      "result": {
+        "name": "result",
+        "schema": {
+          "title": "Transaction receipt with block info",
+          "$ref": "#/components/schemas/TXN_RECEIPT_WITH_BLOCK_INFO"
+        }
+      },
+      "errors": [
+        {
+          "$ref": "#/components/errors/TXN_HASH_NOT_FOUND"
+        }
+      ]
+    },
+    {
+      "name": "starknet_getClass",
+      "summary": "Get the contract class definition in the given block associated with the given hash",
+      "params": [
+        {
+          "name": "block_id",
+          "description": "The hash of the requested block, or number (height) of the requested block, or a block tag",
+          "required": true,
+          "schema": {
+            "title": "Block id",
+            "$ref": "#/components/schemas/BLOCK_ID"
+          }
+        },
+        {
+          "name": "class_hash",
+          "description": "The hash of the requested contract class",
+          "required": true,
+          "schema": {
+            "title": "Field element",
+            "$ref": "#/components/schemas/FELT"
+          }
+        }
+      ],
+      "result": {
+        "name": "result",
+        "description": "The contract class, if found",
+        "schema": {
+          "title": "Starknet get class result",
+          "oneOf": [
+            {
+              "title": "Deprecated contract class",
+              "$ref": "#/components/schemas/DEPRECATED_CONTRACT_CLASS"
+            },
+            {
+              "title": "Contract class",
+              "$ref": "#/components/schemas/CONTRACT_CLASS"
+            }
+          ]
+        }
+      },
+      "errors": [
+        {
+          "$ref": "#/components/errors/BLOCK_NOT_FOUND"
+        },
+        {
+          "$ref": "#/components/errors/CLASS_HASH_NOT_FOUND"
+        }
+      ]
+    },
+    {
+      "name": "starknet_getClassHashAt",
+      "summary": "Get the contract class hash in the given block for the contract deployed at the given address",
+      "params": [
+        {
+          "name": "block_id",
+          "description": "The hash of the requested block, or number (height) of the requested block, or a block tag",
+          "required": true,
+          "schema": {
+            "title": "Block id",
+            "$ref": "#/components/schemas/BLOCK_ID"
+          }
+        },
+        {
+          "name": "contract_address",
+          "description": "The address of the contract whose class hash will be returned",
+          "required": true,
+          "schema": {
+            "title": "Address",
+            "$ref": "#/components/schemas/ADDRESS"
+          }
+        }
+      ],
+      "result": {
+        "name": "result",
+        "description": "The class hash of the given contract",
+        "schema": {
+          "title": "Field element",
+          "$ref": "#/components/schemas/FELT"
+        }
+      },
+      "errors": [
+        {
+          "$ref": "#/components/errors/BLOCK_NOT_FOUND"
+        },
+        {
+          "$ref": "#/components/errors/CONTRACT_NOT_FOUND"
+        }
+      ]
+    },
+    {
+      "name": "starknet_getClassAt",
+      "summary": "Get the contract class definition in the given block at the given address",
+      "params": [
+        {
+          "name": "block_id",
+          "description": "The hash of the requested block, or number (height) of the requested block, or a block tag",
+          "required": true,
+          "schema": {
+            "title": "Block id",
+            "$ref": "#/components/schemas/BLOCK_ID"
+          }
+        },
+        {
+          "name": "contract_address",
+          "description": "The address of the contract whose class definition will be returned",
+          "required": true,
+          "schema": {
+            "title": "Address",
+            "$ref": "#/components/schemas/ADDRESS"
+          }
+        }
+      ],
+      "result": {
+        "name": "result",
+        "description": "The contract class",
+        "schema": {
+          "title": "Starknet get class at result",
+          "oneOf": [
+            {
+              "title": "Deprecated contract class",
+              "$ref": "#/components/schemas/DEPRECATED_CONTRACT_CLASS"
+            },
+            {
+              "title": "Contract class",
+              "$ref": "#/components/schemas/CONTRACT_CLASS"
+            }
+          ]
+        }
+      },
+      "errors": [
+        {
+          "$ref": "#/components/errors/BLOCK_NOT_FOUND"
+        },
+        {
+          "$ref": "#/components/errors/CONTRACT_NOT_FOUND"
+        }
+      ]
+    },
+    {
+      "name": "starknet_getBlockTransactionCount",
+      "summary": "Get the number of transactions in a block given a block id",
+      "description": "Returns the number of transactions in the designated block.",
+      "params": [
+        {
+          "name": "block_id",
+          "description": "The hash of the requested block, or number (height) of the requested block, or a block tag",
+          "required": true,
+          "schema": {
+            "title": "Block id",
+            "$ref": "#/components/schemas/BLOCK_ID"
+          }
+        }
+      ],
+      "result": {
+        "name": "result",
+        "description": "The number of transactions in the designated block",
+        "summary": "The number of transactions in the designated block",
+        "schema": {
+          "title": "Block transaction count",
+          "type": "integer",
+          "minimum": 0
+        }
+      },
+      "errors": [
+        {
+          "$ref": "#/components/errors/BLOCK_NOT_FOUND"
+        }
+      ]
+    },
+    {
+      "name": "starknet_call",
+      "summary": "call a starknet function without creating a StarkNet transaction",
+      "description": "Calls a function in a contract and returns the return value.  Using this call will not create a transaction; hence, will not change the state",
+      "params": [
+        {
+          "name": "request",
+          "summary": "The details of the function call",
+          "schema": {
+            "title": "Function call",
+            "$ref": "#/components/schemas/FUNCTION_CALL"
+          },
+          "required": true
+        },
+        {
+          "name": "block_id",
+          "description": "The hash of the requested block, or number (height) of the requested block, or a block tag, for the block referencing the state or call the transaction on.",
+          "required": true,
+          "schema": {
+            "title": "Block id",
+            "$ref": "#/components/schemas/BLOCK_ID"
+          }
+        }
+      ],
+      "result": {
+        "name": "result",
+        "summary": "The function's return value",
+        "description": "The function's return value, as defined in the Cairo output",
+        "schema": {
+          "type": "array",
+          "title": "Field element",
+          "items": {
+            "$ref": "#/components/schemas/FELT"
+          }
+        }
+      },
+      "errors": [
+        {
+          "$ref": "#/components/errors/CONTRACT_NOT_FOUND"
+        },
+        {
+          "$ref": "#/components/errors/ENTRYPOINT_NOT_FOUND"
+        },
+        {
+          "$ref": "#/components/errors/CONTRACT_ERROR"
+        },
+        {
+          "$ref": "#/components/errors/BLOCK_NOT_FOUND"
+        }
+      ]
+    },
+    {
+      "name": "starknet_estimateFee",
+      "summary": "estimate the fee for of StarkNet transactions",
+      "description": "Estimates the resources required by a given sequence of transactions when applied on a given state. If one of the transactions reverts or fails due to any reason (e.g. validation failure or an internal error), a TRANSACTION_EXECUTION_ERROR is returned. The estimate is given in fri.",
+      "params": [
+        {
+          "name": "request",
+          "summary": "The transaction to estimate",
+          "schema": {
+            "type": "array",
+            "description": "a sequence of transactions to estimate, running each transaction on the state resulting from applying all the previous ones",
+            "title": "Transaction",
+            "items": {
+              "$ref": "#/components/schemas/BROADCASTED_TXN"
+            }
+          },
+          "required": true
+        },
+        {
+          "name": "simulation_flags",
+          "description": "describes what parts of the transaction should be executed",
+          "required": true,
+          "schema": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SIMULATION_FLAG_FOR_ESTIMATE_FEE"
+            }
+          }
+        },
+        {
+          "name": "block_id",
+          "description": "The hash of the requested block, or number (height) of the requested block, or a block tag, for the block referencing the state or call the transaction on.",
+          "required": true,
+          "schema": {
+            "title": "Block id",
+            "$ref": "#/components/schemas/BLOCK_ID"
+          }
+        }
+      ],
+      "result": {
+        "name": "result",
+        "description": "the fee estimations",
+        "schema": {
+          "title": "Estimation",
+          "type": "array",
+          "description": "a sequence of fee estimation where the i'th estimate corresponds to the i'th transaction",
+          "items": {
+            "$ref": "#/components/schemas/FEE_ESTIMATE"
+          }
+        }
+      },
+      "errors": [
+        {
+          "$ref": "#/components/errors/TRANSACTION_EXECUTION_ERROR"
+        },
+        {
+          "$ref": "#/components/errors/BLOCK_NOT_FOUND"
+        }
+      ]
+    },
+    {
+      "name": "starknet_estimateMessageFee",
+      "summary": "estimate the L2 fee of a message sent on L1",
+      "description": "estimates the resources required by the l1_handler transaction induced by the message",
+      "params": [
+        {
+          "name": "message",
+          "description": "the message's parameters",
+          "schema": {
+            "$ref": "#/components/schemas/MSG_FROM_L1"
+          },
+          "required": true
+        },
+        {
+          "name": "block_id",
+          "description": "The hash of the requested block, or number (height) of the requested block, or a block tag, for the block referencing the state or call the transaction on.",
+          "required": true,
+          "schema": {
+            "title": "Block id",
+            "$ref": "#/components/schemas/BLOCK_ID"
+          }
+        }
+      ],
+      "result": {
+        "name": "result",
+        "description": "the fee estimation",
+        "schema": {
+          "$ref": "#/components/schemas/FEE_ESTIMATE"
+        }
+      },
+      "errors": [
+        {
+          "$ref": "#/components/errors/CONTRACT_ERROR"
+        },
+        {
+          "$ref": "#/components/errors/BLOCK_NOT_FOUND"
+        }
+      ]
+    },
+    {
+      "name": "starknet_blockNumber",
+      "summary": "Get the most recent accepted block number",
+      "params": [],
+      "result": {
+        "name": "result",
+        "description": "The latest block number",
+        "schema": {
+          "title": "Block number",
+          "$ref": "#/components/schemas/BLOCK_NUMBER"
+        }
+      },
+      "errors": [
+        {
+          "$ref": "#/components/errors/NO_BLOCKS"
+        }
+      ]
+    },
+    {
+      "name": "starknet_blockHashAndNumber",
+      "summary": "Get the most recent accepted block hash and number",
+      "params": [],
+      "result": {
+        "name": "result",
+        "description": "The latest block hash and number",
+        "schema": {
+          "title": "Starknet block hash and number result",
+          "type": "object",
+          "properties": {
+            "block_hash": {
+              "title": "Block hash",
+              "$ref": "#/components/schemas/BLOCK_HASH"
+            },
+            "block_number": {
+              "title": "Block number",
+              "$ref": "#/components/schemas/BLOCK_NUMBER"
+            }
+          },
+          "required": ["block_hash", "block_number"]
+        }
+      },
+      "errors": [
+        {
+          "$ref": "#/components/errors/NO_BLOCKS"
+        }
+      ]
+    },
+    {
+      "name": "starknet_chainId",
+      "summary": "Return the currently configured StarkNet chain id",
+      "params": [],
+      "result": {
+        "name": "result",
+        "description": "The chain id this node is connected to",
+        "schema": {
+          "title": "Chain id",
+          "$ref": "#/components/schemas/CHAIN_ID"
+        }
+      }
+    },
+    {
+      "name": "starknet_syncing",
+      "summary": "Returns an object about the sync status, or false if the node is not synching",
+      "params": [],
+      "result": {
+        "name": "syncing",
+        "summary": "The state of the synchronization, or false if the node is not synchronizing",
+        "description": "The status of the node, if it is currently synchronizing state. FALSE otherwise",
+        "schema": {
+          "title": "SyncingStatus",
+          "oneOf": [
+            {
+              "type": "boolean",
+              "title": "False",
+              "description": "only legal value is FALSE here"
+            },
+            {
+              "title": "Sync status",
+              "$ref": "#/components/schemas/SYNC_STATUS"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "name": "starknet_getEvents",
+      "summary": "Returns all events matching the given filter",
+      "description": "Returns all event objects matching the conditions in the provided filter",
+      "params": [
+        {
+          "name": "filter",
+          "summary": "The conditions used to filter the returned events",
+          "required": true,
+          "schema": {
+            "title": "Events request",
+            "allOf": [
+              {
+                "title": "Event filter",
+                "$ref": "#/components/schemas/EVENT_FILTER"
+              },
+              {
+                "title": "Result page request",
+                "$ref": "#/components/schemas/RESULT_PAGE_REQUEST"
+              }
+            ]
+          }
+        }
+      ],
+      "result": {
+        "name": "events",
+        "description": "All the event objects matching the filter",
+        "schema": {
+          "title": "Events chunk",
+          "$ref": "#/components/schemas/EVENTS_CHUNK"
+        }
+      },
+      "errors": [
+        {
+          "$ref": "#/components/errors/PAGE_SIZE_TOO_BIG"
+        },
+        {
+          "$ref": "#/components/errors/INVALID_CONTINUATION_TOKEN"
+        },
+        {
+          "$ref": "#/components/errors/BLOCK_NOT_FOUND"
+        },
+        {
+          "$ref": "#/components/errors/TOO_MANY_KEYS_IN_FILTER"
+        }
+      ]
+    },
+    {
+      "name": "starknet_getNonce",
+      "summary": "Get the nonce associated with the given address in the given block",
+      "params": [
+        {
+          "name": "block_id",
+          "description": "The hash of the requested block, or number (height) of the requested block, or a block tag",
+          "required": true,
+          "schema": {
+            "title": "Block id",
+            "$ref": "#/components/schemas/BLOCK_ID"
+          }
+        },
+        {
+          "name": "contract_address",
+          "description": "The address of the contract whose nonce we're seeking",
+          "required": true,
+          "schema": {
+            "title": "Address",
+            "$ref": "#/components/schemas/ADDRESS"
+          }
+        }
+      ],
+      "result": {
+        "name": "result",
+        "description": "The contract's nonce at the requested state",
+        "schema": {
+          "title": "Field element",
+          "$ref": "#/components/schemas/FELT"
+        }
+      },
+      "errors": [
+        {
+          "$ref": "#/components/errors/BLOCK_NOT_FOUND"
+        },
+        {
+          "$ref": "#/components/errors/CONTRACT_NOT_FOUND"
+        }
+      ]
+    },
+    {
+      "name": "starknet_getStorageProof",
+      "summary": "Get merkle paths in one of the state tries: global state, classes, individual contract. A single request can query for any mix of the three types of storage proofs (classes, contracts, and storage).",
+      "params": [
+        {
+          "name": "block_id",
+          "description": "The hash of the requested block, or number (height) of the requested block, or a block tag",
+          "required": true,
+          "schema": {
+            "title": "Block id",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/BLOCK_ID"
+              },
+              {
+                "not": {
+                  "type": "string",
+                  "enum": ["pending"]
+                }
+              }
+            ]
+          }
+        },
+        {
+          "name": "class_hashes",
+          "description": "a list of the class hashes for which we want to prove membership in the classes trie",
+          "required": false,
+          "schema": {
+            "title": "classes",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FELT"
+            }
+          }
+        },
+        {
+          "name": "contract_addresses",
+          "description": "a list of contracts for which we want to prove membership in the global state trie",
+          "required": false,
+          "schema": {
+            "title": "contracts",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ADDRESS"
+            }
+          }
+        },
+        {
+          "name": "contracts_storage_keys",
+          "description": "a list of (contract_address, storage_keys) pairs",
+          "required": false,
+          "schema": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "contract_address": {
+                  "$ref": "#/components/schemas/ADDRESS"
+                },
+                "storage_keys": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/FELT"
+                  }
+                }
+              },
+              "required": ["contract_address", "storage_keys"]
+            }
+          }
+        }
+      ],
+      "result": {
+        "name": "result",
+        "description": "The requested storage proofs. Note that if a requested leaf has the default value, the path to it may end in an edge node whose path is not a prefix of the requested leaf, thus effectively proving non-membership",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "classes_proof": {
+              "$ref": "#/components/schemas/NODE_HASH_TO_NODE_MAPPING"
+            },
+            "contracts_proof": {
+              "type": "object",
+              "properties": {
+                "nodes": {
+                  "description": "The nodes in the union of the paths from the contracts tree root to the requested leaves",
+                  "$ref": "#/components/schemas/NODE_HASH_TO_NODE_MAPPING"
+                },
+                "contract_leaves_data": {
+                  "type": "array",
+                  "items": {
+                    "description": "The nonce and class hash for each requested contract address, in the order in which they appear in the request. These values are needed to construct the associated leaf node",
+                    "type": "object",
+                    "properties": {
+                      "nonce": {
+                        "$ref": "#/components/schemas/FELT"
+                      },
+                      "class_hash": {
+                        "$ref": "#/components/schemas/FELT"
+                      },
+                      "storage_root": {
+                        "$ref": "#/components/schemas/FELT"
+                      }
+                    },
+                    "required": ["nonce", "class_hash"]
+                  }
+                }
+              },
+              "required": ["nodes", "contract_leaves_data"]
+            },
+            "contracts_storage_proofs": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/NODE_HASH_TO_NODE_MAPPING"
+              }
+            },
+            "global_roots": {
+              "type": "object",
+              "properties": {
+                "contracts_tree_root": {
+                  "$ref": "#/components/schemas/FELT"
+                },
+                "classes_tree_root": {
+                  "$ref": "#/components/schemas/FELT"
+                },
+                "block_hash": {
+                  "description": "the associated block hash (needed in case the caller used a block tag for the block_id parameter)",
+                  "$ref": "#/components/schemas/FELT"
+                }
+              },
+              "required": [
+                "contracts_tree_root",
+                "classes_tree_root",
+                "block_hash"
+              ]
+            }
+          },
+          "required": [
+            "classes_proof",
+            "contracts_proof",
+            "contracts_storage_proofs",
+            "global_roots"
+          ]
+        }
+      },
+      "errors": [
+        {
+          "$ref": "#/components/errors/BLOCK_NOT_FOUND"
+        },
+        {
+          "$ref": "#/components/errors/STORAGE_PROOF_NOT_SUPPORTED"
+        }
+      ]
+    }
+  ],
+  "components": {
+    "contentDescriptors": {},
+    "schemas": {
+      "EVENTS_CHUNK": {
+        "title": "Events chunk",
+        "type": "object",
+        "properties": {
+          "events": {
+            "type": "array",
+            "title": "Matching Events",
+            "items": {
+              "$ref": "#/components/schemas/EMITTED_EVENT"
+            }
+          },
+          "continuation_token": {
+            "title": "Continuation token",
+            "description": "Use this token in a subsequent query to obtain the next page. Should not appear if there are no more pages.",
+            "type": "string"
+          }
+        },
+        "required": ["events"]
+      },
+      "RESULT_PAGE_REQUEST": {
+        "title": "Result page request",
+        "type": "object",
+        "properties": {
+          "continuation_token": {
+            "title": "Continuation token",
+            "description": "The token returned from the previous query. If no token is provided the first page is returned.",
+            "type": "string"
+          },
+          "chunk_size": {
+            "title": "Chunk size",
+            "type": "integer",
+            "minimum": 1
+          }
+        },
+        "required": ["chunk_size"]
+      },
+      "EMITTED_EVENT": {
+        "title": "Emitted event",
+        "description": "Event information decorated with metadata on where it was emitted / An event emitted as a result of transaction execution",
+        "allOf": [
+          {
+            "title": "Event",
+            "description": "The event information",
+            "$ref": "#/components/schemas/EVENT"
+          },
+          {
+            "title": "Event context",
+            "description": "The event emission information",
+            "type": "object",
+            "properties": {
+              "block_hash": {
+                "title": "Block hash",
+                "description": "The hash of the block in which the event was emitted",
+                "$ref": "#/components/schemas/BLOCK_HASH"
+              },
+              "block_number": {
+                "title": "Block number",
+                "description": "The number of the block in which the event was emitted",
+                "$ref": "#/components/schemas/BLOCK_NUMBER"
+              },
+              "transaction_hash": {
+                "title": "Transaction hash",
+                "description": "The transaction that emitted the event",
+                "$ref": "#/components/schemas/TXN_HASH"
+              }
+            },
+            "required": ["transaction_hash"]
+          }
+        ]
+      },
+      "EVENT": {
+        "title": "Event",
+        "description": "A StarkNet event",
+        "allOf": [
+          {
+            "title": "Event emitter",
+            "type": "object",
+            "properties": {
+              "from_address": {
+                "title": "From address",
+                "$ref": "#/components/schemas/ADDRESS"
+              }
+            },
+            "required": ["from_address"]
+          },
+          {
+            "title": "Event content",
+            "$ref": "#/components/schemas/EVENT_CONTENT"
+          }
+        ]
+      },
+      "EVENT_CONTENT": {
+        "title": "Event content",
+        "description": "The content of an event",
+        "type": "object",
+        "properties": {
+          "keys": {
+            "type": "array",
+            "title": "Keys",
+            "items": {
+              "$ref": "#/components/schemas/FELT"
+            }
+          },
+          "data": {
+            "type": "array",
+            "title": "Data",
+            "items": {
+              "$ref": "#/components/schemas/FELT"
+            }
+          }
+        },
+        "required": ["keys", "data"]
+      },
+      "EVENT_KEYS": {
+        "title": "Keys",
+        "description": "The keys to filter over",
+        "type": "array",
+        "items": {
+          "title": "Keys",
+          "description": "Per key (by position), designate the possible values to be matched for events to be returned. Empty array designates 'any' value",
+          "type": "array",
+          "items": {
+            "$ref": "#/components/schemas/FELT"
+          }
+        }
+      },
+      "EVENT_FILTER": {
+        "title": "Event filter",
+        "description": "An event filter/query",
+        "type": "object",
+        "properties": {
+          "from_block": {
+            "title": "from block",
+            "$ref": "#/components/schemas/BLOCK_ID"
+          },
+          "to_block": {
+            "title": "to block",
+            "$ref": "#/components/schemas/BLOCK_ID"
+          },
+          "address": {
+            "title": "from contract",
+            "$ref": "#/components/schemas/ADDRESS"
+          },
+          "keys": {
+            "title": "event keys",
+            "description": "The keys to filter over",
+            "$ref": "#/components/schemas/EVENT_KEYS"
+          }
+        },
+        "required": []
+      },
+      "BLOCK_ID": {
+        "title": "Block id",
+        "description": "Block hash, number or tag",
+        "oneOf": [
+          {
+            "title": "Block hash",
+            "type": "object",
+            "properties": {
+              "block_hash": {
+                "title": "Block hash",
+                "$ref": "#/components/schemas/BLOCK_HASH"
+              }
+            },
+            "required": ["block_hash"]
+          },
+          {
+            "title": "Block number",
+            "type": "object",
+            "properties": {
+              "block_number": {
+                "title": "Block number",
+                "$ref": "#/components/schemas/BLOCK_NUMBER"
+              }
+            },
+            "required": ["block_number"]
+          },
+          {
+            "title": "Block tag",
+            "$ref": "#/components/schemas/BLOCK_TAG"
+          }
+        ]
+      },
+      "BLOCK_TAG": {
+        "title": "Block tag",
+        "type": "string",
+        "description": "A tag specifying a dynamic reference to a block",
+        "enum": ["latest", "pending"]
+      },
+      "SYNC_STATUS": {
+        "title": "Sync status",
+        "type": "object",
+        "description": "An object describing the node synchronization status",
+        "properties": {
+          "starting_block_hash": {
+            "title": "Starting block hash",
+            "description": "The hash of the block from which the sync started",
+            "$ref": "#/components/schemas/BLOCK_HASH"
+          },
+          "starting_block_num": {
+            "title": "Starting block number",
+            "description": "The number (height) of the block from which the sync started",
+            "$ref": "#/components/schemas/BLOCK_NUMBER"
+          },
+          "current_block_hash": {
+            "title": "Current block hash",
+            "description": "The hash of the current block being synchronized",
+            "$ref": "#/components/schemas/BLOCK_HASH"
+          },
+          "current_block_num": {
+            "title": "Current block number",
+            "description": "The number (height) of the current block being synchronized",
+            "$ref": "#/components/schemas/BLOCK_NUMBER"
+          },
+          "highest_block_hash": {
+            "title": "Highest block hash",
+            "description": "The hash of the estimated highest block to be synchronized",
+            "$ref": "#/components/schemas/BLOCK_HASH"
+          },
+          "highest_block_num": {
+            "title": "Highest block number",
+            "description": "The number (height) of the estimated highest block to be synchronized",
+            "$ref": "#/components/schemas/BLOCK_NUMBER"
+          }
+        },
+        "required": [
+          "starting_block_hash",
+          "starting_block_num",
+          "current_block_hash",
+          "current_block_num",
+          "highest_block_hash",
+          "highest_block_num"
+        ]
+      },
+      "NUM_AS_HEX": {
+        "title": "Number as hex",
+        "description": "An integer number in hex format (0x...)",
+        "type": "string",
+        "pattern": "^0x[a-fA-F0-9]+$"
+      },
+      "u64": {
+        "type": "string",
+        "title": "u64",
+        "description": "64 bit integers, represented by hex string of length at most 16",
+        "pattern": "^0x(0|[a-fA-F1-9]{1}[a-fA-F0-9]{0,15})$"
+      },
+      "u128": {
+        "type": "string",
+        "title": "u128",
+        "description": "128 bit integers, represented by hex string of length at most 32",
+        "pattern": "^0x(0|[a-fA-F1-9]{1}[a-fA-F0-9]{0,31})$"
+      },
+      "CHAIN_ID": {
+        "title": "Chain id",
+        "description": "StarkNet chain id, given in hex representation.",
+        "type": "string",
+        "pattern": "^0x[a-fA-F0-9]+$"
+      },
+      "STATE_DIFF": {
+        "description": "The change in state applied in this block, given as a mapping of addresses to the new values and/or new contracts",
+        "type": "object",
+        "properties": {
+          "storage_diffs": {
+            "title": "Storage diffs",
+            "type": "array",
+            "items": {
+              "description": "The changes in the storage per contract address",
+              "$ref": "#/components/schemas/CONTRACT_STORAGE_DIFF_ITEM"
+            }
+          },
+          "deprecated_declared_classes": {
+            "title": "Deprecated declared classes",
+            "type": "array",
+            "items": {
+              "description": "The hash of the declared class",
+              "$ref": "#/components/schemas/FELT"
+            }
+          },
+          "declared_classes": {
+            "title": "Declared classes",
+            "type": "array",
+            "items": {
+              "title": "New classes",
+              "type": "object",
+              "description": "The declared class hash and compiled class hash",
+              "properties": {
+                "class_hash": {
+                  "title": "Class hash",
+                  "description": "The hash of the declared class",
+                  "$ref": "#/components/schemas/FELT"
+                },
+                "compiled_class_hash": {
+                  "title": "Compiled class hash",
+                  "description": "The Cairo assembly hash corresponding to the declared class",
+                  "$ref": "#/components/schemas/FELT"
+                }
+              }
+            }
+          },
+          "deployed_contracts": {
+            "title": "Deployed contracts",
+            "type": "array",
+            "items": {
+              "description": "A new contract deployed as part of the state update",
+              "$ref": "#/components/schemas/DEPLOYED_CONTRACT_ITEM"
+            }
+          },
+          "replaced_classes": {
+            "title": "Replaced classes",
+            "type": "array",
+            "items": {
+              "description": "The list of contracts whose class was replaced",
+              "title": "Replaced class",
+              "type": "object",
+              "properties": {
+                "contract_address": {
+                  "title": "Contract address",
+                  "description": "The address of the contract whose class was replaced",
+                  "$ref": "#/components/schemas/ADDRESS"
+                },
+                "class_hash": {
+                  "title": "Class hash",
+                  "description": "The new class hash",
+                  "$ref": "#/components/schemas/FELT"
+                }
+              }
+            }
+          },
+          "nonces": {
+            "title": "Nonces",
+            "type": "array",
+            "items": {
+              "title": "Nonce update",
+              "description": "The updated nonce per contract address",
+              "type": "object",
+              "properties": {
+                "contract_address": {
+                  "title": "Contract address",
+                  "description": "The address of the contract",
+                  "$ref": "#/components/schemas/ADDRESS"
+                },
+                "nonce": {
+                  "title": "Nonce",
+                  "description": "The nonce for the given address at the end of the block",
+                  "$ref": "#/components/schemas/FELT"
+                }
+              }
+            }
+          }
+        },
+        "required": [
+          "storage_diffs",
+          "deprecated_declared_classes",
+          "declared_classes",
+          "replaced_classes",
+          "deployed_contracts",
+          "nonces"
+        ]
+      },
+      "PENDING_STATE_UPDATE": {
+        "title": "Pending state update",
+        "description": "Pending state update",
+        "type": "object",
+        "properties": {
+          "old_root": {
+            "title": "Old root",
+            "description": "The previous global state root",
+            "$ref": "#/components/schemas/FELT"
+          },
+          "state_diff": {
+            "title": "State diff",
+            "$ref": "#/components/schemas/STATE_DIFF"
+          }
+        },
+        "required": ["old_root", "state_diff"],
+        "additionalProperties": false
+      },
+      "STATE_UPDATE": {
+        "title": "State update",
+        "type": "object",
+        "properties": {
+          "block_hash": {
+            "title": "Block hash",
+            "$ref": "#/components/schemas/BLOCK_HASH"
+          },
+          "old_root": {
+            "title": "Old root",
+            "description": "The previous global state root",
+            "$ref": "#/components/schemas/FELT"
+          },
+          "new_root": {
+            "title": "New root",
+            "description": "The new global state root",
+            "$ref": "#/components/schemas/FELT"
+          },
+          "state_diff": {
+            "title": "State diff",
+            "$ref": "#/components/schemas/STATE_DIFF"
+          }
+        },
+        "required": ["state_diff", "block_hash", "old_root", "new_root"]
+      },
+      "ADDRESS": {
+        "title": "Address",
+        "$ref": "#/components/schemas/FELT"
+      },
+      "STORAGE_KEY": {
+        "type": "string",
+        "title": "Storage key",
+        "$comment": "A storage key, represented as a string of hex digits",
+        "description": "A storage key. Represented as up to 62 hex digits, 3 bits, and 5 leading zeroes.",
+        "pattern": "^0x(0|[0-7]{1}[a-fA-F0-9]{0,62}$)"
+      },
+      "ETH_ADDRESS": {
+        "title": "Ethereum address",
+        "type": "string",
+        "$comment": "An ethereum address",
+        "description": "an ethereum address represented as 40 hex digits",
+        "pattern": "^0x[a-fA-F0-9]{40}$"
+      },
+      "TXN_HASH": {
+        "$ref": "#/components/schemas/FELT",
+        "description": "The hash of a Starknet transaction",
+        "title": "Transaction hash"
+      },
+      "L1_TXN_HASH": {
+        "$ref": "#/components/schemas/NUM_AS_HEX",
+        "description": "The hash of an Ethereum transaction"
+      },
+      "FELT": {
+        "type": "string",
+        "title": "Field element",
+        "description": "A field element. represented by at most 63 hex digits",
+        "pattern": "^0x(0|[a-fA-F1-9]{1}[a-fA-F0-9]{0,62})$"
+      },
+      "BLOCK_NUMBER": {
+        "title": "Block number",
+        "description": "The block's number (its height)",
+        "type": "integer",
+        "minimum": 0
+      },
+      "BLOCK_HASH": {
+        "title": "Block hash",
+        "$ref": "#/components/schemas/FELT"
+      },
+      "BLOCK_BODY_WITH_TX_HASHES": {
+        "title": "Block body with transaction hashes",
+        "type": "object",
+        "properties": {
+          "transactions": {
+            "title": "Transaction hashes",
+            "description": "The hashes of the transactions included in this block",
+            "type": "array",
+            "items": {
+              "description": "The hash of a single transaction",
+              "$ref": "#/components/schemas/TXN_HASH"
+            }
+          }
+        },
+        "required": ["transactions"]
+      },
+      "BLOCK_BODY_WITH_TXS": {
+        "title": "Block body with transactions",
+        "type": "object",
+        "properties": {
+          "transactions": {
+            "title": "Transactions",
+            "description": "The transactions in this block",
+            "type": "array",
+            "items": {
+              "schema": {
+                "$ref": "#/components/schemas/TXN_WITH_HASH"
+              }
+            }
+          }
+        },
+        "required": ["transactions"]
+      },
+      "BLOCK_BODY_WITH_RECEIPTS": {
+        "title": "Block body with transactions and receipts",
+        "type": "object",
+        "properties": {
+          "transactions": {
+            "title": "Transactions",
+            "description": "The transactions in this block",
+            "type": "array",
+            "items": {
+              "type": "object",
+              "title": "transaction and receipt",
+              "properties": {
+                "transaction": {
+                  "title": "transaction",
+                  "$ref": "#/components/schemas/TXN"
+                },
+                "receipt": {
+                  "title": "receipt",
+                  "$ref": "#/components/schemas/TXN_RECEIPT"
+                }
+              },
+              "required": ["transaction", "receipt"]
+            }
+          }
+        },
+        "required": ["transactions"]
+      },
+      "BLOCK_HEADER": {
+        "title": "Block header",
+        "type": "object",
+        "properties": {
+          "block_hash": {
+            "title": "Block hash",
+            "$ref": "#/components/schemas/BLOCK_HASH"
+          },
+          "parent_hash": {
+            "title": "Parent hash",
+            "description": "The hash of this block's parent",
+            "$ref": "#/components/schemas/BLOCK_HASH"
+          },
+          "block_number": {
+            "title": "Block number",
+            "description": "The block number (its height)",
+            "$ref": "#/components/schemas/BLOCK_NUMBER"
+          },
+          "new_root": {
+            "title": "New root",
+            "description": "The new global state root",
+            "$ref": "#/components/schemas/FELT"
+          },
+          "timestamp": {
+            "title": "Timestamp",
+            "description": "The time in which the block was created, encoded in Unix time",
+            "type": "integer",
+            "minimum": 0
+          },
+          "sequencer_address": {
+            "title": "Sequencer address",
+            "description": "The StarkNet identity of the sequencer submitting this block",
+            "$ref": "#/components/schemas/FELT"
+          },
+          "l1_gas_price": {
+            "title": "L1 gas price",
+            "description": "The price of l1 gas in the block",
+            "$ref": "#/components/schemas/RESOURCE_PRICE"
+          },
+          "l2_gas_price": {
+            "title": "L2 gas price",
+            "description": "The price of l2 gas in the block",
+            "$ref": "#/components/schemas/RESOURCE_PRICE"
+          },
+          "l1_data_gas_price": {
+            "title": "L1 data gas price",
+            "description": "The price of l1 data gas in the block",
+            "$ref": "#/components/schemas/RESOURCE_PRICE"
+          },
+          "l1_da_mode": {
+            "title": "L1 da mode",
+            "type": "string",
+            "description": "specifies whether the data of this block is published via blob data or calldata",
+            "enum": ["BLOB", "CALLDATA"]
+          },
+          "starknet_version": {
+            "title": "Starknet version",
+            "description": "Semver of the current Starknet protocol",
+            "type": "string"
+          }
+        },
+        "required": [
+          "block_hash",
+          "parent_hash",
+          "block_number",
+          "new_root",
+          "timestamp",
+          "sequencer_address",
+          "l1_gas_price",
+          "l2_gas_price",
+          "l1_data_gas_price",
+          "l1_da_mode",
+          "starknet_version"
+        ]
+      },
+      "PENDING_BLOCK_HEADER": {
+        "title": "Pending block header",
+        "type": "object",
+        "properties": {
+          "parent_hash": {
+            "title": "Parent hash",
+            "description": "The hash of this block's parent",
+            "$ref": "#/components/schemas/BLOCK_HASH"
+          },
+          "timestamp": {
+            "title": "Timestamp",
+            "description": "The time in which the block was created, encoded in Unix time",
+            "type": "integer",
+            "minimum": 0
+          },
+          "sequencer_address": {
+            "title": "Sequencer address",
+            "description": "The StarkNet identity of the sequencer submitting this block",
+            "$ref": "#/components/schemas/FELT"
+          },
+          "l1_gas_price": {
+            "title": "L1 gas price",
+            "description": "The price of l1 gas in the block",
+            "$ref": "#/components/schemas/RESOURCE_PRICE"
+          },
+          "l2_gas_price": {
+            "title": "L2 gas price",
+            "description": "The price of l2 gas in the block",
+            "$ref": "#/components/schemas/RESOURCE_PRICE"
+          },
+          "l1_data_gas_price": {
+            "title": "L1 data gas price",
+            "description": "The price of l1 data gas in the block",
+            "$ref": "#/components/schemas/RESOURCE_PRICE"
+          },
+          "l1_da_mode": {
+            "title": "L1 da mode",
+            "type": "string",
+            "description": "specifies whether the data of this block is published via blob data or calldata",
+            "enum": ["BLOB", "CALLDATA"]
+          },
+          "starknet_version": {
+            "title": "Starknet version",
+            "description": "Semver of the current Starknet protocol",
+            "type": "string"
+          }
+        },
+        "required": [
+          "parent_hash",
+          "timestamp",
+          "sequencer_address",
+          "l1_gas_price",
+          "l2_gas_price",
+          "l1_data_gas_price",
+          "l1_da_mode",
+          "starknet_version"
+        ],
+        "not": {
+          "required": ["block_hash", "block_number", "new_root"]
+        }
+      },
+      "BLOCK_WITH_TX_HASHES": {
+        "title": "Block with transaction hashes",
+        "description": "The block object",
+        "allOf": [
+          {
+            "title": "Block status",
+            "type": "object",
+            "properties": {
+              "status": {
+                "title": "Status",
+                "$ref": "#/components/schemas/BLOCK_STATUS"
+              }
+            },
+            "required": ["status"]
+          },
+          {
+            "title": "Block header",
+            "$ref": "#/components/schemas/BLOCK_HEADER"
+          },
+          {
+            "title": "Block body with transaction hashes",
+            "$ref": "#/components/schemas/BLOCK_BODY_WITH_TX_HASHES"
+          }
+        ]
+      },
+      "BLOCK_WITH_TXS": {
+        "title": "Block with transactions",
+        "description": "The block object",
+        "allOf": [
+          {
+            "title": "block with txs",
+            "type": "object",
+            "properties": {
+              "status": {
+                "title": "Status",
+                "$ref": "#/components/schemas/BLOCK_STATUS"
+              }
+            },
+            "required": ["status"]
+          },
+          {
+            "title": "Block header",
+            "$ref": "#/components/schemas/BLOCK_HEADER"
+          },
+          {
+            "title": "Block body with transactions",
+            "$ref": "#/components/schemas/BLOCK_BODY_WITH_TXS"
+          }
+        ]
+      },
+      "BLOCK_WITH_RECEIPTS": {
+        "title": "Block with transactions and receipts",
+        "description": "The block object",
+        "allOf": [
+          {
+            "title": "block with txs",
+            "type": "object",
+            "properties": {
+              "status": {
+                "title": "Status",
+                "$ref": "#/components/schemas/BLOCK_STATUS"
+              }
+            },
+            "required": ["status"]
+          },
+          {
+            "title": "Block header",
+            "$ref": "#/components/schemas/BLOCK_HEADER"
+          },
+          {
+            "title": "Block body with transactions and receipts",
+            "$ref": "#/components/schemas/BLOCK_BODY_WITH_RECEIPTS"
+          }
+        ]
+      },
+      "PENDING_BLOCK_WITH_TX_HASHES": {
+        "title": "Pending block with transaction hashes",
+        "description": "The dynamic block being constructed by the sequencer. Note that this object will be deprecated upon decentralization.",
+        "allOf": [
+          {
+            "title": "Block body with transactions hashes",
+            "$ref": "#/components/schemas/BLOCK_BODY_WITH_TX_HASHES"
+          },
+          {
+            "title": "Pending block header",
+            "$ref": "#/components/schemas/PENDING_BLOCK_HEADER"
+          }
+        ]
+      },
+      "PENDING_BLOCK_WITH_TXS": {
+        "title": "Pending block with transactions",
+        "description": "The dynamic block being constructed by the sequencer. Note that this object will be deprecated upon decentralization.",
+        "allOf": [
+          {
+            "title": "Block body with transactions",
+            "$ref": "#/components/schemas/BLOCK_BODY_WITH_TXS"
+          },
+          {
+            "title": "Pending block header",
+            "$ref": "#/components/schemas/PENDING_BLOCK_HEADER"
+          }
+        ]
+      },
+      "PENDING_BLOCK_WITH_RECEIPTS": {
+        "title": "Pending block with transactions and receipts",
+        "description": "The dynamic block being constructed by the sequencer. Note that this object will be deprecated upon decentralization.",
+        "allOf": [
+          {
+            "title": "Block body with transactions and receipts",
+            "$ref": "#/components/schemas/BLOCK_BODY_WITH_RECEIPTS"
+          },
+          {
+            "title": "Pending block header",
+            "$ref": "#/components/schemas/PENDING_BLOCK_HEADER"
+          }
+        ]
+      },
+      "DEPLOYED_CONTRACT_ITEM": {
+        "title": "Deployed contract item",
+        "type": "object",
+        "properties": {
+          "address": {
+            "title": "Address",
+            "description": "The address of the contract",
+            "$ref": "#/components/schemas/FELT"
+          },
+          "class_hash": {
+            "title": "Class hash",
+            "description": "The hash of the contract code",
+            "$ref": "#/components/schemas/FELT"
+          }
+        },
+        "required": ["address", "class_hash"]
+      },
+      "CONTRACT_STORAGE_DIFF_ITEM": {
+        "title": "Contract storage diff item",
+        "type": "object",
+        "properties": {
+          "address": {
+            "title": "Address",
+            "description": "The contract address for which the storage changed",
+            "$ref": "#/components/schemas/FELT"
+          },
+          "storage_entries": {
+            "title": "Storage entries",
+            "description": "The changes in the storage of the contract",
+            "type": "array",
+            "items": {
+              "title": "Storage diff item",
+              "type": "object",
+              "properties": {
+                "key": {
+                  "title": "Key",
+                  "description": "The key of the changed value",
+                  "$ref": "#/components/schemas/FELT"
+                },
+                "value": {
+                  "title": "Value",
+                  "description": "The new value applied to the given address",
+                  "$ref": "#/components/schemas/FELT"
+                }
+              }
+            }
+          }
+        },
+        "required": ["address", "storage_entries"]
+      },
+      "TXN": {
+        "title": "Transaction",
+        "description": "The transaction schema, as it appears inside a block",
+        "oneOf": [
+          {
+            "title": "Invoke transaction",
+            "$ref": "#/components/schemas/INVOKE_TXN"
+          },
+          {
+            "title": "L1 handler transaction",
+            "$ref": "#/components/schemas/L1_HANDLER_TXN"
+          },
+          {
+            "title": "Declare transaction",
+            "$ref": "#/components/schemas/DECLARE_TXN"
+          },
+          {
+            "title": "Deploy transaction",
+            "$ref": "#/components/schemas/DEPLOY_TXN"
+          },
+          {
+            "title": "Deploy account transaction",
+            "$ref": "#/components/schemas/DEPLOY_ACCOUNT_TXN"
+          }
+        ]
+      },
+      "TXN_WITH_HASH": {
+        "schema": {
+          "title": "Transaction",
+          "allOf": [
+            {
+              "$ref": "#/components/schemas/TXN"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "transaction_hash": {
+                  "title": "transaction hash",
+                  "$ref": "#/components/schemas/TXN_HASH"
+                }
+              },
+              "required": ["transaction_hash"]
+            }
+          ]
+        }
+      },
+      "SIGNATURE": {
+        "title": "Signature",
+        "description": "A transaction signature",
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/FELT"
+        }
+      },
+      "DECLARE_TXN": {
+        "title": "Declare transaction",
+        "oneOf": [
+          {
+            "title": "Declare transaction V0",
+            "$ref": "#/components/schemas/DECLARE_TXN_V0"
+          },
+          {
+            "title": "Declare transaction V1",
+            "$ref": "#/components/schemas/DECLARE_TXN_V1"
+          },
+          {
+            "title": "Declare transaction V2",
+            "$ref": "#/components/schemas/DECLARE_TXN_V2"
+          },
+          {
+            "title": "Declare transaction V3",
+            "$ref": "#/components/schemas/DECLARE_TXN_V3"
+          }
+        ]
+      },
+      "DECLARE_TXN_V0": {
+        "title": "Declare Contract Transaction V0",
+        "description": "Declare Contract Transaction V0",
+        "allOf": [
+          {
+            "type": "object",
+            "title": "Declare txn v0",
+            "properties": {
+              "type": {
+                "title": "Declare",
+                "type": "string",
+                "enum": ["DECLARE"]
+              },
+              "sender_address": {
+                "title": "Sender address",
+                "description": "The address of the account contract sending the declaration transaction",
+                "$ref": "#/components/schemas/ADDRESS"
+              },
+              "max_fee": {
+                "title": "Max fee",
+                "$ref": "#/components/schemas/FELT",
+                "description": "The maximal fee that can be charged for including the transaction"
+              },
+              "version": {
+                "title": "Version",
+                "description": "Version of the transaction scheme",
+                "type": "string",
+                "enum": ["0x0", "0x100000000000000000000000000000000"]
+              },
+              "signature": {
+                "title": "Signature",
+                "$ref": "#/components/schemas/SIGNATURE"
+              },
+              "class_hash": {
+                "title": "Class hash",
+                "description": "The hash of the declared class",
+                "$ref": "#/components/schemas/FELT"
+              }
+            },
+            "required": [
+              "type",
+              "sender_address",
+              "max_fee",
+              "version",
+              "signature",
+              "class_hash"
+            ]
+          }
+        ]
+      },
+      "DECLARE_TXN_V1": {
+        "title": "Declare Contract Transaction V1",
+        "description": "Declare Contract Transaction V1",
+        "allOf": [
+          {
+            "type": "object",
+            "title": "Declare txn v1",
+            "properties": {
+              "type": {
+                "title": "Declare",
+                "type": "string",
+                "enum": ["DECLARE"]
+              },
+              "sender_address": {
+                "title": "Sender address",
+                "description": "The address of the account contract sending the declaration transaction",
+                "$ref": "#/components/schemas/ADDRESS"
+              },
+              "max_fee": {
+                "title": "Max fee",
+                "$ref": "#/components/schemas/FELT",
+                "description": "The maximal fee that can be charged for including the transaction"
+              },
+              "version": {
+                "title": "Version",
+                "description": "Version of the transaction scheme",
+                "type": "string",
+                "enum": ["0x1", "0x100000000000000000000000000000001"]
+              },
+              "signature": {
+                "title": "Signature",
+                "$ref": "#/components/schemas/SIGNATURE"
+              },
+              "nonce": {
+                "title": "Nonce",
+                "$ref": "#/components/schemas/FELT"
+              },
+              "class_hash": {
+                "title": "Class hash",
+                "description": "The hash of the declared class",
+                "$ref": "#/components/schemas/FELT"
+              }
+            },
+            "required": [
+              "type",
+              "sender_address",
+              "max_fee",
+              "version",
+              "signature",
+              "nonce",
+              "class_hash"
+            ]
+          }
+        ]
+      },
+      "DECLARE_TXN_V2": {
+        "title": "Declare Transaction V2",
+        "description": "Declare Contract Transaction V2",
+        "allOf": [
+          {
+            "type": "object",
+            "title": "Declare txn v2",
+            "properties": {
+              "type": {
+                "title": "Declare",
+                "type": "string",
+                "enum": ["DECLARE"]
+              },
+              "sender_address": {
+                "title": "Sender address",
+                "description": "The address of the account contract sending the declaration transaction",
+                "$ref": "#/components/schemas/ADDRESS"
+              },
+              "compiled_class_hash": {
+                "title": "Compiled class hash",
+                "description": "The hash of the Cairo assembly resulting from the Sierra compilation",
+                "$ref": "#/components/schemas/FELT"
+              },
+              "max_fee": {
+                "title": "Max fee",
+                "$ref": "#/components/schemas/FELT",
+                "description": "The maximal fee that can be charged for including the transaction"
+              },
+              "version": {
+                "title": "Version",
+                "description": "Version of the transaction scheme",
+                "type": "string",
+                "enum": ["0x2", "0x100000000000000000000000000000002"]
+              },
+              "signature": {
+                "title": "Signature",
+                "$ref": "#/components/schemas/SIGNATURE"
+              },
+              "nonce": {
+                "title": "Nonce",
+                "$ref": "#/components/schemas/FELT"
+              },
+              "class_hash": {
+                "title": "Class hash",
+                "description": "The hash of the declared class",
+                "$ref": "#/components/schemas/FELT"
+              }
+            },
+            "required": [
+              "type",
+              "sender_address",
+              "compiled_class_hash",
+              "max_fee",
+              "version",
+              "signature",
+              "nonce",
+              "class_hash"
+            ]
+          }
+        ]
+      },
+      "DECLARE_TXN_V3": {
+        "title": "Declare Transaction V3",
+        "description": "Declare Contract Transaction V3",
+        "allOf": [
+          {
+            "type": "object",
+            "title": "Declare txn v3",
+            "properties": {
+              "type": {
+                "title": "Declare",
+                "type": "string",
+                "enum": ["DECLARE"]
+              },
+              "sender_address": {
+                "title": "Sender address",
+                "description": "The address of the account contract sending the declaration transaction",
+                "$ref": "#/components/schemas/ADDRESS"
+              },
+              "compiled_class_hash": {
+                "title": "Compiled class hash",
+                "description": "The hash of the Cairo assembly resulting from the Sierra compilation",
+                "$ref": "#/components/schemas/FELT"
+              },
+              "version": {
+                "title": "Version",
+                "description": "Version of the transaction scheme",
+                "type": "string",
+                "enum": ["0x3", "0x100000000000000000000000000000003"]
+              },
+              "signature": {
+                "title": "Signature",
+                "$ref": "#/components/schemas/SIGNATURE"
+              },
+              "nonce": {
+                "title": "Nonce",
+                "$ref": "#/components/schemas/FELT"
+              },
+              "class_hash": {
+                "title": "Class hash",
+                "description": "The hash of the declared class",
+                "$ref": "#/components/schemas/FELT"
+              },
+              "resource_bounds": {
+                "title": "Resource bounds",
+                "description": "resource bounds for the transaction execution",
+                "$ref": "#/components/schemas/RESOURCE_BOUNDS_MAPPING"
+              },
+              "tip": {
+                "title": "Tip",
+                "$ref": "#/components/schemas/u64",
+                "description": "the tip for the transaction"
+              },
+              "paymaster_data": {
+                "title": "Paymaster data",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/FELT"
+                },
+                "description": "data needed to allow the paymaster to pay for the transaction in native tokens"
+              },
+              "account_deployment_data": {
+                "title": "Account deployment data",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/FELT"
+                },
+                "description": "data needed to deploy the account contract from which this tx will be initiated"
+              },
+              "nonce_data_availability_mode": {
+                "title": "Nonce DA mode",
+                "description": "The storage domain of the account's nonce (an account has a nonce per DA mode)",
+                "$ref": "#/components/schemas/DA_MODE"
+              },
+              "fee_data_availability_mode": {
+                "title": "Fee DA mode",
+                "description": "The storage domain of the account's balance from which fee will be charged",
+                "$ref": "#/components/schemas/DA_MODE"
+              }
+            },
+            "required": [
+              "type",
+              "sender_address",
+              "compiled_class_hash",
+              "version",
+              "signature",
+              "nonce",
+              "class_hash",
+              "resource_bounds",
+              "tip",
+              "paymaster_data",
+              "account_deployment_data",
+              "nonce_data_availability_mode",
+              "fee_data_availability_mode"
+            ]
+          }
+        ]
+      },
+      "BROADCASTED_TXN": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/BROADCASTED_INVOKE_TXN"
+          },
+          {
+            "$ref": "#/components/schemas/BROADCASTED_DECLARE_TXN"
+          },
+          {
+            "$ref": "#/components/schemas/BROADCASTED_DEPLOY_ACCOUNT_TXN"
+          }
+        ]
+      },
+      "BROADCASTED_INVOKE_TXN": {
+        "title": "Broadcasted invoke transaction",
+        "$ref": "#/components/schemas/INVOKE_TXN_V3"
+      },
+      "BROADCASTED_DEPLOY_ACCOUNT_TXN": {
+        "title": "Broadcasted deploy account transaction",
+        "$ref": "#/components/schemas/DEPLOY_ACCOUNT_TXN_V3"
+      },
+      "BROADCASTED_DECLARE_TXN": {
+        "title": "Broadcasted declare transaction",
+        "$ref": "#/components/schemas/BROADCASTED_DECLARE_TXN_V3"
+      },
+      "BROADCASTED_DECLARE_TXN_V3": {
+        "title": "Broadcasted declare Transaction V3",
+        "description": "Broadcasted declare Contract Transaction V3",
+        "allOf": [
+          {
+            "type": "object",
+            "title": "Declare txn v3",
+            "properties": {
+              "type": {
+                "title": "Declare",
+                "type": "string",
+                "enum": ["DECLARE"]
+              },
+              "sender_address": {
+                "title": "Sender address",
+                "description": "The address of the account contract sending the declaration transaction",
+                "$ref": "#/components/schemas/ADDRESS"
+              },
+              "compiled_class_hash": {
+                "title": "Compiled class hash",
+                "description": "The hash of the Cairo assembly resulting from the Sierra compilation",
+                "$ref": "#/components/schemas/FELT"
+              },
+              "version": {
+                "title": "Version",
+                "description": "Version of the transaction scheme",
+                "type": "string",
+                "enum": ["0x3", "0x100000000000000000000000000000003"]
+              },
+              "signature": {
+                "title": "Signature",
+                "$ref": "#/components/schemas/SIGNATURE"
+              },
+              "nonce": {
+                "title": "Nonce",
+                "$ref": "#/components/schemas/FELT"
+              },
+              "contract_class": {
+                "title": "Contract class",
+                "description": "The class to be declared",
+                "$ref": "#/components/schemas/CONTRACT_CLASS"
+              },
+              "resource_bounds": {
+                "title": "Resource bounds",
+                "description": "resource bounds for the transaction execution",
+                "$ref": "#/components/schemas/RESOURCE_BOUNDS_MAPPING"
+              },
+              "tip": {
+                "title": "Tip",
+                "$ref": "#/components/schemas/u64",
+                "description": "the tip for the transaction"
+              },
+              "paymaster_data": {
+                "title": "Paymaster data",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/FELT"
+                },
+                "description": "data needed to allow the paymaster to pay for the transaction in native tokens"
+              },
+              "account_deployment_data": {
+                "title": "Account deployment data",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/FELT"
+                },
+                "description": "data needed to deploy the account contract from which this tx will be initiated"
+              },
+              "nonce_data_availability_mode": {
+                "title": "Nonce DA mode",
+                "description": "The storage domain of the account's nonce (an account has a nonce per DA mode)",
+                "$ref": "#/components/schemas/DA_MODE"
+              },
+              "fee_data_availability_mode": {
+                "title": "Fee DA mode",
+                "description": "The storage domain of the account's balance from which fee will be charged",
+                "$ref": "#/components/schemas/DA_MODE"
+              }
+            },
+            "required": [
+              "type",
+              "sender_address",
+              "compiled_class_hash",
+              "version",
+              "signature",
+              "nonce",
+              "contract_class",
+              "resource_bounds",
+              "tip",
+              "paymaster_data",
+              "account_deployment_data",
+              "nonce_data_availability_mode",
+              "fee_data_availability_mode"
+            ]
+          }
+        ]
+      },
+      "DEPLOY_ACCOUNT_TXN": {
+        "title": "Deploy account transaction",
+        "description": "deploys a new account contract",
+        "oneOf": [
+          {
+            "title": "Deploy account V1",
+            "$ref": "#/components/schemas/DEPLOY_ACCOUNT_TXN_V1"
+          },
+          {
+            "title": "Deploy account V3",
+            "$ref": "#/components/schemas/DEPLOY_ACCOUNT_TXN_V3"
+          }
+        ]
+      },
+      "DEPLOY_ACCOUNT_TXN_V1": {
+        "title": "Deploy account transaction",
+        "description": "Deploys an account contract, charges fee from the pre-funded account addresses",
+        "type": "object",
+        "properties": {
+          "type": {
+            "title": "Deploy account",
+            "type": "string",
+            "enum": ["DEPLOY_ACCOUNT"]
+          },
+          "max_fee": {
+            "title": "Max fee",
+            "$ref": "#/components/schemas/FELT",
+            "description": "The maximal fee that can be charged for including the transaction"
+          },
+          "version": {
+            "title": "Version",
+            "description": "Version of the transaction scheme",
+            "type": "string",
+            "enum": ["0x1", "0x100000000000000000000000000000001"]
+          },
+          "signature": {
+            "title": "Signature",
+            "$ref": "#/components/schemas/SIGNATURE"
+          },
+          "nonce": {
+            "title": "Nonce",
+            "$ref": "#/components/schemas/FELT"
+          },
+          "contract_address_salt": {
+            "title": "Contract address salt",
+            "description": "The salt for the address of the deployed contract",
+            "$ref": "#/components/schemas/FELT"
+          },
+          "constructor_calldata": {
+            "type": "array",
+            "description": "The parameters passed to the constructor",
+            "title": "Constructor calldata",
+            "items": {
+              "$ref": "#/components/schemas/FELT"
+            }
+          },
+          "class_hash": {
+            "title": "Class hash",
+            "description": "The hash of the deployed contract's class",
+            "$ref": "#/components/schemas/FELT"
+          }
+        },
+        "required": [
+          "max_fee",
+          "version",
+          "signature",
+          "nonce",
+          "type",
+          "contract_address_salt",
+          "constructor_calldata",
+          "class_hash"
+        ]
+      },
+      "DEPLOY_ACCOUNT_TXN_V3": {
+        "title": "Deploy account transaction",
+        "description": "Deploys an account contract, charges fee from the pre-funded account addresses",
+        "type": "object",
+        "properties": {
+          "type": {
+            "title": "Deploy account",
+            "type": "string",
+            "enum": ["DEPLOY_ACCOUNT"]
+          },
+          "version": {
+            "title": "Version",
+            "description": "Version of the transaction scheme",
+            "type": "string",
+            "enum": ["0x3", "0x100000000000000000000000000000003"]
+          },
+          "signature": {
+            "title": "Signature",
+            "$ref": "#/components/schemas/SIGNATURE"
+          },
+          "nonce": {
+            "title": "Nonce",
+            "$ref": "#/components/schemas/FELT"
+          },
+          "contract_address_salt": {
+            "title": "Contract address salt",
+            "description": "The salt for the address of the deployed contract",
+            "$ref": "#/components/schemas/FELT"
+          },
+          "constructor_calldata": {
+            "type": "array",
+            "description": "The parameters passed to the constructor",
+            "title": "Constructor calldata",
+            "items": {
+              "$ref": "#/components/schemas/FELT"
+            }
+          },
+          "class_hash": {
+            "title": "Class hash",
+            "description": "The hash of the deployed contract's class",
+            "$ref": "#/components/schemas/FELT"
+          },
+          "resource_bounds": {
+            "title": "Resource bounds",
+            "description": "resource bounds for the transaction execution",
+            "$ref": "#/components/schemas/RESOURCE_BOUNDS_MAPPING"
+          },
+          "tip": {
+            "title": "Tip",
+            "$ref": "#/components/schemas/u64",
+            "description": "the tip for the transaction"
+          },
+          "paymaster_data": {
+            "title": "Paymaster data",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FELT"
+            },
+            "description": "data needed to allow the paymaster to pay for the transaction in native tokens"
+          },
+          "nonce_data_availability_mode": {
+            "title": "Nonce DA mode",
+            "description": "The storage domain of the account's nonce (an account has a nonce per DA mode)",
+            "$ref": "#/components/schemas/DA_MODE"
+          },
+          "fee_data_availability_mode": {
+            "title": "Fee DA mode",
+            "description": "The storage domain of the account's balance from which fee will be charged",
+            "$ref": "#/components/schemas/DA_MODE"
+          }
+        },
+        "required": [
+          "version",
+          "signature",
+          "nonce",
+          "type",
+          "contract_address_salt",
+          "constructor_calldata",
+          "class_hash",
+          "resource_bounds",
+          "tip",
+          "paymaster_data",
+          "nonce_data_availability_mode",
+          "fee_data_availability_mode"
+        ]
+      },
+      "DEPLOY_TXN": {
+        "title": "Deploy Contract Transaction",
+        "description": "The structure of a deploy transaction. Note that this transaction type is deprecated and will no longer be supported in future versions",
+        "allOf": [
+          {
+            "type": "object",
+            "title": "Deploy txn",
+            "properties": {
+              "version": {
+                "title": "Version",
+                "description": "Version of the transaction scheme",
+                "$ref": "#/components/schemas/FELT"
+              },
+              "type": {
+                "title": "Deploy",
+                "type": "string",
+                "enum": ["DEPLOY"]
+              },
+              "contract_address_salt": {
+                "description": "The salt for the address of the deployed contract",
+                "title": "Contract address salt",
+                "$ref": "#/components/schemas/FELT"
+              },
+              "constructor_calldata": {
+                "type": "array",
+                "title": "Constructor calldata",
+                "description": "The parameters passed to the constructor",
+                "items": {
+                  "$ref": "#/components/schemas/FELT"
+                }
+              },
+              "class_hash": {
+                "title": "Class hash",
+                "description": "The hash of the deployed contract's class",
+                "$ref": "#/components/schemas/FELT"
+              }
+            },
+            "required": [
+              "version",
+              "type",
+              "constructor_calldata",
+              "contract_address_salt",
+              "class_hash"
+            ]
+          }
+        ]
+      },
+      "INVOKE_TXN_V0": {
+        "title": "Invoke transaction V0",
+        "description": "invokes a specific function in the desired contract (not necessarily an account)",
+        "type": "object",
+        "properties": {
+          "type": {
+            "title": "Type",
+            "type": "string",
+            "enum": ["INVOKE"]
+          },
+          "max_fee": {
+            "title": "Max fee",
+            "$ref": "#/components/schemas/FELT",
+            "description": "The maximal fee that can be charged for including the transaction"
+          },
+          "version": {
+            "title": "Version",
+            "description": "Version of the transaction scheme",
+            "type": "string",
+            "enum": ["0x0", "0x100000000000000000000000000000000"]
+          },
+          "signature": {
+            "title": "Signature",
+            "$ref": "#/components/schemas/SIGNATURE"
+          },
+          "contract_address": {
+            "title": "Contract address",
+            "$ref": "#/components/schemas/ADDRESS"
+          },
+          "entry_point_selector": {
+            "title": "Entry point selector",
+            "$ref": "#/components/schemas/FELT"
+          },
+          "calldata": {
+            "title": "Calldata",
+            "type": "array",
+            "description": "The parameters passed to the function",
+            "items": {
+              "$ref": "#/components/schemas/FELT"
+            }
+          }
+        },
+        "required": [
+          "type",
+          "contract_address",
+          "entry_point_selector",
+          "calldata",
+          "max_fee",
+          "version",
+          "signature"
+        ]
+      },
+      "INVOKE_TXN_V1": {
+        "title": "Invoke transaction V1",
+        "description": "initiates a transaction from a given account",
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "title": "Type",
+                "type": "string",
+                "enum": ["INVOKE"]
+              },
+              "sender_address": {
+                "title": "sender address",
+                "$ref": "#/components/schemas/ADDRESS"
+              },
+              "calldata": {
+                "type": "array",
+                "title": "calldata",
+                "description": "The data expected by the account's `execute` function (in most usecases, this includes the called contract address and a function selector)",
+                "items": {
+                  "$ref": "#/components/schemas/FELT"
+                }
+              },
+              "max_fee": {
+                "title": "Max fee",
+                "$ref": "#/components/schemas/FELT",
+                "description": "The maximal fee that can be charged for including the transaction"
+              },
+              "version": {
+                "title": "Version",
+                "description": "Version of the transaction scheme",
+                "type": "string",
+                "enum": ["0x1", "0x100000000000000000000000000000001"]
+              },
+              "signature": {
+                "title": "Signature",
+                "$ref": "#/components/schemas/SIGNATURE"
+              },
+              "nonce": {
+                "title": "Nonce",
+                "$ref": "#/components/schemas/FELT"
+              }
+            },
+            "required": [
+              "type",
+              "sender_address",
+              "calldata",
+              "max_fee",
+              "version",
+              "signature",
+              "nonce"
+            ]
+          }
+        ]
+      },
+      "INVOKE_TXN_V3": {
+        "title": "Invoke transaction V3",
+        "description": "initiates a transaction from a given account",
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "title": "Type",
+                "type": "string",
+                "enum": ["INVOKE"]
+              },
+              "sender_address": {
+                "title": "sender address",
+                "$ref": "#/components/schemas/ADDRESS"
+              },
+              "calldata": {
+                "type": "array",
+                "title": "calldata",
+                "description": "The data expected by the account's `execute` function (in most usecases, this includes the called contract address and a function selector)",
+                "items": {
+                  "$ref": "#/components/schemas/FELT"
+                }
+              },
+              "version": {
+                "title": "Version",
+                "description": "Version of the transaction scheme",
+                "type": "string",
+                "enum": ["0x3", "0x100000000000000000000000000000003"]
+              },
+              "signature": {
+                "title": "Signature",
+                "$ref": "#/components/schemas/SIGNATURE"
+              },
+              "nonce": {
+                "title": "Nonce",
+                "$ref": "#/components/schemas/FELT"
+              },
+              "resource_bounds": {
+                "title": "Resource bounds",
+                "description": "resource bounds for the transaction execution",
+                "$ref": "#/components/schemas/RESOURCE_BOUNDS_MAPPING"
+              },
+              "tip": {
+                "title": "Tip",
+                "$ref": "#/components/schemas/u64",
+                "description": "the tip for the transaction"
+              },
+              "paymaster_data": {
+                "title": "Paymaster data",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/FELT"
+                },
+                "description": "data needed to allow the paymaster to pay for the transaction in native tokens"
+              },
+              "account_deployment_data": {
+                "title": "Account deployment data",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/FELT"
+                },
+                "description": "data needed to deploy the account contract from which this tx will be initiated"
+              },
+              "nonce_data_availability_mode": {
+                "title": "Nonce DA mode",
+                "description": "The storage domain of the account's nonce (an account has a nonce per DA mode)",
+                "$ref": "#/components/schemas/DA_MODE"
+              },
+              "fee_data_availability_mode": {
+                "title": "Fee DA mode",
+                "description": "The storage domain of the account's balance from which fee will be charged",
+                "$ref": "#/components/schemas/DA_MODE"
+              }
+            },
+            "required": [
+              "type",
+              "sender_address",
+              "calldata",
+              "version",
+              "signature",
+              "nonce",
+              "resource_bounds",
+              "tip",
+              "paymaster_data",
+              "account_deployment_data",
+              "nonce_data_availability_mode",
+              "fee_data_availability_mode"
+            ]
+          }
+        ]
+      },
+      "INVOKE_TXN": {
+        "title": "Invoke transaction",
+        "description": "Initiate a transaction from an account",
+        "oneOf": [
+          {
+            "title": "Invoke transaction V0",
+            "$ref": "#/components/schemas/INVOKE_TXN_V0"
+          },
+          {
+            "title": "Invoke transaction V1",
+            "$ref": "#/components/schemas/INVOKE_TXN_V1"
+          },
+          {
+            "title": "Invoke transaction V3",
+            "$ref": "#/components/schemas/INVOKE_TXN_V3"
+          }
+        ]
+      },
+      "L1_HANDLER_TXN": {
+        "title": "L1 Handler transaction",
+        "allOf": [
+          {
+            "type": "object",
+            "title": "L1 handler transaction",
+            "description": "a call to an l1_handler on an L2 contract induced by a message from L1",
+            "properties": {
+              "version": {
+                "title": "Version",
+                "description": "Version of the transaction scheme",
+                "type": "string",
+                "enum": ["0x0"]
+              },
+              "type": {
+                "title": "type",
+                "type": "string",
+                "enum": ["L1_HANDLER"]
+              },
+              "nonce": {
+                "title": "Nonce",
+                "description": "The L1->L2 message nonce field of the SN Core L1 contract at the time the transaction was sent",
+                "$ref": "#/components/schemas/NUM_AS_HEX"
+              }
+            },
+            "required": ["version", "type", "nonce"]
+          },
+          {
+            "title": "Function call",
+            "$ref": "#/components/schemas/FUNCTION_CALL"
+          }
+        ]
+      },
+      "COMMON_RECEIPT_PROPERTIES": {
+        "allOf": [
+          {
+            "title": "Common receipt properties",
+            "description": "Common properties for a transaction receipt",
+            "type": "object",
+            "properties": {
+              "transaction_hash": {
+                "title": "Transaction hash",
+                "$ref": "#/components/schemas/TXN_HASH",
+                "description": "The hash identifying the transaction"
+              },
+              "actual_fee": {
+                "title": "Actual fee",
+                "$ref": "#/components/schemas/FEE_PAYMENT",
+                "description": "The fee that was charged by the sequencer"
+              },
+              "finality_status": {
+                "title": "Finality status",
+                "description": "finality status of the tx",
+                "$ref": "#/components/schemas/TXN_FINALITY_STATUS"
+              },
+              "messages_sent": {
+                "type": "array",
+                "title": "Messages sent",
+                "items": {
+                  "$ref": "#/components/schemas/MSG_TO_L1"
+                }
+              },
+              "events": {
+                "description": "The events emitted as part of this transaction",
+                "title": "Events",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/EVENT"
+                }
+              },
+              "execution_resources": {
+                "title": "Execution resources",
+                "description": "The resources consumed by the transaction",
+                "$ref": "#/components/schemas/EXECUTION_RESOURCES"
+              }
+            },
+            "required": [
+              "transaction_hash",
+              "actual_fee",
+              "finality_status",
+              "messages_sent",
+              "events",
+              "execution_resources"
+            ]
+          },
+          {
+            "oneOf": [
+              {
+                "title": "Successful Common receipt properties",
+                "description": "Common properties for a transaction receipt that was executed successfully",
+                "type": "object",
+                "properties": {
+                  "execution_status": {
+                    "title": "Execution status",
+                    "type": "string",
+                    "enum": ["SUCCEEDED"],
+                    "description": "The execution status of the transaction"
+                  }
+                },
+                "required": ["execution_status"]
+              },
+              {
+                "title": "Reverted Common receipt properties",
+                "description": "Common properties for a transaction receipt that was reverted",
+                "type": "object",
+                "properties": {
+                  "execution_status": {
+                    "title": "Execution status",
+                    "type": "string",
+                    "enum": ["REVERTED"],
+                    "description": "The execution status of the transaction"
+                  },
+                  "revert_reason": {
+                    "title": "Revert reason",
+                    "name": "revert reason",
+                    "description": "the revert reason for the failed execution",
+                    "type": "string"
+                  }
+                },
+                "required": ["execution_status", "revert_reason"]
+              }
+            ]
+          }
+        ]
+      },
+      "INVOKE_TXN_RECEIPT": {
+        "title": "Invoke Transaction Receipt",
+        "allOf": [
+          {
+            "title": "Type",
+            "type": "object",
+            "properties": {
+              "type": {
+                "title": "Type",
+                "type": "string",
+                "enum": ["INVOKE"]
+              }
+            },
+            "required": ["type"]
+          },
+          {
+            "title": "Common receipt properties",
+            "$ref": "#/components/schemas/COMMON_RECEIPT_PROPERTIES"
+          }
+        ]
+      },
+      "DECLARE_TXN_RECEIPT": {
+        "title": "Declare Transaction Receipt",
+        "allOf": [
+          {
+            "title": "Declare txn receipt",
+            "type": "object",
+            "properties": {
+              "type": {
+                "title": "Declare",
+                "type": "string",
+                "enum": ["DECLARE"]
+              }
+            },
+            "required": ["type"]
+          },
+          {
+            "title": "Common receipt properties",
+            "$ref": "#/components/schemas/COMMON_RECEIPT_PROPERTIES"
+          }
+        ]
+      },
+      "DEPLOY_ACCOUNT_TXN_RECEIPT": {
+        "title": "Deploy Account Transaction Receipt",
+        "allOf": [
+          {
+            "title": "Common receipt properties",
+            "$ref": "#/components/schemas/COMMON_RECEIPT_PROPERTIES"
+          },
+          {
+            "title": "DeployAccount txn receipt",
+            "type": "object",
+            "properties": {
+              "type": {
+                "title": "Deploy account",
+                "type": "string",
+                "enum": ["DEPLOY_ACCOUNT"]
+              },
+              "contract_address": {
+                "title": "Contract address",
+                "description": "The address of the deployed contract",
+                "$ref": "#/components/schemas/FELT"
+              }
+            },
+            "required": ["type", "contract_address"]
+          }
+        ]
+      },
+      "DEPLOY_TXN_RECEIPT": {
+        "title": "Deploy Transaction Receipt",
+        "allOf": [
+          {
+            "title": "Common receipt properties",
+            "$ref": "#/components/schemas/COMMON_RECEIPT_PROPERTIES"
+          },
+          {
+            "title": "Deploy txn receipt",
+            "type": "object",
+            "properties": {
+              "type": {
+                "title": "Deploy",
+                "type": "string",
+                "enum": ["DEPLOY"]
+              },
+              "contract_address": {
+                "title": "Contract address",
+                "description": "The address of the deployed contract",
+                "$ref": "#/components/schemas/FELT"
+              }
+            },
+            "required": ["type", "contract_address"]
+          }
+        ]
+      },
+      "L1_HANDLER_TXN_RECEIPT": {
+        "title": "L1 Handler Transaction Receipt",
+        "description": "receipt for l1 handler transaction",
+        "allOf": [
+          {
+            "title": "Transaction type",
+            "type": "object",
+            "properties": {
+              "type": {
+                "title": "type",
+                "type": "string",
+                "enum": ["L1_HANDLER"]
+              },
+              "message_hash": {
+                "title": "Message hash",
+                "description": "The message hash as it appears on the L1 core contract",
+                "$ref": "#/components/schemas/NUM_AS_HEX"
+              }
+            },
+            "required": ["type", "message_hash"]
+          },
+          {
+            "title": "Common receipt properties",
+            "$ref": "#/components/schemas/COMMON_RECEIPT_PROPERTIES"
+          }
+        ]
+      },
+      "TXN_RECEIPT": {
+        "title": "Transaction Receipt",
+        "oneOf": [
+          {
+            "title": "Invoke transaction receipt",
+            "$ref": "#/components/schemas/INVOKE_TXN_RECEIPT"
+          },
+          {
+            "title": "L1 handler transaction receipt",
+            "$ref": "#/components/schemas/L1_HANDLER_TXN_RECEIPT"
+          },
+          {
+            "title": "Declare transaction receipt",
+            "$ref": "#/components/schemas/DECLARE_TXN_RECEIPT"
+          },
+          {
+            "title": "Deploy transaction receipt",
+            "$ref": "#/components/schemas/DEPLOY_TXN_RECEIPT"
+          },
+          {
+            "title": "Deploy account transaction receipt",
+            "$ref": "#/components/schemas/DEPLOY_ACCOUNT_TXN_RECEIPT"
+          }
+        ]
+      },
+      "TXN_RECEIPT_WITH_BLOCK_INFO": {
+        "title": "Transaction receipt with block info",
+        "allOf": [
+          {
+            "title": "Transaction receipt",
+            "$ref": "#/components/schemas/TXN_RECEIPT"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "block_hash": {
+                "title": "Block hash",
+                "$ref": "#/components/schemas/BLOCK_HASH",
+                "description": "If this field is missing, it means the receipt belongs to the pending block"
+              },
+              "block_number": {
+                "title": "Block number",
+                "$ref": "#/components/schemas/BLOCK_NUMBER",
+                "description": "If this field is missing, it means the receipt belongs to the pending block"
+              }
+            }
+          }
+        ]
+      },
+      "MSG_TO_L1": {
+        "title": "Message to L1",
+        "type": "object",
+        "properties": {
+          "from_address": {
+            "description": "The address of the L2 contract sending the message",
+            "$ref": "#/components/schemas/FELT"
+          },
+          "to_address": {
+            "title": "To address",
+            "description": "The target L1 address the message is sent to",
+            "$ref": "#/components/schemas/FELT"
+          },
+          "payload": {
+            "description": "The payload of the message",
+            "title": "Payload",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FELT"
+            }
+          }
+        },
+        "required": ["from_address", "to_address", "payload"]
+      },
+      "MSG_FROM_L1": {
+        "title": "Message from L1",
+        "type": "object",
+        "properties": {
+          "from_address": {
+            "description": "The address of the L1 contract sending the message",
+            "$ref": "#/components/schemas/ETH_ADDRESS"
+          },
+          "to_address": {
+            "title": "To address",
+            "description": "The target L2 address the message is sent to",
+            "$ref": "#/components/schemas/ADDRESS"
+          },
+          "entry_point_selector": {
+            "title": "Selector",
+            "description": "The selector of the l1_handler in invoke in the target contract",
+            "$ref": "#/components/schemas/FELT"
+          },
+          "payload": {
+            "description": "The payload of the message",
+            "title": "Payload",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FELT"
+            }
+          }
+        },
+        "required": [
+          "from_address",
+          "to_address",
+          "payload",
+          "entry_point_selector"
+        ]
+      },
+      "TXN_STATUS_RESULT": {
+        "title": "Transaction status result",
+        "description": "Transaction status result, including finality status and execution status",
+        "type": "object",
+        "properties": {
+          "finality_status": {
+            "title": "finality status",
+            "$ref": "#/components/schemas/TXN_STATUS"
+          },
+          "execution_status": {
+            "title": "execution status",
+            "$ref": "#/components/schemas/TXN_EXECUTION_STATUS"
+          },
+          "failure_reason": {
+            "title": "failure reason",
+            "description": "the failure reason, only appears if finality_status is REJECTED or execution_status is REVERTED",
+            "type": "string"
+          }
+        },
+        "required": ["finality_status"]
+      },
+      "TXN_STATUS": {
+        "title": "Transaction status",
+        "type": "string",
+        "enum": ["RECEIVED", "REJECTED", "ACCEPTED_ON_L2", "ACCEPTED_ON_L1"],
+        "description": "The finality status of the transaction, including the case the txn is still in the mempool or failed validation during the block construction phase"
+      },
+      "TXN_FINALITY_STATUS": {
+        "title": "Finality status",
+        "type": "string",
+        "enum": ["ACCEPTED_ON_L2", "ACCEPTED_ON_L1"],
+        "description": "The finality status of the transaction"
+      },
+      "TXN_EXECUTION_STATUS": {
+        "title": "Execution status",
+        "type": "string",
+        "enum": ["SUCCEEDED", "REVERTED"],
+        "description": "The execution status of the transaction"
+      },
+      "TXN_TYPE": {
+        "title": "Transaction type",
+        "type": "string",
+        "enum": ["DECLARE", "DEPLOY", "DEPLOY_ACCOUNT", "INVOKE", "L1_HANDLER"],
+        "description": "The type of the transaction"
+      },
+      "BLOCK_STATUS": {
+        "title": "Block status",
+        "type": "string",
+        "enum": ["PENDING", "ACCEPTED_ON_L2", "ACCEPTED_ON_L1", "REJECTED"],
+        "description": "The status of the block"
+      },
+      "FUNCTION_CALL": {
+        "title": "Function call",
+        "type": "object",
+        "description": "Function call information",
+        "properties": {
+          "contract_address": {
+            "title": "Contract address",
+            "$ref": "#/components/schemas/ADDRESS"
+          },
+          "entry_point_selector": {
+            "title": "Entry point selector",
+            "$ref": "#/components/schemas/FELT"
+          },
+          "calldata": {
+            "title": "Calldata",
+            "type": "array",
+            "description": "The parameters passed to the function",
+            "items": {
+              "$ref": "#/components/schemas/FELT"
+            }
+          }
+        },
+        "required": ["contract_address", "entry_point_selector", "calldata"]
+      },
+      "CONTRACT_CLASS": {
+        "title": "Contract class",
+        "type": "object",
+        "properties": {
+          "sierra_program": {
+            "title": "Sierra program",
+            "type": "array",
+            "description": "The list of Sierra instructions of which the program consists",
+            "items": {
+              "$ref": "#/components/schemas/FELT"
+            }
+          },
+          "contract_class_version": {
+            "title": "Contract class version",
+            "type": "string",
+            "description": "The version of the contract class object. Currently, the Starknet OS supports version 0.1.0"
+          },
+          "entry_points_by_type": {
+            "title": "Entry points by type",
+            "type": "object",
+            "properties": {
+              "CONSTRUCTOR": {
+                "type": "array",
+                "title": "Constructor",
+                "items": {
+                  "$ref": "#/components/schemas/SIERRA_ENTRY_POINT"
+                }
+              },
+              "EXTERNAL": {
+                "title": "External",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/SIERRA_ENTRY_POINT"
+                }
+              },
+              "L1_HANDLER": {
+                "title": "L1 handler",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/SIERRA_ENTRY_POINT"
+                }
+              }
+            },
+            "required": ["CONSTRUCTOR", "EXTERNAL", "L1_HANDLER"]
+          },
+          "abi": {
+            "title": "ABI",
+            "type": "string",
+            "description": "The class ABI, as supplied by the user declaring the class"
+          }
+        },
+        "required": [
+          "sierra_program",
+          "contract_class_version",
+          "entry_points_by_type"
+        ]
+      },
+      "DEPRECATED_CONTRACT_CLASS": {
+        "title": "Deprecated contract class",
+        "description": "The definition of a StarkNet contract class",
+        "type": "object",
+        "properties": {
+          "program": {
+            "type": "string",
+            "title": "Program",
+            "description": "A base64 representation of the compressed program code",
+            "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)?$"
+          },
+          "entry_points_by_type": {
+            "type": "object",
+            "title": "Deprecated entry points by type",
+            "properties": {
+              "CONSTRUCTOR": {
+                "type": "array",
+                "title": "Deprecated constructor",
+                "items": {
+                  "$ref": "#/components/schemas/DEPRECATED_CAIRO_ENTRY_POINT"
+                }
+              },
+              "EXTERNAL": {
+                "type": "array",
+                "title": "Deprecated external",
+                "items": {
+                  "$ref": "#/components/schemas/DEPRECATED_CAIRO_ENTRY_POINT"
+                }
+              },
+              "L1_HANDLER": {
+                "type": "array",
+                "title": "Deprecated L1 handler",
+                "items": {
+                  "$ref": "#/components/schemas/DEPRECATED_CAIRO_ENTRY_POINT"
+                }
+              }
+            }
+          },
+          "abi": {
+            "title": "Contract ABI",
+            "$ref": "#/components/schemas/CONTRACT_ABI"
+          }
+        },
+        "required": ["program", "entry_points_by_type"]
+      },
+      "DEPRECATED_CAIRO_ENTRY_POINT": {
+        "title": "Deprecated Cairo entry point",
+        "type": "object",
+        "properties": {
+          "offset": {
+            "title": "Offset",
+            "description": "The offset of the entry point in the program",
+            "$ref": "#/components/schemas/NUM_AS_HEX"
+          },
+          "selector": {
+            "title": "Selector",
+            "description": "A unique identifier of the entry point (function) in the program",
+            "$ref": "#/components/schemas/FELT"
+          }
+        },
+        "required": ["offset", "selector"]
+      },
+      "SIERRA_ENTRY_POINT": {
+        "title": "Sierra entry point",
+        "type": "object",
+        "properties": {
+          "selector": {
+            "title": "Selector",
+            "description": "A unique identifier of the entry point (function) in the program",
+            "$ref": "#/components/schemas/FELT"
+          },
+          "function_idx": {
+            "title": "Function index",
+            "description": "The index of the function in the program",
+            "type": "integer"
+          }
+        },
+        "required": ["selector", "function_idx"]
+      },
+      "CONTRACT_ABI": {
+        "title": "Contract ABI",
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/CONTRACT_ABI_ENTRY"
+        }
+      },
+      "CONTRACT_ABI_ENTRY": {
+        "title": "Contract ABI entry",
+        "oneOf": [
+          {
+            "title": "Function ABI entry",
+            "$ref": "#/components/schemas/FUNCTION_ABI_ENTRY"
+          },
+          {
+            "title": "Event ABI entry",
+            "$ref": "#/components/schemas/EVENT_ABI_ENTRY"
+          },
+          {
+            "title": "Struct ABI entry",
+            "$ref": "#/components/schemas/STRUCT_ABI_ENTRY"
+          }
+        ]
+      },
+      "STRUCT_ABI_TYPE": {
+        "title": "Struct ABI type",
+        "type": "string",
+        "enum": ["struct"]
+      },
+      "EVENT_ABI_TYPE": {
+        "title": "Event ABI type",
+        "type": "string",
+        "enum": ["event"]
+      },
+      "FUNCTION_ABI_TYPE": {
+        "title": "Function ABI type",
+        "type": "string",
+        "enum": ["function", "l1_handler", "constructor"]
+      },
+      "STRUCT_ABI_ENTRY": {
+        "title": "Struct ABI entry",
+        "type": "object",
+        "properties": {
+          "type": {
+            "title": "Struct ABI type",
+            "$ref": "#/components/schemas/STRUCT_ABI_TYPE"
+          },
+          "name": {
+            "title": "Struct name",
+            "description": "The struct name",
+            "type": "string"
+          },
+          "size": {
+            "title": "Size",
+            "type": "integer",
+            "minimum": 1
+          },
+          "members": {
+            "type": "array",
+            "title": "Members",
+            "items": {
+              "$ref": "#/components/schemas/STRUCT_MEMBER"
+            }
+          }
+        },
+        "required": ["type", "name", "size", "members"]
+      },
+      "STRUCT_MEMBER": {
+        "title": "Struct member",
+        "allOf": [
+          {
+            "title": "Typed parameter",
+            "$ref": "#/components/schemas/TYPED_PARAMETER"
+          },
+          {
+            "type": "object",
+            "title": "Offset",
+            "properties": {
+              "offset": {
+                "title": "Offset",
+                "description": "offset of this property within the struct",
+                "type": "integer"
+              }
+            }
+          }
+        ]
+      },
+      "EVENT_ABI_ENTRY": {
+        "title": "Event ABI entry",
+        "type": "object",
+        "properties": {
+          "type": {
+            "title": "Event ABI type",
+            "$ref": "#/components/schemas/EVENT_ABI_TYPE"
+          },
+          "name": {
+            "title": "Event name",
+            "description": "The event name",
+            "type": "string"
+          },
+          "keys": {
+            "type": "array",
+            "title": "Typed parameter",
+            "items": {
+              "$ref": "#/components/schemas/TYPED_PARAMETER"
+            }
+          },
+          "data": {
+            "type": "array",
+            "title": "Typed parameter",
+            "items": {
+              "$ref": "#/components/schemas/TYPED_PARAMETER"
+            }
+          }
+        },
+        "required": ["type", "name", "keys", "data"]
+      },
+      "FUNCTION_STATE_MUTABILITY": {
+        "title": "Function state mutability type",
+        "type": "string",
+        "enum": ["view"]
+      },
+      "FUNCTION_ABI_ENTRY": {
+        "title": "Function ABI entry",
+        "type": "object",
+        "properties": {
+          "type": {
+            "title": "Function ABI type",
+            "$ref": "#/components/schemas/FUNCTION_ABI_TYPE"
+          },
+          "name": {
+            "title": "Function name",
+            "description": "The function name",
+            "type": "string"
+          },
+          "inputs": {
+            "type": "array",
+            "title": "Typed parameter",
+            "items": {
+              "$ref": "#/components/schemas/TYPED_PARAMETER"
+            }
+          },
+          "outputs": {
+            "type": "array",
+            "title": "Typed parameter",
+            "items": {
+              "$ref": "#/components/schemas/TYPED_PARAMETER"
+            }
+          },
+          "stateMutability": {
+            "title": "Function state mutability",
+            "$ref": "#/components/schemas/FUNCTION_STATE_MUTABILITY"
+          }
+        },
+        "required": ["type", "name", "inputs", "outputs"]
+      },
+      "TYPED_PARAMETER": {
+        "title": "Typed parameter",
+        "type": "object",
+        "properties": {
+          "name": {
+            "title": "Parameter name",
+            "description": "The parameter's name",
+            "type": "string"
+          },
+          "type": {
+            "title": "Parameter type",
+            "description": "The parameter's type",
+            "type": "string"
+          }
+        },
+        "required": ["name", "type"]
+      },
+      "SIMULATION_FLAG_FOR_ESTIMATE_FEE": {
+        "type": "string",
+        "enum": ["SKIP_VALIDATE"],
+        "description": "Flags that indicate how to simulate a given transaction. By default, the sequencer behavior is replicated locally"
+      },
+      "PRICE_UNIT": {
+        "title": "price unit",
+        "type": "string",
+        "enum": ["WEI", "FRI"]
+      },
+      "FEE_ESTIMATE": {
+        "title": "Fee estimation",
+        "type": "object",
+        "properties": {
+          "l1_gas_consumed": {
+            "title": "L1 gas consumed",
+            "description": "The Ethereum gas consumption of the transaction, charged for L1->L2 messages and, depending on the block's DA_MODE, state diffs",
+            "$ref": "#/components/schemas/u64"
+          },
+          "l1_gas_price": {
+            "title": "L1 gas price",
+            "description": "The gas price (in wei or fri, depending on the tx version) that was used in the cost estimation",
+            "$ref": "#/components/schemas/u128"
+          },
+          "l2_gas_consumed": {
+            "title": "L2 gas consumed",
+            "description": "The L2 gas consumption of the transaction",
+            "$ref": "#/components/schemas/u64"
+          },
+          "l2_gas_price": {
+            "title": "L2 gas price",
+            "description": "The L2 gas price (in wei or fri, depending on the tx version) that was used in the cost estimation",
+            "$ref": "#/components/schemas/u128"
+          },
+          "l1_data_gas_consumed": {
+            "title": "L1 data gas consumed",
+            "description": "The Ethereum data gas consumption of the transaction",
+            "$ref": "#/components/schemas/u64"
+          },
+          "l1_data_gas_price": {
+            "title": "L1 data gas price",
+            "description": "The data gas price (in wei or fri, depending on the tx version) that was used in the cost estimation",
+            "$ref": "#/components/schemas/u128"
+          },
+          "overall_fee": {
+            "title": "Overall fee",
+            "description": "The estimated fee for the transaction (in wei or fri, depending on the tx version), equals to l1_gas_consumed*l1_gas_price + l1_data_gas_consumed*l1_data_gas_price + l2_gas_consumed*l2_gas_price",
+            "$ref": "#/components/schemas/u128"
+          },
+          "unit": {
+            "title": "Fee unit",
+            "description": "units in which the fee is given",
+            "$ref": "#/components/schemas/PRICE_UNIT"
+          }
+        },
+        "required": [
+          "l1_gas_consumed",
+          "l1_gas_price",
+          "l2_gas_consumed",
+          "l2_gas_price",
+          "l1_data_gas_consumed",
+          "l1_data_gas_price",
+          "overall_fee",
+          "unit"
+        ]
+      },
+      "FEE_PAYMENT": {
+        "title": "Fee Payment",
+        "description": "fee payment info as it appears in receipts",
+        "type": "object",
+        "properties": {
+          "amount": {
+            "title": "Amount",
+            "description": "amount paid",
+            "$ref": "#/components/schemas/FELT"
+          },
+          "unit": {
+            "title": "Fee unit",
+            "description": "units in which the fee is given",
+            "$ref": "#/components/schemas/PRICE_UNIT"
+          }
+        },
+        "required": ["amount", "unit"]
+      },
+      "DA_MODE": {
+        "title": "DA mode",
+        "type": "string",
+        "description": "Specifies a storage domain in Starknet. Each domain has different guarantees regarding availability",
+        "enum": ["L1", "L2"]
+      },
+      "RESOURCE_BOUNDS_MAPPING": {
+        "type": "object",
+        "properties": {
+          "l1_gas": {
+            "title": "L1 Gas",
+            "description": "The max amount and max price per unit of L1 gas used in this tx",
+            "$ref": "#/components/schemas/RESOURCE_BOUNDS"
+          },
+          "l1_data_gas": {
+            "title": "L1 Data Gas",
+            "description": "The max amount and max price per unit of L1 blob gas used in this tx",
+            "$ref": "#/components/schemas/RESOURCE_BOUNDS"
+          },
+          "l2_gas": {
+            "title": "L2 Gas",
+            "description": "The max amount and max price per unit of L2 gas used in this tx",
+            "$ref": "#/components/schemas/RESOURCE_BOUNDS"
+          }
+        },
+        "required": ["l1_gas", "l1_data_gas", "l2_gas"]
+      },
+      "RESOURCE_BOUNDS": {
+        "type": "object",
+        "properties": {
+          "max_amount": {
+            "title": "max amount",
+            "description": "the max amount of the resource that can be used in the tx",
+            "$ref": "#/components/schemas/u64"
+          },
+          "max_price_per_unit": {
+            "title": "max price",
+            "description": "the max price per unit of this resource for this tx",
+            "$ref": "#/components/schemas/u128"
+          }
+        },
+        "required": ["max_amount", "max_price_per_unit"]
+      },
+      "RESOURCE_PRICE": {
+        "type": "object",
+        "properties": {
+          "price_in_fri": {
+            "title": "price in fri",
+            "description": "the price of one unit of the given resource, denominated in fri (10^-18 strk)",
+            "$ref": "#/components/schemas/FELT"
+          },
+          "price_in_wei": {
+            "title": "price in wei",
+            "description": "the price of one unit of the given resource, denominated in wei",
+            "$ref": "#/components/schemas/FELT"
+          }
+        },
+        "required": ["price_in_wei", "price_in_fri"]
+      },
+      "EXECUTION_RESOURCES": {
+        "type": "object",
+        "title": "Execution resources",
+        "description": "the resources consumed by the transaction",
+        "properties": {
+          "l1_gas": {
+            "title": "L1Gas",
+            "description": "l1 gas consumed by this transaction, used for l2-->l1 messages and state updates if blobs are not used",
+            "type": "integer"
+          },
+          "l1_data_gas": {
+            "title": "L1DataGas",
+            "description": "data gas consumed by this transaction, 0 if blobs are not used",
+            "type": "integer"
+          },
+          "l2_gas": {
+            "title": "L2Gas",
+            "description": "l2 gas consumed by this transaction, used for computation and calldata",
+            "type": "integer"
+          }
+        },
+        "required": ["l1_gas", "l1_data_gas", "l2_gas"]
+      },
+      "MERKLE_NODE": {
+        "title": "MP node",
+        "description": "a node in the Merkle-Patricia tree, can be a leaf, binary node, or an edge node",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/BINARY_NODE"
+          },
+          {
+            "$ref": "#/components/schemas/EDGE_NODE"
+          }
+        ]
+      },
+      "BINARY_NODE": {
+        "type": "object",
+        "description": "an internal node whose both children are non-zero",
+        "properties": {
+          "left": {
+            "description": "the hash of the left child",
+            "$ref": "#/components/schemas/FELT"
+          },
+          "right": {
+            "description": "the hash of the right child",
+            "$ref": "#/components/schemas/FELT"
+          }
+        },
+        "required": ["left", "right"]
+      },
+      "EDGE_NODE": {
+        "type": "object",
+        "description": "represents a path to the highest non-zero descendant node",
+        "properties": {
+          "path": {
+            "description": "an integer whose binary representation represents the path from the current node to its highest non-zero descendant (bounded by 2^251)",
+            "$ref": "#/components/schemas/NUM_AS_HEX"
+          },
+          "length": {
+            "description": "the length of the path (bounded by 251)",
+            "type": "integer"
+          },
+          "child": {
+            "description": "the hash of the unique non-zero maximal-height descendant node",
+            "$ref": "#/components/schemas/FELT"
+          }
+        },
+        "required": ["path", "length", "child"]
+      },
+      "NODE_HASH_TO_NODE_MAPPING": {
+        "description": "a node_hash -> node mapping of all the nodes in the union of the paths between the requested leaves and the root",
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "node_hash": {
+              "$ref": "#/components/schemas/FELT"
+            },
+            "node": {
+              "$ref": "#/components/schemas/MERKLE_NODE"
+            }
+          },
+          "required": ["node_hash", "node"]
+        }
+      },
+      "CONTRACT_EXECUTION_ERROR": {
+        "description": "structured error that can later be processed by wallets or sdks",
+        "title": "contract execution error",
+        "$ref": "#/components/schemas/CONTRACT_EXECUTION_ERROR_INNER"
+      },
+      "CONTRACT_EXECUTION_ERROR_INNER": {
+        "description": "structured error that can later be processed by wallets or sdks",
+        "title": "contract execution error",
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "contract_address": {
+                "$ref": "#/components/schemas/ADDRESS"
+              },
+              "class_hash": {
+                "$ref": "#/components/schemas/FELT"
+              },
+              "selector": {
+                "$ref": "#/components/schemas/FELT"
+              },
+              "error": {
+                "$ref": "#/components/schemas/CONTRACT_EXECUTION_ERROR"
+              }
+            },
+            "required": ["contract_address", "class_hash", "selector", "error"]
+          },
+          {
+            "title": "error message",
+            "description": "the error raised during execution",
+            "type": "string"
+          }
+        ]
+      }
+    },
+    "errors": {
+      "FAILED_TO_RECEIVE_TXN": {
+        "code": 1,
+        "message": "Failed to write transaction"
+      },
+      "CONTRACT_NOT_FOUND": {
+        "code": 20,
+        "message": "Contract not found"
+      },
+      "ENTRYPOINT_NOT_FOUND": {
+        "code": 21,
+        "message": "Requested entrypoint does not exist in the contract"
+      },
+      "BLOCK_NOT_FOUND": {
+        "code": 24,
+        "message": "Block not found"
+      },
+      "INVALID_TXN_INDEX": {
+        "code": 27,
+        "message": "Invalid transaction index in a block"
+      },
+      "CLASS_HASH_NOT_FOUND": {
+        "code": 28,
+        "message": "Class hash not found"
+      },
+      "TXN_HASH_NOT_FOUND": {
+        "code": 29,
+        "message": "Transaction hash not found"
+      },
+      "PAGE_SIZE_TOO_BIG": {
+        "code": 31,
+        "message": "Requested page size is too big"
+      },
+      "NO_BLOCKS": {
+        "code": 32,
+        "message": "There are no blocks"
+      },
+      "INVALID_CONTINUATION_TOKEN": {
+        "code": 33,
+        "message": "The supplied continuation token is invalid or unknown"
+      },
+      "TOO_MANY_KEYS_IN_FILTER": {
+        "code": 34,
+        "message": "Too many keys provided in a filter"
+      },
+      "CONTRACT_ERROR": {
+        "code": 40,
+        "message": "Contract error",
+        "data": {
+          "type": "object",
+          "description": "More data about the execution failure",
+          "properties": {
+            "revert_error": {
+              "title": "revert error",
+              "description": "the execution trace up to the point of failure",
+              "$ref": "#/components/schemas/CONTRACT_EXECUTION_ERROR"
+            }
+          },
+          "required": "revert_error"
+        }
+      },
+      "TRANSACTION_EXECUTION_ERROR": {
+        "code": 41,
+        "message": "Transaction execution error",
+        "data": {
+          "type": "object",
+          "description": "More data about the execution failure",
+          "properties": {
+            "transaction_index": {
+              "title": "Transaction index",
+              "description": "The index of the first transaction failing in a sequence of given transactions",
+              "type": "integer"
+            },
+            "execution_error": {
+              "title": "revert error",
+              "description": "the execution trace up to the point of failure",
+              "$ref": "#/components/schemas/CONTRACT_EXECUTION_ERROR"
+            }
+          },
+          "required": ["transaction_index", "execution_error"]
+        }
+      },
+      "STORAGE_PROOF_NOT_SUPPORTED": {
+        "code": 42,
+        "message": "the node doesn't support storage proofs for blocks that are too far in the past"
+      }
+    }
+  }
+}

--- a/packages/wallet_provider/starknet_executables.json
+++ b/packages/wallet_provider/starknet_executables.json
@@ -1,0 +1,1178 @@
+{
+  "openrpc": "1.0.0",
+  "info": {
+    "version": "0.8.1",
+    "title": "API for getting Starknet executables from nodes that store compiled artifacts",
+    "license": {}
+  },
+  "servers": [],
+  "methods": [
+    {
+      "name": "starknet_getCompiledCasm",
+      "summary": "Get the CASM code resulting from compiling a given class",
+      "params": [
+        {
+          "name": "class_hash",
+          "description": "The hash of the contract class whose CASM will be returned",
+          "required": true,
+          "schema": {
+            "title": "Field element",
+            "$ref": "#/components/schemas/FELT"
+          }
+        }
+      ],
+      "result": {
+        "name": "result",
+        "description": "The compiled contract class",
+        "schema": {
+          "title": "Starknet get compiled CASM result",
+          "$ref": "#/components/schemas/CASM_COMPILED_CONTRACT_CLASS"
+        }
+      },
+      "errors": [
+        {
+          "$ref": "#/components/errors/COMPILATION_ERROR"
+        },
+        {
+          "$ref": "./api/starknet_api_openrpc.json#/components/errors/CLASS_HASH_NOT_FOUND"
+        }
+      ]
+    }
+  ],
+  "components": {
+    "contentDescriptors": {},
+    "schemas": {
+      "CASM_COMPILED_CONTRACT_CLASS": {
+        "type": "object",
+        "properties": {
+          "entry_points_by_type": {
+            "title": "Entry points by type",
+            "type": "object",
+            "properties": {
+              "CONSTRUCTOR": {
+                "type": "array",
+                "title": "Constructor",
+                "items": {
+                  "$ref": "#/components/schemas/CASM_ENTRY_POINT"
+                }
+              },
+              "EXTERNAL": {
+                "title": "External",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/CASM_ENTRY_POINT"
+                }
+              },
+              "L1_HANDLER": {
+                "title": "L1 handler",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/CASM_ENTRY_POINT"
+                }
+              }
+            },
+            "required": ["CONSTRUCTOR", "EXTERNAL", "L1_HANDLER"]
+          },
+          "bytecode": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FELT"
+            }
+          },
+          "prime": {
+            "$ref": "#/components/schemas/NUM_AS_HEX"
+          },
+          "compiler_version": {
+            "type": "string"
+          },
+          "hints": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "description": "2-tuple of pc value and an array of hints to execute",
+              "items": {
+                "oneOf": [
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/HINT"
+                    }
+                  }
+                ]
+              },
+              "minItems": 2,
+              "maxItems": 2
+            }
+          },
+          "bytecode_segment_lengths": {
+            "type": "array",
+            "description": "a list of sizes of segments in the bytecode, each segment is hashed individually when computing the bytecode hash",
+            "items": {
+              "type": "integer"
+            }
+          }
+        },
+        "required": [
+          "prime",
+          "compiler_version",
+          "entry_points_by_type",
+          "bytecode",
+          "hints"
+        ]
+      },
+      "CASM_ENTRY_POINT": {
+        "type": "object",
+        "properties": {
+          "offset": {
+            "title": "Offset",
+            "description": "The offset of the entry point in the program",
+            "type": "integer"
+          },
+          "selector": {
+            "title": "Selector",
+            "description": "A unique identifier of the entry point (function) in the program",
+            "$ref": "#/components/schemas/FELT"
+          },
+          "builtins": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": ["offset", "selector", "builtins"]
+      },
+      "CellRef": {
+        "title": "CellRef",
+        "type": "object",
+        "properties": {
+          "register": {
+            "type": "string",
+            "enum": ["AP", "FP"]
+          },
+          "offset": {
+            "type": "integer"
+          }
+        },
+        "required": ["register", "offset"]
+      },
+      "Deref": {
+        "type": "object",
+        "properties": {
+          "Deref": {
+            "$ref": "#/components/schemas/CellRef"
+          }
+        },
+        "required": ["Deref"]
+      },
+      "DoubleDeref": {
+        "title": "DoubleDeref",
+        "type": "object",
+        "properties": {
+          "DoubleDeref": {
+            "title": "DoubleDeref",
+            "description": "A (CellRef, offset) tuple",
+            "type": "array",
+            "items": {
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/CellRef"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "minItems": 2,
+            "maxItems": 2
+          }
+        },
+        "required": ["DoubleDeref"]
+      },
+      "Immediate": {
+        "title": "Immediate",
+        "type": "object",
+        "properties": {
+          "Immediate": {
+            "$ref": "#/components/schemas/NUM_AS_HEX"
+          }
+        },
+        "required": ["Immediate"]
+      },
+      "BinOp": {
+        "title": "BinOperand",
+        "type": "object",
+        "properties": {
+          "BinOp": {
+            "type": "object",
+            "properties": {
+              "op": {
+                "type": "string",
+                "enum": ["Add", "Mul"]
+              },
+              "a": {
+                "$ref": "#/components/schemas/CellRef"
+              },
+              "b": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/Deref"
+                  },
+                  {
+                    "$ref": "#/components/schemas/Immediate"
+                  }
+                ]
+              }
+            },
+            "required": ["op", "a", "b"]
+          }
+        },
+        "required": ["BinOp"]
+      },
+      "ResOperand": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/Deref"
+          },
+          {
+            "$ref": "#/components/schemas/DoubleDeref"
+          },
+          {
+            "$ref": "#/components/schemas/Immediate"
+          },
+          {
+            "$ref": "#/components/schemas/BinOp"
+          }
+        ]
+      },
+      "HINT": {
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/DEPRECATED_HINT"
+          },
+          {
+            "$ref": "#/components/schemas/CORE_HINT"
+          },
+          {
+            "$ref": "#/components/schemas/STARKNET_HINT"
+          }
+        ]
+      },
+      "DEPRECATED_HINT": {
+        "oneOf": [
+          {
+            "type": "string",
+            "title": "AssertCurrentAccessIndicesIsEmpty",
+            "enum": ["AssertCurrentAccessIndicesIsEmpty"]
+          },
+          {
+            "type": "object",
+            "title": "AssertAllAccessesUsed",
+            "properties": {
+              "AssertAllAccessesUsed": {
+                "type": "object",
+                "properties": {
+                  "n_used_accesses": {
+                    "$ref": "#/components/schemas/CellRef"
+                  }
+                },
+                "required": ["n_used_accesses"]
+              }
+            },
+            "required": ["AssertAllAccessesUsed"]
+          },
+          {
+            "type": "string",
+            "title": "AssertAllKeysUsed",
+            "enum": ["AssertAllKeysUsed"]
+          },
+          {
+            "type": "string",
+            "title": "AssertLeAssertThirdArcExcluded",
+            "enum": ["AssertLeAssertThirdArcExcluded"]
+          },
+          {
+            "type": "object",
+            "title": "AssertLtAssertValidInput",
+            "properties": {
+              "AssertLtAssertValidInput": {
+                "type": "object",
+                "properties": {
+                  "a": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "b": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  }
+                },
+                "required": ["a", "b"]
+              }
+            },
+            "required": ["AssertLtAssertValidInput"]
+          },
+          {
+            "type": "object",
+            "title": "Felt252DictRead",
+            "properties": {
+              "Felt252DictRead": {
+                "type": "object",
+                "properties": {
+                  "dict_ptr": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "key": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "value_dst": {
+                    "$ref": "#/components/schemas/CellRef"
+                  }
+                },
+                "required": ["dict_ptr", "key", "value_dst"]
+              }
+            },
+            "required": ["Felt252DictRead"]
+          },
+          {
+            "type": "object",
+            "title": "Felt252DictWrite",
+            "properties": {
+              "Felt252DictWrite": {
+                "type": "object",
+                "properties": {
+                  "dict_ptr": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "key": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "value": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  }
+                },
+                "required": ["dict_ptr", "key", "value"]
+              }
+            },
+            "required": ["Felt252DictWrite"]
+          }
+        ]
+      },
+      "CORE_HINT": {
+        "oneOf": [
+          {
+            "type": "object",
+            "title": "AllocSegment",
+            "properties": {
+              "AllocSegment": {
+                "type": "object",
+                "properties": {
+                  "dst": {
+                    "$ref": "#/components/schemas/CellRef"
+                  }
+                },
+                "required": ["dst"]
+              }
+            },
+            "required": ["AllocSegment"]
+          },
+          {
+            "type": "object",
+            "title": "TestLessThan",
+            "properties": {
+              "TestLessThan": {
+                "type": "object",
+                "properties": {
+                  "lhs": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "rhs": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "dst": {
+                    "$ref": "#/components/schemas/CellRef"
+                  }
+                },
+                "required": ["lhs", "rhs", "dst"]
+              }
+            },
+            "required": ["TestLessThan"]
+          },
+          {
+            "type": "object",
+            "title": "TestLessThanOrEqual",
+            "properties": {
+              "TestLessThanOrEqual": {
+                "type": "object",
+                "properties": {
+                  "lhs": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "rhs": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "dst": {
+                    "$ref": "#/components/schemas/CellRef"
+                  }
+                },
+                "required": ["lhs", "rhs", "dst"]
+              }
+            },
+            "required": ["TestLessThanOrEqual"]
+          },
+          {
+            "type": "object",
+            "title": "TestLessThanOrEqualAddress",
+            "properties": {
+              "TestLessThanOrEqualAddress": {
+                "type": "object",
+                "properties": {
+                  "lhs": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "rhs": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "dst": {
+                    "$ref": "#/components/schemas/CellRef"
+                  }
+                },
+                "required": ["lhs", "rhs", "dst"]
+              }
+            },
+            "required": ["TestLessThanOrEqualAddress"]
+          },
+          {
+            "type": "object",
+            "title": "WideMul128",
+            "properties": {
+              "WideMul128": {
+                "type": "object",
+                "properties": {
+                  "lhs": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "rhs": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "high": {
+                    "$ref": "#/components/schemas/CellRef"
+                  },
+                  "low": {
+                    "$ref": "#/components/schemas/CellRef"
+                  }
+                },
+                "required": ["lhs", "rhs", "high", "low"]
+              }
+            },
+            "required": ["WideMul128"]
+          },
+          {
+            "type": "object",
+            "title": "DivMod",
+            "properties": {
+              "DivMod": {
+                "type": "object",
+                "properties": {
+                  "lhs": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "rhs": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "quotient": {
+                    "$ref": "#/components/schemas/CellRef"
+                  },
+                  "remainder": {
+                    "$ref": "#/components/schemas/CellRef"
+                  }
+                },
+                "required": ["lhs", "rhs", "quotient", "remainder"]
+              }
+            },
+            "required": ["DivMod"]
+          },
+          {
+            "type": "object",
+            "title": "Uint256DivMod",
+            "properties": {
+              "Uint256DivMod": {
+                "type": "object",
+                "properties": {
+                  "dividend0": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "dividend1": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "divisor0": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "divisor1": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "quotient0": {
+                    "$ref": "#/components/schemas/CellRef"
+                  },
+                  "quotient1": {
+                    "$ref": "#/components/schemas/CellRef"
+                  },
+                  "remainder0": {
+                    "$ref": "#/components/schemas/CellRef"
+                  },
+                  "remainder1": {
+                    "$ref": "#/components/schemas/CellRef"
+                  }
+                },
+                "required": [
+                  "dividend0",
+                  "dividend1",
+                  "divisor0",
+                  "divisor1",
+                  "quotient0",
+                  "quotient1",
+                  "remainder0",
+                  "remainder1"
+                ]
+              }
+            },
+            "required": ["Uint256DivMod"]
+          },
+          {
+            "type": "object",
+            "title": "Uint512DivModByUint256",
+            "properties": {
+              "Uint512DivModByUint256": {
+                "type": "object",
+                "properties": {
+                  "dividend0": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "dividend1": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "dividend2": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "dividend3": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "divisor0": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "divisor1": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "quotient0": {
+                    "$ref": "#/components/schemas/CellRef"
+                  },
+                  "quotient1": {
+                    "$ref": "#/components/schemas/CellRef"
+                  },
+                  "quotient2": {
+                    "$ref": "#/components/schemas/CellRef"
+                  },
+                  "quotient3": {
+                    "$ref": "#/components/schemas/CellRef"
+                  },
+                  "remainder0": {
+                    "$ref": "#/components/schemas/CellRef"
+                  },
+                  "remainder1": {
+                    "$ref": "#/components/schemas/CellRef"
+                  }
+                },
+                "required": [
+                  "dividend0",
+                  "dividend1",
+                  "dividend2",
+                  "dividend3",
+                  "divisor0",
+                  "divisor1",
+                  "quotient0",
+                  "quotient1",
+                  "quotient2",
+                  "quotient3",
+                  "remainder0",
+                  "remainder1"
+                ]
+              }
+            },
+            "required": ["Uint512DivModByUint256"]
+          },
+          {
+            "type": "object",
+            "title": "SquareRoot",
+            "properties": {
+              "SquareRoot": {
+                "type": "object",
+                "properties": {
+                  "value": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "dst": {
+                    "$ref": "#/components/schemas/CellRef"
+                  }
+                },
+                "required": ["value", "dst"]
+              }
+            },
+            "required": ["SquareRoot"]
+          },
+          {
+            "type": "object",
+            "title": "Uint256SquareRoot",
+            "properties": {
+              "Uint256SquareRoot": {
+                "type": "object",
+                "properties": {
+                  "value_low": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "value_high": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "sqrt0": {
+                    "$ref": "#/components/schemas/CellRef"
+                  },
+                  "sqrt1": {
+                    "$ref": "#/components/schemas/CellRef"
+                  },
+                  "remainder_low": {
+                    "$ref": "#/components/schemas/CellRef"
+                  },
+                  "remainder_high": {
+                    "$ref": "#/components/schemas/CellRef"
+                  },
+                  "sqrt_mul_2_minus_remainder_ge_u128": {
+                    "$ref": "#/components/schemas/CellRef"
+                  }
+                },
+                "required": [
+                  "value_low",
+                  "value_high",
+                  "sqrt0",
+                  "sqrt1",
+                  "remainder_low",
+                  "remainder_high",
+                  "sqrt_mul_2_minus_remainder_ge_u128"
+                ]
+              }
+            },
+            "required": ["Uint256SquareRoot"]
+          },
+          {
+            "type": "object",
+            "title": "LinearSplit",
+            "properties": {
+              "LinearSplit": {
+                "type": "object",
+                "properties": {
+                  "value": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "scalar": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "max_x": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "x": {
+                    "$ref": "#/components/schemas/CellRef"
+                  },
+                  "y": {
+                    "$ref": "#/components/schemas/CellRef"
+                  }
+                },
+                "required": ["value", "scalar", "max_x", "x", "y"]
+              }
+            },
+            "required": ["LinearSplit"]
+          },
+          {
+            "type": "object",
+            "title": "AllocFelt252Dict",
+            "properties": {
+              "AllocFelt252Dict": {
+                "type": "object",
+                "properties": {
+                  "segment_arena_ptr": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  }
+                },
+                "required": ["segment_arena_ptr"]
+              }
+            },
+            "required": ["AllocFelt252Dict"]
+          },
+          {
+            "type": "object",
+            "title": "Felt252DictEntryInit",
+            "properties": {
+              "Felt252DictEntryInit": {
+                "type": "object",
+                "properties": {
+                  "dict_ptr": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "key": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  }
+                },
+                "required": ["dict_ptr", "key"]
+              }
+            },
+            "required": ["Felt252DictEntryInit"]
+          },
+          {
+            "type": "object",
+            "title": "Felt252DictEntryUpdate",
+            "properties": {
+              "Felt252DictEntryUpdate": {
+                "type": "object",
+                "properties": {
+                  "dict_ptr": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "value": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  }
+                },
+                "required": ["dict_ptr", "value"]
+              }
+            },
+            "required": ["Felt252DictEntryUpdate"]
+          },
+          {
+            "type": "object",
+            "title": "GetSegmentArenaIndex",
+            "properties": {
+              "GetSegmentArenaIndex": {
+                "type": "object",
+                "properties": {
+                  "dict_end_ptr": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "dict_index": {
+                    "$ref": "#/components/schemas/CellRef"
+                  }
+                },
+                "required": ["dict_end_ptr", "dict_index"]
+              }
+            },
+            "required": ["GetSegmentArenaIndex"]
+          },
+          {
+            "type": "object",
+            "title": "InitSquashData",
+            "properties": {
+              "InitSquashData": {
+                "type": "object",
+                "properties": {
+                  "dict_accesses": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "ptr_diff": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "n_accesses": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "big_keys": {
+                    "$ref": "#/components/schemas/CellRef"
+                  },
+                  "first_key": {
+                    "$ref": "#/components/schemas/CellRef"
+                  }
+                },
+                "required": [
+                  "dict_accesses",
+                  "ptr_diff",
+                  "n_accesses",
+                  "big_keys",
+                  "first_key"
+                ]
+              }
+            },
+            "required": ["InitSquashData"]
+          },
+          {
+            "type": "object",
+            "title": "GetCurrentAccessIndex",
+            "properties": {
+              "GetCurrentAccessIndex": {
+                "type": "object",
+                "properties": {
+                  "range_check_ptr": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  }
+                },
+                "required": ["range_check_ptr"]
+              }
+            },
+            "required": ["GetCurrentAccessIndex"]
+          },
+          {
+            "type": "object",
+            "title": "ShouldSkipSquashLoop",
+            "properties": {
+              "ShouldSkipSquashLoop": {
+                "type": "object",
+                "properties": {
+                  "should_skip_loop": {
+                    "$ref": "#/components/schemas/CellRef"
+                  }
+                },
+                "required": ["should_skip_loop"]
+              }
+            },
+            "required": ["ShouldSkipSquashLoop"]
+          },
+          {
+            "type": "object",
+            "title": "GetCurrentAccessDelta",
+            "properties": {
+              "GetCurrentAccessDelta": {
+                "type": "object",
+                "properties": {
+                  "index_delta_minus1": {
+                    "$ref": "#/components/schemas/CellRef"
+                  }
+                },
+                "required": ["index_delta_minus1"]
+              }
+            },
+            "required": ["GetCurrentAccessDelta"]
+          },
+          {
+            "type": "object",
+            "title": "ShouldContinueSquashLoop",
+            "properties": {
+              "ShouldContinueSquashLoop": {
+                "type": "object",
+                "properties": {
+                  "should_continue": {
+                    "$ref": "#/components/schemas/CellRef"
+                  }
+                },
+                "required": ["should_continue"]
+              }
+            },
+            "required": ["ShouldContinueSquashLoop"]
+          },
+          {
+            "type": "object",
+            "title": "GetNextDictKey",
+            "properties": {
+              "GetNextDictKey": {
+                "type": "object",
+                "properties": {
+                  "next_key": {
+                    "$ref": "#/components/schemas/CellRef"
+                  }
+                },
+                "required": ["next_key"]
+              }
+            },
+            "required": ["GetNextDictKey"]
+          },
+          {
+            "type": "object",
+            "title": "AssertLeFindSmallArcs",
+            "properties": {
+              "AssertLeFindSmallArcs": {
+                "type": "object",
+                "properties": {
+                  "range_check_ptr": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "a": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "b": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  }
+                },
+                "required": ["range_check_ptr", "a", "b"]
+              }
+            },
+            "required": ["AssertLeFindSmallArcs"]
+          },
+          {
+            "type": "object",
+            "title": "AssertLeIsFirstArcExcluded",
+            "properties": {
+              "AssertLeIsFirstArcExcluded": {
+                "type": "object",
+                "properties": {
+                  "skip_exclude_a_flag": {
+                    "$ref": "#/components/schemas/CellRef"
+                  }
+                },
+                "required": ["skip_exclude_a_flag"]
+              }
+            },
+            "required": ["AssertLeIsFirstArcExcluded"]
+          },
+          {
+            "type": "object",
+            "title": "AssertLeIsSecondArcExcluded",
+            "properties": {
+              "AssertLeIsSecondArcExcluded": {
+                "type": "object",
+                "properties": {
+                  "skip_exclude_b_minus_a": {
+                    "$ref": "#/components/schemas/CellRef"
+                  }
+                },
+                "required": ["skip_exclude_b_minus_a"]
+              }
+            },
+            "required": ["AssertLeIsSecondArcExcluded"]
+          },
+          {
+            "type": "object",
+            "title": "RandomEcPoint",
+            "properties": {
+              "RandomEcPoint": {
+                "type": "object",
+                "properties": {
+                  "x": {
+                    "$ref": "#/components/schemas/CellRef"
+                  },
+                  "y": {
+                    "$ref": "#/components/schemas/CellRef"
+                  }
+                },
+                "required": ["x", "y"]
+              }
+            },
+            "required": ["RandomEcPoint"]
+          },
+          {
+            "type": "object",
+            "title": "FieldSqrt",
+            "properties": {
+              "FieldSqrt": {
+                "type": "object",
+                "properties": {
+                  "val": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "sqrt": {
+                    "$ref": "#/components/schemas/CellRef"
+                  }
+                },
+                "required": ["val", "sqrt"]
+              }
+            },
+            "required": ["FieldSqrt"]
+          },
+          {
+            "type": "object",
+            "title": "DebugPrint",
+            "properties": {
+              "DebugPrint": {
+                "type": "object",
+                "properties": {
+                  "start": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "end": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  }
+                },
+                "required": ["start", "end"]
+              }
+            },
+            "required": ["DebugPrint"]
+          },
+          {
+            "type": "object",
+            "title": "AllocConstantSize",
+            "properties": {
+              "AllocConstantSize": {
+                "type": "object",
+                "properties": {
+                  "size": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "dst": {
+                    "$ref": "#/components/schemas/CellRef"
+                  }
+                },
+                "required": ["size", "dst"]
+              }
+            },
+            "required": ["AllocConstantSize"]
+          },
+          {
+            "type": "object",
+            "title": "U256InvModN",
+            "properties": {
+              "U256InvModN": {
+                "type": "object",
+                "properties": {
+                  "b0": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "b1": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "n0": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "n1": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "g0_or_no_inv": {
+                    "$ref": "#/components/schemas/CellRef"
+                  },
+                  "g1_option": {
+                    "$ref": "#/components/schemas/CellRef"
+                  },
+                  "s_or_r0": {
+                    "$ref": "#/components/schemas/CellRef"
+                  },
+                  "s_or_r1": {
+                    "$ref": "#/components/schemas/CellRef"
+                  },
+                  "t_or_k0": {
+                    "$ref": "#/components/schemas/CellRef"
+                  },
+                  "t_or_k1": {
+                    "$ref": "#/components/schemas/CellRef"
+                  }
+                },
+                "required": [
+                  "b0",
+                  "b1",
+                  "n0",
+                  "n1",
+                  "g0_or_no_inv",
+                  "g1_option",
+                  "s_or_r0",
+                  "s_or_r1",
+                  "t_or_k0",
+                  "t_or_k1"
+                ]
+              }
+            },
+            "required": ["U256InvModN"]
+          },
+          {
+            "type": "object",
+            "title": "EvalCircuit",
+            "properties": {
+              "EvalCircuit": {
+                "type": "object",
+                "properties": {
+                  "n_add_mods": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "add_mod_builtin": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "n_mul_mods": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "mul_mod_builtin": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  }
+                },
+                "required": [
+                  "n_add_mods",
+                  "add_mod_builtin",
+                  "n_mul_mods",
+                  "mul_mod_builtin"
+                ]
+              }
+            },
+            "required": ["EvalCircuit"]
+          }
+        ]
+      },
+      "STARKNET_HINT": {
+        "oneOf": [
+          {
+            "type": "object",
+            "title": "SystemCall",
+            "properties": {
+              "SystemCall": {
+                "type": "object",
+                "properties": {
+                  "system": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  }
+                },
+                "required": ["system"]
+              }
+            },
+            "required": ["SystemCall"]
+          },
+          {
+            "type": "object",
+            "title": "Cheatcode",
+            "properties": {
+              "Cheatcode": {
+                "type": "object",
+                "properties": {
+                  "selector": {
+                    "$ref": "#/components/schemas/NUM_AS_HEX"
+                  },
+                  "input_start": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "input_end": {
+                    "$ref": "#/components/schemas/ResOperand"
+                  },
+                  "output_start": {
+                    "$ref": "#/components/schemas/CellRef"
+                  },
+                  "output_end": {
+                    "$ref": "#/components/schemas/CellRef"
+                  }
+                },
+                "required": [
+                  "selector",
+                  "input_start",
+                  "input_end",
+                  "output_start",
+                  "output_end"
+                ]
+              }
+            },
+            "required": ["Cheatcode"]
+          }
+        ]
+      },
+      "FELT": {
+        "$ref": "./api/starknet_api_openrpc.json#/components/schemas/FELT"
+      },
+      "NUM_AS_HEX": {
+        "$ref": "./api/starknet_api_openrpc.json#/components/schemas/NUM_AS_HEX"
+      },
+      "DEPRECATED_CAIRO_ENTRY_POINT": {
+        "$ref": "./api/starknet_api_openrpc.json#/components/schemas/DEPRECATED_CAIRO_ENTRY_POINT"
+      }
+    },
+    "errors": {
+      "COMPILATION_ERROR": {
+        "code": 100,
+        "message": "Failed to compile the contract",
+        "data": {
+          "type": "object",
+          "description": "More data about the compilation failure",
+          "properties": {
+            "compilation_error": {
+              "title": "compilation error",
+              "type": "string"
+            }
+          },
+          "required": "compilation_error"
+        }
+      }
+    }
+  }
+}

--- a/packages/wallet_provider/starknet_metadata.json
+++ b/packages/wallet_provider/starknet_metadata.json
@@ -1,0 +1,429 @@
+{
+  "openrpc": "1.0.0",
+  "info": {
+    "version": "0.8.1",
+    "title": "Starknet ABI specs"
+  },
+  "methods": [],
+  "components": {
+    "contentDescriptors": {
+      "ABI": {
+        "name": "abi",
+        "required": true,
+        "description": "A Cairo v>=2 contract ABI",
+        "schema": {
+          "$ref": "#/components/schemas/ABI"
+        }
+      }
+    },
+    "schemas": {
+      "ABI": {
+        "type": "array",
+        "items": {
+          "oneOf": [
+            {
+              "title": "function",
+              "$ref": "#/components/schemas/FUNCTION"
+            },
+            {
+              "title": "constructor",
+              "$ref": "#/components/schemas/CONSTRUCTOR"
+            },
+            {
+              "title": "l1_handler",
+              "$ref": "#/components/schemas/L1_HANDLER"
+            },
+            {
+              "title": "event",
+              "$ref": "#/components/schemas/EVENT"
+            },
+            {
+              "title": "struct",
+              "$ref": "#/components/schemas/STRUCT"
+            },
+            {
+              "title": "enum",
+              "$ref": "#/components/schemas/ENUM"
+            },
+            {
+              "title": "interface",
+              "$ref": "#/components/schemas/INTERFACE"
+            },
+            {
+              "title": "impl",
+              "$ref": "#/components/schemas/IMPL"
+            }
+          ]
+        }
+      },
+      "FUNCTION": {
+        "type": "object",
+        "title": "function",
+        "properties": {
+          "type": {
+            "title": "abi_entry_type",
+            "type": "string",
+            "enum": ["function"]
+          },
+          "name": {
+            "title": "name",
+            "description": "the function's name",
+            "type": "string"
+          },
+          "inputs": {
+            "type": "array",
+            "description": "the function's inputs",
+            "title": "inputs",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "title": "name",
+                  "description": "the argument name",
+                  "type": "string"
+                },
+                "type": {
+                  "title": "type",
+                  "description": "the argument type",
+                  "type": "string"
+                }
+              },
+              "required": ["name", "type"]
+            }
+          },
+          "outputs": {
+            "type": "array",
+            "title": "outputs",
+            "description": "the function's outputs",
+            "items": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "title": "type",
+                  "description": "the output type",
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "state_mutability": {
+            "title": "state mutability",
+            "type": "string",
+            "enum": ["view", "external"]
+          }
+        },
+        "required": ["type", "name", "inputs", "outputs", "state_mutability"]
+      },
+      "CONSTRUCTOR": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "title": "abi_entry_type",
+            "type": "string",
+            "enum": ["constructor"]
+          },
+          "name": {
+            "title": "name",
+            "type": "string",
+            "description": "the constructor name, currently forced to be `constructor`",
+            "enum": ["constructor"]
+          },
+          "inputs": {
+            "type": "array",
+            "title": "inputs",
+            "description": "the constructor's inputs",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "title": "name",
+                  "description": "the argument name",
+                  "type": "string"
+                },
+                "type": {
+                  "title": "type",
+                  "description": "the argument type",
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "required": ["type", "name", "inputs"]
+      },
+      "L1_HANDLER": {
+        "type": "object",
+        "title": "function",
+        "properties": {
+          "type": {
+            "title": "abi_entry_type",
+            "type": "string",
+            "enum": ["l1_handler"]
+          },
+          "name": {
+            "title": "name",
+            "description": "the l1_handler name",
+            "type": "string"
+          },
+          "inputs": {
+            "type": "array",
+            "description": "the l1_handler inputs",
+            "title": "inputs",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "title": "name",
+                  "description": "the argument name",
+                  "type": "string"
+                },
+                "type": {
+                  "title": "type",
+                  "description": "the argument type",
+                  "type": "string"
+                }
+              },
+              "required": ["name", "type"]
+            }
+          },
+          "outputs": {
+            "type": "array",
+            "title": "outputs",
+            "items": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "title": "type",
+                  "description": "the output type",
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "state_mutability": {
+            "title": "state mutability",
+            "type": "string",
+            "enum": ["view", "external"]
+          }
+        },
+        "required": ["type", "name", "inputs", "outputs", "state_mutability"]
+      },
+      "EVENT": {
+        "title": "event",
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "type": {
+                "title": "abi_entry_type",
+                "type": "string",
+                "enum": ["event"]
+              },
+              "name": {
+                "title": "name",
+                "description": "the name of the (Cairo) type associated with the event",
+                "type": "string"
+              }
+            },
+            "required": ["type", "name"]
+          },
+          {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/ENUM_EVENT"
+              },
+              {
+                "$ref": "#/components/schemas/STRUCT_EVENT"
+              }
+            ]
+          }
+        ]
+      },
+      "STRUCT_EVENT": {
+        "type": "object",
+        "properties": {
+          "kind": {
+            "title": "kind",
+            "description": "determines the serialization of the corresponding type",
+            "type": "string",
+            "enum": ["struct"]
+          },
+          "members": {
+            "type": "array",
+            "description": "struct members",
+            "title": "members",
+            "items": {
+              "$ref": "#/components/schemas/EVENT_FIELD"
+            }
+          }
+        },
+        "required": ["kind", "members"]
+      },
+      "ENUM_EVENT": {
+        "type": "object",
+        "properties": {
+          "kind": {
+            "title": "kind",
+            "description": "determines the serialization of the corresponding type",
+            "type": "string",
+            "enum": ["enum"]
+          },
+          "variants": {
+            "type": "array",
+            "title": "variants",
+            "description": "enum variants",
+            "items": {
+              "$ref": "#/components/schemas/EVENT_FIELD"
+            }
+          }
+        },
+        "required": ["kind", "variants"]
+      },
+      "STRUCT": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "title": "abi_entry_type",
+            "type": "string",
+            "enum": ["struct"]
+          },
+          "name": {
+            "title": "name",
+            "description": "the (Cairo) struct name, including namespacing",
+            "type": "string"
+          },
+          "members": {
+            "type": "array",
+            "title": "members",
+            "description": "the struct members",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "title": "name",
+                  "description": "name of the struct member",
+                  "type": "string"
+                },
+                "type": {
+                  "title": "type",
+                  "description": "the member type, including namespacing",
+                  "type": "string"
+                }
+              },
+              "required": ["name", "type"]
+            }
+          }
+        },
+        "required": ["type", "name", "members"]
+      },
+      "ENUM": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "title": "abi_entry_type",
+            "type": "string",
+            "enum": ["enum"]
+          },
+          "name": {
+            "title": "name",
+            "description": "the (Cairo) enum name, including namespacing",
+            "type": "string"
+          },
+          "variants": {
+            "type": "array",
+            "title": "variants",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "title": "name",
+                  "description": "name of the enum variant",
+                  "type": "string"
+                },
+                "type": {
+                  "title": "type",
+                  "description": " the variant type, including namespacing",
+                  "type": "string"
+                }
+              },
+              "required": ["name", "type"]
+            }
+          }
+        },
+        "required": ["type", "name", "variants"]
+      },
+      "INTERFACE": {
+        "type": "object",
+        "title": "interface",
+        "properties": {
+          "type": {
+            "title": "abi_entry_type",
+            "type": "string",
+            "enum": ["interface"]
+          },
+          "name": {
+            "title": "name",
+            "description": "the name of the trait which defines the contract interface",
+            "type": "string"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FUNCTION"
+            }
+          }
+        },
+        "required": ["type", "name", "items"]
+      },
+      "IMPL": {
+        "type": "object",
+        "title": "impl",
+        "properties": {
+          "type": {
+            "title": "abi_entry_type",
+            "type": "string",
+            "enum": ["impl"]
+          },
+          "name": {
+            "title": "name",
+            "description": "the name of an impl containing contract entry points",
+            "type": "string"
+          },
+          "interface_name": {
+            "description": "the name of the trait corresponding to this impl",
+            "title": "interface name",
+            "type": "string"
+          }
+        },
+        "required": ["type", "name", "interface_name"]
+      },
+      "EVENT_KIND": {
+        "type": "string",
+        "enum": ["struct", "enum"]
+      },
+      "EVENT_FIELD": {
+        "title": "member",
+        "type": "object",
+        "properties": {
+          "name": {
+            "title": "name",
+            "description": "the name of the struct member or enum variant",
+            "type": "string"
+          },
+          "type": {
+            "description": "the Cairo type of the member or variant, including namespacing",
+            "title": "type",
+            "type": "string"
+          },
+          "kind": {
+            "title": "kind",
+            "description": "specifies how the field should be serialized, via the starknet::Event trait or the serde::Serde trait",
+            "type": "string",
+            "enum": ["key", "data", "nested", "flat"]
+          }
+        },
+        "required": ["name", "type", "kind"]
+      }
+    }
+  }
+}

--- a/packages/wallet_provider/starknet_trace_api_openrpc.json
+++ b/packages/wallet_provider/starknet_trace_api_openrpc.json
@@ -1,0 +1,496 @@
+{
+  "openrpc": "1.0.0-rc1",
+  "info": {
+    "version": "0.8.1",
+    "title": "StarkNet Trace API",
+    "license": {}
+  },
+  "servers": [],
+  "methods": [
+    {
+      "name": "starknet_traceTransaction",
+      "summary": "For a given executed transaction, return the trace of its execution, including internal calls",
+      "description": "Returns the execution trace of the transaction designated by the input hash",
+      "params": [
+        {
+          "name": "transaction_hash",
+          "summary": "The hash of the transaction to trace",
+          "required": true,
+          "schema": {
+            "$ref": "./api/starknet_api_openrpc.json#/components/schemas/TXN_HASH"
+          }
+        }
+      ],
+      "result": {
+        "name": "trace",
+        "description": "The function call trace of the transaction designated by the given hash",
+        "schema": {
+          "$ref": "#/components/schemas/TRANSACTION_TRACE"
+        }
+      },
+      "errors": [
+        {
+          "$ref": "./api/starknet_api_openrpc.json#/components/errors/TXN_HASH_NOT_FOUND"
+        },
+        {
+          "$ref": "#/components/errors/NO_TRACE_AVAILABLE"
+        }
+      ]
+    },
+    {
+      "name": "starknet_simulateTransactions",
+      "summary": "Simulate a given sequence of transactions on the requested state, and generate the execution traces. Note that some of the transactions may revert, in which case no error is thrown, but revert details can be seen on the returned trace object. Note that some of the transactions may revert, this will be reflected by the revert_error property in the trace. Other types of failures (e.g. unexpected error or failure in the validation phase) will result in TRANSACTION_EXECUTION_ERROR.",
+      "params": [
+        {
+          "name": "block_id",
+          "description": "The hash of the requested block, or number (height) of the requested block, or a block tag, for the block referencing the state or call the transaction on.",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/BLOCK_ID"
+          }
+        },
+        {
+          "name": "transactions",
+          "description": "The transactions to simulate",
+          "required": true,
+          "schema": {
+            "type": "array",
+            "description": "a sequence of transactions to simulate, running each transaction on the state resulting from applying all the previous ones",
+            "items": {
+              "$ref": "#/components/schemas/BROADCASTED_TXN"
+            }
+          }
+        },
+        {
+          "name": "simulation_flags",
+          "description": "describes what parts of the transaction should be executed",
+          "required": true,
+          "schema": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SIMULATION_FLAG"
+            }
+          }
+        }
+      ],
+      "result": {
+        "name": "simulated_transactions",
+        "description": "The execution trace and consumed resources of the required transactions",
+        "schema": {
+          "type": "array",
+          "items": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "transaction_trace": {
+                  "title": "the transaction's trace",
+                  "$ref": "#/components/schemas/TRANSACTION_TRACE"
+                },
+                "fee_estimation": {
+                  "title": "the transaction's resources and fee",
+                  "$ref": "#/components/schemas/FEE_ESTIMATE"
+                }
+              }
+            }
+          }
+        }
+      },
+      "errors": [
+        {
+          "$ref": "./api/starknet_api_openrpc.json#/components/errors/BLOCK_NOT_FOUND"
+        },
+        {
+          "$ref": "./api/starknet_api_openrpc.json#/components/errors/TRANSACTION_EXECUTION_ERROR"
+        }
+      ]
+    },
+    {
+      "name": "starknet_traceBlockTransactions",
+      "summary": "Retrieve traces for all transactions in the given block",
+      "description": "Returns the execution traces of all transactions included in the given block",
+      "params": [
+        {
+          "name": "block_id",
+          "description": "The hash of the requested block, or number (height) of the requested block, or a block tag",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/BLOCK_ID"
+          }
+        }
+      ],
+      "result": {
+        "name": "traces",
+        "description": "The traces of all transactions in the block",
+        "schema": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "description": "A single pair of transaction hash and corresponding trace",
+            "properties": {
+              "transaction_hash": {
+                "$ref": "#/components/schemas/FELT"
+              },
+              "trace_root": {
+                "$ref": "#/components/schemas/TRANSACTION_TRACE"
+              }
+            }
+          }
+        }
+      },
+      "errors": [
+        {
+          "$ref": "./api/starknet_api_openrpc.json#/components/errors/BLOCK_NOT_FOUND"
+        }
+      ]
+    }
+  ],
+  "components": {
+    "contentDescriptors": {},
+    "schemas": {
+      "TRANSACTION_TRACE": {
+        "oneOf": [
+          {
+            "name": "INVOKE_TXN_TRACE",
+            "type": "object",
+            "description": "the execution trace of an invoke transaction",
+            "properties": {
+              "validate_invocation": {
+                "$ref": "#/components/schemas/FUNCTION_INVOCATION"
+              },
+              "execute_invocation": {
+                "description": "the trace of the __execute__ call or constructor call, depending on the transaction type (none for declare transactions)",
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/FUNCTION_INVOCATION"
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "revert_reason": {
+                        "name": "revert reason",
+                        "description": "the revert reason for the failed execution",
+                        "type": "string"
+                      }
+                    },
+                    "required": ["revert_reason"]
+                  }
+                ]
+              },
+              "fee_transfer_invocation": {
+                "$ref": "#/components/schemas/FUNCTION_INVOCATION"
+              },
+              "state_diff": {
+                "title": "state_diff",
+                "description": "the state diffs induced by the transaction",
+                "$ref": "#/components/schemas/STATE_DIFF"
+              },
+              "execution_resources": {
+                "title": "Execution resources",
+                "description": "the resources consumed by the transaction, includes both computation and data",
+                "$ref": "#/components/schemas/EXECUTION_RESOURCES"
+              },
+              "type": {
+                "title": "Type",
+                "type": "string",
+                "enum": ["INVOKE"]
+              }
+            },
+            "required": ["type", "execute_invocation", "execution_resources"]
+          },
+          {
+            "name": "DECLARE_TXN_TRACE",
+            "type": "object",
+            "description": "the execution trace of a declare transaction",
+            "properties": {
+              "validate_invocation": {
+                "$ref": "#/components/schemas/FUNCTION_INVOCATION"
+              },
+              "fee_transfer_invocation": {
+                "$ref": "#/components/schemas/FUNCTION_INVOCATION"
+              },
+              "state_diff": {
+                "title": "state_diff",
+                "description": "the state diffs induced by the transaction",
+                "$ref": "#/components/schemas/STATE_DIFF"
+              },
+              "execution_resources": {
+                "title": "Execution resources",
+                "description": "the resources consumed by the transaction, includes both computation and data",
+                "$ref": "#/components/schemas/EXECUTION_RESOURCES"
+              },
+              "type": {
+                "title": "Type",
+                "type": "string",
+                "enum": ["DECLARE"]
+              }
+            },
+            "required": ["type", "execution_resources"]
+          },
+          {
+            "name": "DEPLOY_ACCOUNT_TXN_TRACE",
+            "type": "object",
+            "description": "the execution trace of a deploy account transaction",
+            "properties": {
+              "validate_invocation": {
+                "$ref": "#/components/schemas/FUNCTION_INVOCATION"
+              },
+              "constructor_invocation": {
+                "description": "the trace of the __execute__ call or constructor call, depending on the transaction type (none for declare transactions)",
+                "$ref": "#/components/schemas/FUNCTION_INVOCATION"
+              },
+              "fee_transfer_invocation": {
+                "$ref": "#/components/schemas/FUNCTION_INVOCATION"
+              },
+              "state_diff": {
+                "title": "state_diff",
+                "description": "the state diffs induced by the transaction",
+                "$ref": "#/components/schemas/STATE_DIFF"
+              },
+              "execution_resources": {
+                "title": "Execution resources",
+                "description": "the resources consumed by the transaction, includes both computation and data",
+                "$ref": "#/components/schemas/EXECUTION_RESOURCES"
+              },
+              "type": {
+                "title": "Type",
+                "type": "string",
+                "enum": ["DEPLOY_ACCOUNT"]
+              }
+            },
+            "required": [
+              "type",
+              "execution_resources",
+              "constructor_invocation"
+            ]
+          },
+          {
+            "name": "L1_HANDLER_TXN_TRACE",
+            "type": "object",
+            "description": "the execution trace of an L1 handler transaction",
+            "properties": {
+              "function_invocation": {
+                "description": "the trace of the __execute__ call or constructor call, depending on the transaction type (none for declare transactions)",
+                "$ref": "#/components/schemas/FUNCTION_INVOCATION"
+              },
+              "state_diff": {
+                "title": "state_diff",
+                "description": "the state diffs induced by the transaction",
+                "$ref": "#/components/schemas/STATE_DIFF"
+              },
+              "execution_resources": {
+                "title": "Execution resources",
+                "description": "the resources consumed by the transaction, includes both computation and data",
+                "$ref": "#/components/schemas/EXECUTION_RESOURCES"
+              },
+              "type": {
+                "title": "Type",
+                "type": "string",
+                "enum": ["L1_HANDLER"]
+              }
+            },
+            "required": ["type", "function_invocation", "execution_resources"]
+          }
+        ]
+      },
+      "SIMULATION_FLAG": {
+        "type": "string",
+        "enum": ["SKIP_VALIDATE", "SKIP_FEE_CHARGE"],
+        "description": "Flags that indicate how to simulate a given transaction. By default, the sequencer behavior is replicated locally (enough funds are expected to be in the account, and fee will be deducted from the balance before the simulation of the next transaction). To skip the fee charge, use the SKIP_FEE_CHARGE flag."
+      },
+      "NESTED_CALL": {
+        "$ref": "#/components/schemas/FUNCTION_INVOCATION"
+      },
+      "FUNCTION_INVOCATION": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/FUNCTION_CALL"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "caller_address": {
+                "title": "Caller Address",
+                "description": "The address of the invoking contract. 0 for the root invocation",
+                "$ref": "#/components/schemas/FELT"
+              },
+              "class_hash": {
+                "title": "Class hash",
+                "description": "The hash of the class being called",
+                "$ref": "#/components/schemas/FELT"
+              },
+              "entry_point_type": {
+                "$ref": "#/components/schemas/ENTRY_POINT_TYPE"
+              },
+              "call_type": {
+                "$ref": "#/components/schemas/CALL_TYPE"
+              },
+              "result": {
+                "title": "Invocation Result",
+                "description": "The value returned from the function invocation",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/FELT"
+                }
+              },
+              "calls": {
+                "title": "Nested Calls",
+                "description": "The calls made by this invocation",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/NESTED_CALL"
+                }
+              },
+              "events": {
+                "title": "Invocation Events",
+                "description": "The events emitted in this invocation",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/ORDERED_EVENT"
+                }
+              },
+              "messages": {
+                "title": "L1 Messages",
+                "description": "The messages sent by this invocation to L1",
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/ORDERED_MESSAGE"
+                }
+              },
+              "execution_resources": {
+                "title": "Execution resources",
+                "description": "Resources consumed by the call tree rooted at this given call (including the root)",
+                "$ref": "#/components/schemas/INNER_CALL_EXECUTION_RESOURCES"
+              },
+              "is_reverted": {
+                "title": "Is Reverted",
+                "description": "true if this inner call panicked",
+                "type": "boolean"
+              }
+            },
+            "required": [
+              "caller_address",
+              "class_hash",
+              "entry_point_type",
+              "call_type",
+              "result",
+              "calls",
+              "events",
+              "messages",
+              "execution_resources",
+              "is_reverted"
+            ]
+          }
+        ]
+      },
+      "ENTRY_POINT_TYPE": {
+        "type": "string",
+        "enum": ["EXTERNAL", "L1_HANDLER", "CONSTRUCTOR"]
+      },
+      "CALL_TYPE": {
+        "type": "string",
+        "enum": ["LIBRARY_CALL", "CALL", "DELEGATE"]
+      },
+      "ORDERED_EVENT": {
+        "type": "object",
+        "title": "orderedEvent",
+        "description": "an event alongside its order within the transaction",
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "order": {
+                "title": "order",
+                "description": "the order of the event within the transaction",
+                "type": "integer"
+              }
+            }
+          },
+          {
+            "$ref": "#/components/schemas/EVENT"
+          }
+        ]
+      },
+      "ORDERED_MESSAGE": {
+        "type": "object",
+        "title": "orderedMessage",
+        "description": "a message alongside its order within the transaction",
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "order": {
+                "title": "order",
+                "description": "the order of the message within the transaction",
+                "type": "integer"
+              }
+            }
+          },
+          {
+            "$ref": "#/components/schemas/MSG_TO_L1"
+          }
+        ]
+      },
+      "INNER_CALL_EXECUTION_RESOURCES": {
+        "type": "object",
+        "title": "Execution resources",
+        "description": "the resources consumed by an inner call (does not account for state diffs since data is squashed across the transaction)",
+        "properties": {
+          "l1_gas": {
+            "title": "L1Gas",
+            "description": "l1 gas consumed by this transaction, used for l2-->l1 messages and state updates if blobs are not used",
+            "type": "integer"
+          },
+          "l2_gas": {
+            "title": "L2Gas",
+            "description": "l2 gas consumed by this transaction, used for computation and calldata",
+            "type": "integer"
+          }
+        },
+        "required": ["l1_gas", "l2_gas"]
+      },
+      "FELT": {
+        "$ref": "./api/starknet_api_openrpc.json#/components/schemas/FELT"
+      },
+      "FUNCTION_CALL": {
+        "$ref": "./api/starknet_api_openrpc.json#/components/schemas/FUNCTION_CALL"
+      },
+      "EVENT": {
+        "$ref": "./api/starknet_api_openrpc.json#/components/schemas/EVENT_CONTENT"
+      },
+      "MSG_TO_L1": {
+        "$ref": "./api/starknet_api_openrpc.json#/components/schemas/MSG_TO_L1"
+      },
+      "BLOCK_ID": {
+        "$ref": "./api/starknet_api_openrpc.json#/components/schemas/BLOCK_ID"
+      },
+      "FEE_ESTIMATE": {
+        "$ref": "./api/starknet_api_openrpc.json#/components/schemas/FEE_ESTIMATE"
+      },
+      "BROADCASTED_TXN": {
+        "$ref": "./api/starknet_api_openrpc.json#/components/schemas/BROADCASTED_TXN"
+      },
+      "STATE_DIFF": {
+        "$ref": "./api/starknet_api_openrpc.json#/components/schemas/STATE_DIFF"
+      },
+      "EXECUTION_RESOURCES": {
+        "$ref": "./api/starknet_api_openrpc.json#/components/schemas/EXECUTION_RESOURCES"
+      }
+    },
+    "errors": {
+      "NO_TRACE_AVAILABLE": {
+        "code": 10,
+        "message": "No trace available for transaction",
+        "data": {
+          "type": "object",
+          "description": "Extra information on why trace is not available. Either it wasn't executed yet (RECEIVED), or the transaction failed (REJECTED)",
+          "properties": {
+            "status": {
+              "type": "string",
+              "enum": ["RECEIVED", "REJECTED"]
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/wallet_provider/starknet_write_api.json
+++ b/packages/wallet_provider/starknet_write_api.json
@@ -1,0 +1,286 @@
+{
+  "openrpc": "1.0.0-rc1",
+  "info": {
+    "version": "0.8.1",
+    "title": "StarkNet Node Write API",
+    "license": {}
+  },
+  "servers": [],
+  "methods": [
+    {
+      "name": "starknet_addInvokeTransaction",
+      "summary": "Submit a new transaction to be added to the chain",
+      "params": [
+        {
+          "name": "invoke_transaction",
+          "description": "The information needed to invoke the function (or account, for version 1 transactions)",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/BROADCASTED_INVOKE_TXN"
+          }
+        }
+      ],
+      "result": {
+        "name": "result",
+        "description": "The result of the transaction submission",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "transaction_hash": {
+              "title": "The hash of the invoke transaction",
+              "$ref": "#/components/schemas/TXN_HASH"
+            }
+          },
+          "required": ["transaction_hash"]
+        }
+      },
+      "errors": [
+        {
+          "$ref": "#/components/errors/INSUFFICIENT_ACCOUNT_BALANCE"
+        },
+        {
+          "$ref": "#/components/errors/INSUFFICIENT_RESOURCES_FOR_VALIDATE"
+        },
+        {
+          "$ref": "#/components/errors/INVALID_TRANSACTION_NONCE"
+        },
+        {
+          "$ref": "#/components/errors/VALIDATION_FAILURE"
+        },
+        {
+          "$ref": "#/components/errors/NON_ACCOUNT"
+        },
+        {
+          "$ref": "#/components/errors/DUPLICATE_TX"
+        },
+        {
+          "$ref": "#/components/errors/UNSUPPORTED_TX_VERSION"
+        },
+        {
+          "$ref": "#/components/errors/UNEXPECTED_ERROR"
+        }
+      ]
+    },
+    {
+      "name": "starknet_addDeclareTransaction",
+      "summary": "Submit a new class declaration transaction",
+      "params": [
+        {
+          "name": "declare_transaction",
+          "description": "Declare transaction required to declare a new class on Starknet",
+          "required": true,
+          "schema": {
+            "title": "Declare transaction",
+            "$ref": "#/components/schemas/BROADCASTED_DECLARE_TXN"
+          }
+        }
+      ],
+      "result": {
+        "name": "result",
+        "description": "The result of the transaction submission",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "transaction_hash": {
+              "title": "The hash of the declare transaction",
+              "$ref": "#/components/schemas/TXN_HASH"
+            },
+            "class_hash": {
+              "title": "The hash of the declared class",
+              "$ref": "#/components/schemas/FELT"
+            }
+          },
+          "required": ["transaction_hash", "class_hash"]
+        }
+      },
+      "errors": [
+        {
+          "$ref": "#/components/errors/CLASS_ALREADY_DECLARED"
+        },
+        {
+          "$ref": "#/components/errors/COMPILATION_FAILED"
+        },
+        {
+          "$ref": "#/components/errors/COMPILED_CLASS_HASH_MISMATCH"
+        },
+        {
+          "$ref": "#/components/errors/INSUFFICIENT_ACCOUNT_BALANCE"
+        },
+        {
+          "$ref": "#/components/errors/INSUFFICIENT_RESOURCES_FOR_VALIDATE"
+        },
+        {
+          "$ref": "#/components/errors/INVALID_TRANSACTION_NONCE"
+        },
+        {
+          "$ref": "#/components/errors/VALIDATION_FAILURE"
+        },
+        {
+          "$ref": "#/components/errors/NON_ACCOUNT"
+        },
+        {
+          "$ref": "#/components/errors/DUPLICATE_TX"
+        },
+        {
+          "$ref": "#/components/errors/CONTRACT_CLASS_SIZE_IS_TOO_LARGE"
+        },
+        {
+          "$ref": "#/components/errors/UNSUPPORTED_TX_VERSION"
+        },
+        {
+          "$ref": "#/components/errors/UNSUPPORTED_CONTRACT_CLASS_VERSION"
+        },
+        {
+          "$ref": "#/components/errors/UNEXPECTED_ERROR"
+        }
+      ]
+    },
+    {
+      "name": "starknet_addDeployAccountTransaction",
+      "summary": "Submit a new deploy account transaction",
+      "params": [
+        {
+          "name": "deploy_account_transaction",
+          "description": "The deploy account transaction",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/BROADCASTED_DEPLOY_ACCOUNT_TXN"
+          }
+        }
+      ],
+      "result": {
+        "name": "result",
+        "description": "The result of the transaction submission",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "transaction_hash": {
+              "title": "The hash of the deploy transaction",
+              "$ref": "#/components/schemas/TXN_HASH"
+            },
+            "contract_address": {
+              "title": "The address of the new contract",
+              "$ref": "#/components/schemas/FELT"
+            }
+          },
+          "required": ["transaction_hash", "contract_address"]
+        }
+      },
+      "errors": [
+        {
+          "$ref": "#/components/errors/INSUFFICIENT_ACCOUNT_BALANCE"
+        },
+        {
+          "$ref": "#/components/errors/INSUFFICIENT_RESOURCES_FOR_VALIDATE"
+        },
+        {
+          "$ref": "#/components/errors/INVALID_TRANSACTION_NONCE"
+        },
+        {
+          "$ref": "#/components/errors/VALIDATION_FAILURE"
+        },
+        {
+          "$ref": "#/components/errors/NON_ACCOUNT"
+        },
+        {
+          "$ref": "./api/starknet_api_openrpc.json#/components/errors/CLASS_HASH_NOT_FOUND"
+        },
+        {
+          "$ref": "#/components/errors/DUPLICATE_TX"
+        },
+        {
+          "$ref": "#/components/errors/UNSUPPORTED_TX_VERSION"
+        },
+        {
+          "$ref": "#/components/errors/UNEXPECTED_ERROR"
+        }
+      ]
+    }
+  ],
+  "components": {
+    "contentDescriptors": {},
+    "schemas": {
+      "NUM_AS_HEX": {
+        "$ref": "./api/starknet_api_openrpc.json#/components/schemas/NUM_AS_HEX"
+      },
+      "SIGNATURE": {
+        "$ref": "./api/starknet_api_openrpc.json#/components/schemas/SIGNATURE"
+      },
+      "FELT": {
+        "$ref": "./api/starknet_api_openrpc.json#/components/schemas/FELT"
+      },
+      "TXN_HASH": {
+        "$ref": "./api/starknet_api_openrpc.json#/components/schemas/TXN_HASH"
+      },
+      "BROADCASTED_INVOKE_TXN": {
+        "$ref": "./api/starknet_api_openrpc.json#/components/schemas/BROADCASTED_INVOKE_TXN"
+      },
+      "BROADCASTED_DECLARE_TXN": {
+        "$ref": "./api/starknet_api_openrpc.json#/components/schemas/BROADCASTED_DECLARE_TXN"
+      },
+      "BROADCASTED_DEPLOY_ACCOUNT_TXN": {
+        "$ref": "./api/starknet_api_openrpc.json#/components/schemas/BROADCASTED_DEPLOY_ACCOUNT_TXN"
+      },
+      "FUNCTION_CALL": {
+        "$ref": "./api/starknet_api_openrpc.json#/components/schemas/FUNCTION_CALL"
+      }
+    },
+    "errors": {
+      "CLASS_ALREADY_DECLARED": {
+        "code": 51,
+        "message": "Class already declared"
+      },
+      "INVALID_TRANSACTION_NONCE": {
+        "code": 52,
+        "message": "Invalid transaction nonce"
+      },
+      "INSUFFICIENT_RESOURCES_FOR_VALIDATE": {
+        "code": 53,
+        "message": "The transaction's resources don't cover validation or the minimal transaction fee"
+      },
+      "INSUFFICIENT_ACCOUNT_BALANCE": {
+        "code": 54,
+        "message": "Account balance is smaller than the transaction's maximal fee (calculated as the sum of each resource's limit x max price)"
+      },
+      "VALIDATION_FAILURE": {
+        "code": 55,
+        "message": "Account validation failed",
+        "data": "string"
+      },
+      "COMPILATION_FAILED": {
+        "code": 56,
+        "message": "Compilation failed",
+        "data": "string"
+      },
+      "CONTRACT_CLASS_SIZE_IS_TOO_LARGE": {
+        "code": 57,
+        "message": "Contract class size it too large"
+      },
+      "NON_ACCOUNT": {
+        "code": 58,
+        "message": "Sender address in not an account contract"
+      },
+      "DUPLICATE_TX": {
+        "code": 59,
+        "message": "A transaction with the same hash already exists in the mempool"
+      },
+      "COMPILED_CLASS_HASH_MISMATCH": {
+        "code": 60,
+        "message": "the compiled class hash did not match the one supplied in the transaction"
+      },
+      "UNSUPPORTED_TX_VERSION": {
+        "code": 61,
+        "message": "the transaction version is not supported"
+      },
+      "UNSUPPORTED_CONTRACT_CLASS_VERSION": {
+        "code": 62,
+        "message": "the contract class version is not supported"
+      },
+      "UNEXPECTED_ERROR": {
+        "code": 63,
+        "message": "An unexpected error occurred",
+        "data": "string"
+      }
+    }
+  }
+}

--- a/packages/wallet_provider/starknet_ws_api.json
+++ b/packages/wallet_provider/starknet_ws_api.json
@@ -1,0 +1,395 @@
+{
+  "openrpc": "1.3.2",
+  "info": {
+    "version": "0.8.1",
+    "title": "StarkNet WebSocket RPC API",
+    "license": {}
+  },
+  "methods": [
+    {
+      "name": "starknet_subscribeNewHeads",
+      "summary": "New block headers subscription",
+      "description": "Creates a WebSocket stream which will fire events for new block headers",
+      "params": [
+        {
+          "name": "block_id",
+          "summary": "The block to get notifications from, default is latest, limited to 1024 blocks back",
+          "required": false,
+          "schema": {
+            "$ref": "#/components/schemas/SUBSCRIPTION_BLOCK_ID"
+          }
+        }
+      ],
+      "result": {
+        "name": "subscription_id",
+        "schema": {
+          "$ref": "#/components/schemas/SUBSCRIPTION_ID"
+        }
+      },
+      "errors": [
+        {
+          "$ref": "#/components/errors/TOO_MANY_BLOCKS_BACK"
+        },
+        {
+          "$ref": "./api/starknet_api_openrpc.json#/components/errors/BLOCK_NOT_FOUND"
+        }
+      ]
+    },
+    {
+      "name": "starknet_subscriptionNewHeads",
+      "summary": "New block headers notification",
+      "description": "Notification to the client of a new block header",
+      "params": [
+        {
+          "name": "subscription_id",
+          "schema": {
+            "$ref": "#/components/schemas/SUBSCRIPTION_ID"
+          }
+        },
+        {
+          "name": "result",
+          "schema": {
+            "$ref": "./api/starknet_api_openrpc.json#/components/schemas/BLOCK_HEADER"
+          }
+        }
+      ],
+      "errors": []
+    },
+    {
+      "name": "starknet_subscribeEvents",
+      "summary": "Events subscription",
+      "description": "Creates a WebSocket stream which will fire events for new Starknet events with applied filters",
+      "params": [
+        {
+          "name": "from_address",
+          "summary": "Filter events by from_address which emitted the event",
+          "required": false,
+          "schema": {
+            "$ref": "#/components/schemas/ADDRESS"
+          }
+        },
+        {
+          "name": "keys",
+          "summary": "The keys to filter events by",
+          "required": false,
+          "schema": {
+            "title": "event keys",
+            "$ref": "./api/starknet_api_openrpc.json#/components/schemas/EVENT_KEYS"
+          }
+        },
+        {
+          "name": "block_id",
+          "summary": "The block to get notifications from, default is latest, limited to 1024 blocks back",
+          "required": false,
+          "schema": {
+            "$ref": "#/components/schemas/SUBSCRIPTION_BLOCK_ID"
+          }
+        }
+      ],
+      "result": {
+        "name": "subscription_id",
+        "schema": {
+          "$ref": "#/components/schemas/SUBSCRIPTION_ID"
+        }
+      },
+      "errors": [
+        {
+          "$ref": "./api/starknet_api_openrpc.json#/components/errors/TOO_MANY_KEYS_IN_FILTER"
+        },
+        {
+          "$ref": "#/components/errors/TOO_MANY_BLOCKS_BACK"
+        },
+        {
+          "$ref": "./api/starknet_api_openrpc.json#/components/errors/BLOCK_NOT_FOUND"
+        }
+      ]
+    },
+    {
+      "name": "starknet_subscriptionEvents",
+      "summary": "New events notification",
+      "description": "Notification to the client of a new event",
+      "params": [
+        {
+          "name": "subscription_id",
+          "schema": {
+            "$ref": "#/components/schemas/SUBSCRIPTION_ID"
+          }
+        },
+        {
+          "name": "result",
+          "schema": {
+            "$ref": "./api/starknet_api_openrpc.json#/components/schemas/EMITTED_EVENT"
+          }
+        }
+      ],
+      "errors": []
+    },
+    {
+      "name": "starknet_subscribeTransactionStatus",
+      "summary": "Transaction Status subscription",
+      "description": "Creates a WebSocket stream which at first fires an event with the current known transaction status, followed by events for every transaction status update",
+      "params": [
+        {
+          "name": "transaction_hash",
+          "summary": "The transaction hash to fetch status updates for",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/FELT"
+          }
+        }
+      ],
+      "result": {
+        "name": "subscription_id",
+        "schema": {
+          "$ref": "#/components/schemas/SUBSCRIPTION_ID"
+        }
+      },
+      "errors": []
+    },
+    {
+      "name": "starknet_subscriptionTransactionStatus",
+      "summary": "New transaction status notification",
+      "description": "Notification to the client of a new transaction status",
+      "params": [
+        {
+          "name": "subscription_id",
+          "schema": {
+            "$ref": "#/components/schemas/SUBSCRIPTION_ID"
+          }
+        },
+        {
+          "name": "result",
+          "schema": {
+            "$ref": "#/components/schemas/NEW_TXN_STATUS"
+          }
+        }
+      ],
+      "errors": []
+    },
+    {
+      "name": "starknet_subscribePendingTransactions",
+      "summary": "New Pending Transactions subscription",
+      "description": "Creates a WebSocket stream which will fire events when a new pending transaction is added. While there is no mempool, this notifies of transactions in the pending block",
+      "params": [
+        {
+          "name": "transaction_details",
+          "summary": "Get all transaction details, and not only the hash. If not provided, only hash is returned. Default is false",
+          "required": false,
+          "schema": {
+            "type": "boolean"
+          }
+        },
+        {
+          "name": "sender_address",
+          "summary": "Filter transactions to only receive notification from address list",
+          "required": false,
+          "schema": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ADDRESS"
+            }
+          }
+        }
+      ],
+      "result": {
+        "name": "subscription_id",
+        "schema": {
+          "$ref": "#/components/schemas/SUBSCRIPTION_ID"
+        }
+      },
+      "errors": [
+        {
+          "$ref": "#/components/errors/TOO_MANY_ADDRESSES_IN_FILTER"
+        }
+      ]
+    },
+    {
+      "name": "starknet_subscriptionPendingTransactions",
+      "summary": "New pending transaction notification",
+      "description": "Notification to the client of a new pending transaction",
+      "params": [
+        {
+          "name": "subscription_id",
+          "schema": {
+            "$ref": "#/components/schemas/SUBSCRIPTION_ID"
+          }
+        },
+        {
+          "name": "result",
+          "description": "Either a tranasaction hash or full transaction details, based on subscription",
+          "schema": {
+            "oneOf": [
+              {
+                "$ref": "./api/starknet_api_openrpc.json#/components/schemas/TXN_HASH"
+              },
+              {
+                "$ref": "./api/starknet_api_openrpc.json#/components/schemas/TXN_WITH_HASH"
+              }
+            ]
+          }
+        }
+      ],
+      "errors": []
+    },
+    {
+      "name": "starknet_subscriptionReorg",
+      "description": "Notifies the subscriber of a reorganization of the chain",
+      "summary": "Can be received from subscribing to newHeads, Events, TransactionStatus",
+      "params": [
+        {
+          "name": "subscription_id",
+          "schema": {
+            "$ref": "#/components/schemas/SUBSCRIPTION_ID"
+          }
+        },
+        {
+          "name": "result",
+          "schema": {
+            "$ref": "#/components/schemas/REORG_DATA"
+          }
+        }
+      ]
+    },
+    {
+      "name": "starknet_unsubscribe",
+      "summary": "Closes a websocket subscription",
+      "description": "Close a previously opened ws stream, with the corresponding subscription id",
+      "params": [
+        {
+          "name": "subscription_id",
+          "summary": "The subscription to close",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/SUBSCRIPTION_ID"
+          }
+        }
+      ],
+      "result": {
+        "name": "Unsubscription result",
+        "description": "True if the unsubscription was successful",
+        "schema": {
+          "type": "boolean"
+        }
+      },
+      "errors": [
+        {
+          "$ref": "#/components/errors/INVALID_SUBSCRIPTION_ID"
+        }
+      ]
+    }
+  ],
+
+  "components": {
+    "schemas": {
+      "FELT": {
+        "$ref": "./api/starknet_api_openrpc.json#/components/schemas/FELT"
+      },
+      "ADDRESS": {
+        "$ref": "./api/starknet_api_openrpc.json#/components/schemas/ADDRESS"
+      },
+      "NEW_TXN_STATUS": {
+        "title": "New transaction Status",
+        "type": "object",
+        "properties": {
+          "transaction_hash": {
+            "$ref": "./api/starknet_api_openrpc.json#/components/schemas/TXN_HASH"
+          },
+          "status": {
+            "$ref": "./api/starknet_api_openrpc.json#/components/schemas/TXN_STATUS_RESULT"
+          }
+        }
+      },
+      "SUBSCRIPTION_ID": {
+        "name": "subscription id",
+        "description": "An identifier for this subscription stream used to associate events with this subscription.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "SUBSCRIPTION_BLOCK_ID": {
+        "title": "Subscription Block id",
+        "description": "Block hash, number or tag, same as BLOCK_ID, but without 'pending'",
+        "oneOf": [
+          {
+            "title": "Block hash",
+            "type": "object",
+            "properties": {
+              "block_hash": {
+                "title": "Block hash",
+                "$ref": "./api/starknet_api_openrpc.json#/components/schemas/BLOCK_HASH"
+              }
+            },
+            "required": ["block_hash"]
+          },
+          {
+            "title": "Block number",
+            "type": "object",
+            "properties": {
+              "block_number": {
+                "title": "Block number",
+                "$ref": "./api/starknet_api_openrpc.json#/components/schemas/BLOCK_NUMBER"
+              }
+            },
+            "required": ["block_number"]
+          },
+          {
+            "title": "Block tag",
+            "$ref": "#/components/schemas/SUBSCRIPTION_BLOCK_TAG"
+          }
+        ]
+      },
+      "SUBSCRIPTION_BLOCK_TAG": {
+        "title": "Subscription Block tag",
+        "type": "string",
+        "description": "Same as BLOCK_TAG, but without 'pending'",
+        "enum": ["latest"]
+      },
+      "REORG_DATA": {
+        "name": "Reorg Data",
+        "description": "Data about reorganized blocks, starting and ending block number and hash",
+        "properties": {
+          "starting_block_hash": {
+            "title": "Starting Block Hash",
+            "description": "Hash of the first known block of the orphaned chain",
+            "$ref": "./api/starknet_api_openrpc.json#/components/schemas/BLOCK_HASH"
+          },
+          "starting_block_number": {
+            "title": "Starting Block Number",
+            "description": "Number of the first known block of the orphaned chain",
+            "$ref": "./api/starknet_api_openrpc.json#/components/schemas/BLOCK_NUMBER"
+          },
+          "ending_block_hash": {
+            "title": "Ending Block",
+            "description": "The last known block of the orphaned chain",
+            "$ref": "./api/starknet_api_openrpc.json#/components/schemas/BLOCK_HASH"
+          },
+          "ending_block_number": {
+            "title": "Ending Block Number",
+            "description": "Number of the last known block of the orphaned chain",
+            "$ref": "./api/starknet_api_openrpc.json#/components/schemas/BLOCK_NUMBER"
+          }
+        },
+        "required": [
+          "starting_block_hash",
+          "starting_block_number",
+          "ending_block_hash",
+          "ending_block_number"
+        ]
+      }
+    },
+    "errors": {
+      "INVALID_SUBSCRIPTION_ID": {
+        "code": 66,
+        "message": "Invalid subscription id"
+      },
+      "TOO_MANY_ADDRESSES_IN_FILTER": {
+        "code": 67,
+        "message": "Too many addresses in filter sender_address filter"
+      },
+      "TOO_MANY_BLOCKS_BACK": {
+        "code": 68,
+        "message": "Cannot go back more than 1024 blocks"
+      }
+    }
+  }
+}

--- a/packages/wallet_provider/test/melos_test.dart
+++ b/packages/wallet_provider/test/melos_test.dart
@@ -1,0 +1,6 @@
+import 'package:test/test.dart';
+
+void main() {
+  test('Prevent melos from failing when no test tagged unit', () {},
+      tags: ['unit', 'integration']);
+}

--- a/packages/wallet_provider/test/provider_test.dart
+++ b/packages/wallet_provider/test/provider_test.dart
@@ -1,0 +1,128 @@
+import 'dart:io';
+import 'package:starknet/starknet.dart';
+import 'package:wallet_provider/wallet_provider.dart';
+import 'package:test/test.dart';
+
+// Define a test URI - replace with a relevant endpoint if needed
+// Using Sepolia for example, but most wallet methods won't work without a wallet connection
+final testUri = Uri.parse(Platform.environment['STARKNET_RPC'] ??
+    'https://free-rpc.nethermind.io/sepolia-juno');
+
+void main() {
+  late WalletProvider provider;
+
+  setUp(() {
+    provider = WalletProvider(testUri);
+  });
+
+  group('WalletProvider Info Calls', () {
+    test('.supportedWalletApi() fails gracefully on standard node', () async {
+      try {
+        await provider.supportedWalletApi();
+        fail('Should have thrown an error'); // Expecting failure
+      } catch (e) {
+        // Expecting a WalletError with code -32601 (Method Not Found)
+        expect(e, isA<WalletError>());
+        if (e is WalletError) {
+          expect(e.code, equals(-32601));
+        }
+        print(
+            "supportedWalletApi failed as expected against non-wallet endpoint: $e");
+      }
+    });
+
+    test('.supportedSpecs() fails gracefully on standard node', () async {
+      try {
+        await provider.supportedSpecs();
+        fail('Should have thrown an error'); // Expecting failure
+      } catch (e) {
+        // Expecting a WalletError with code -32601 (Method Not Found)
+        expect(e, isA<WalletError>());
+        if (e is WalletError) {
+          expect(e.code, equals(-32601));
+        }
+        print(
+            "supportedSpecs failed as expected against non-wallet endpoint: $e");
+      }
+    });
+
+    // Let's try requestChainId - it might be implemented by some nodes/proxies
+    test('.requestChainId() returns chainId or fails gracefully', () async {
+      try {
+        final chainId = await provider.requestChainId();
+        expect(chainId, isA<Felt>());
+        // You could add a check for the specific chain ID if you know the endpoint
+        // final expectedChainId = Felt.fromHexString('YOUR_EXPECTED_CHAIN_ID_HEX');
+        // expect(chainId, equals(expectedChainId));
+        print(
+            "requestChainId succeeded with chainId: ${chainId.toHexString()}");
+      } catch (e) {
+        // Expecting a WalletError with code -32601 (Method Not Found) if node doesn't support it
+        expect(e, isA<WalletError>());
+        if (e is WalletError) {
+          expect(e.code, equals(-32601));
+        }
+        print("requestChainId failed as expected for this endpoint: $e");
+      }
+    });
+  });
+
+  group('WalletProvider State Calls (requires wallet connection/approval)', () {
+    test('.getPermissions() returns empty list or fails gracefully', () async {
+      try {
+        final permissions = await provider.getPermissions();
+        expect(permissions, isA<List<Permission>>());
+        // Expect empty list if not connected/approved
+        expect(permissions, isEmpty);
+        print("getPermissions returned empty list as expected.");
+      } catch (e) {
+        // Or it might throw an error if the endpoint requires connection upfront
+        // Now expecting WalletError likely (-32601 if method not found)
+        expect(e, isA<WalletError>());
+        print("getPermissions failed as expected: $e");
+      }
+    }, skip: "Behavior depends heavily on wallet connection state");
+
+    test(
+        '.requestAccounts(silentMode: true) returns empty list or fails gracefully',
+        () async {
+      try {
+        final accounts = await provider.requestAccounts(silentMode: true);
+        expect(accounts, isA<List<Felt>>());
+        // Expect empty list if not connected/approved or in silent mode
+        expect(accounts, isEmpty);
+        print("requestAccounts (silent) returned empty list as expected.");
+      } catch (e) {
+        // Or it might throw an error (-32601 if method not found)
+        expect(e, isA<WalletError>());
+        print("requestAccounts (silent) failed as expected: $e");
+      }
+    }, skip: "Behavior depends heavily on wallet connection state");
+
+    test('.deploymentData() returns error without deployed account/wallet',
+        () async {
+      try {
+        await provider.deploymentData();
+        fail("Should have thrown an error");
+      } catch (e) {
+        // Expecting a specific error from the wallet/node
+        expect(e, isA<WalletError>());
+        if (e is WalletError) {
+          print(
+              "deploymentData failed with WalletError code: ${e.code} msg: ${e.message}");
+          // Ideally, check for the specific code, e.g.:
+          // expect(e.code, equals(WalletErrorCode.deploymentDataNotAvailable.???)); // Need code mapping in enum
+        } else {
+          // This case should not happen if expect(e, isA<WalletError>()) passed
+          print("deploymentData failed with non-WalletError: $e");
+        }
+      }
+    },
+        skip:
+            "Requires specific wallet state (connected, account selected, etc.)");
+  });
+
+  tearDown(() {
+    provider.close(); // Ensure the client is closed after tests
+  });
+}

--- a/packages/wallet_provider/wallet_rpc.json
+++ b/packages/wallet_provider/wallet_rpc.json
@@ -1,0 +1,897 @@
+{
+    "openrpc": "1.0.0-rc1",
+    "info": {
+      "version": "0.8.0",
+      "title": "Starknet Wallet API",
+      "license": {}
+    },
+    "servers": [],
+    "methods": [
+      {
+        "name": "wallet_supportedWalletApi",
+        "summary": "Returns a list of wallet api versions compatible with the wallet. Notice this might be different from Starknet JSON-RPC spec",
+        "description": "When wallet is locked, return values. When Dapp is not approved, return values. When wallet is connected and unlocked, return values.",
+        "params": [],
+        "result": {
+          "name": "result",
+          "description": "Semver of the wallet api versions supported by the wallet",
+          "required": true,
+          "schema": {
+            "type": "array",
+            "properties": {
+              "items": {
+                "$ref": "#/components/schemas/API_VERSION"
+              }
+            }
+          }
+        }
+      },
+      {
+        "name": "wallet_supportedSpecs",
+        "summary": "Returns a list of rpc spec versions compatible with the wallet",
+        "description": "When wallet is locked, return values. When Dapp is not approved, return values. When wallet is connected and unlocked, return values.",
+        "params": [],
+        "result": {
+          "name": "result",
+          "description": "Semver of Starknet's JSON-RPC supported by the wallet",
+          "required": true,
+          "schema": {
+            "type": "array",
+            "properties": {
+              "items": {
+                "$ref": "#/components/schemas/SPEC_VERSION"
+              }
+            }
+          }
+        }
+      },
+      {
+        "name": "wallet_getPermissions",
+        "summary": "Get the existing permissions for the Dapp from the wallet",
+        "description": "When wallet is locked, return empty array. When Dapp is not approved, return empty array. When wallet is connected and unlocked, return values.",
+        "params": [
+          {
+            "name": "api_version",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/API_VERSION"
+            }
+          }
+        ],
+        "result": {
+          "name": "result",
+          "schema": {
+            "title": "Wallet permissions",
+            "oneOf": [
+              {
+                "type": "array",
+                "properties": {
+                  "items": {
+                    "$ref": "#/components/schemas/PERMISSION"
+                  }
+                }
+              },
+              {
+                "type": "array",
+                "title": "Empty array"
+              }
+            ],
+            "required": []
+          }
+        },
+        "errors": [
+          {
+            "$ref": "#/components/errors/API_VERSION_NOT_SUPPORTED"
+          },
+          {
+            "$ref": "#/components/errors/UNKNOWN_ERROR"
+          }
+        ]
+      },
+      {
+        "name": "wallet_requestAccounts",
+        "summary": "Get the account addresses of the wallet active account",
+        "description": "When wallet is locked, open wallet-unlock UI. When Dapp is not approved, display Dapp-approve UI. When wallet is connected and unlocked, return values.",
+        "params": [
+          {
+            "name": "silent_mode",
+            "summary": "If true, the wallet will not show the wallet-unlock UI in case of a locked wallet, nor the Dapp-approve UI in case of a non-allowed Dapp, and will return an empty array",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "api_version",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/API_VERSION"
+            }
+          }
+        ],
+        "result": {
+          "name": "result",
+          "description": "The active account of the wallet",
+          "schema": {
+            "title": "Wallet Accounts",
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ADDRESS"
+            },
+            "required": []
+          }
+        },
+        "errors": [
+          {
+            "$ref": "#/components/errors/API_VERSION_NOT_SUPPORTED"
+          },
+          {
+            "$ref": "#/components/errors/UNKNOWN_ERROR"
+          }
+        ]
+      },
+      {
+        "name": "wallet_requestChainId",
+        "summary": "Request the current Chain Id",
+        "description": "When wallet is locked, return values. When Dapp is not approved, return values. When wallet is connected and unlocked, return values.",
+        "params": [
+          {
+            "name": "api_version",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/API_VERSION"
+            }
+          }
+        ],
+        "result": {
+          "name": "result",
+          "description": "The active chainId",
+          "schema": {
+            "$ref": "#/components/schemas/CHAIN_ID"
+          }
+        },
+        "errors": [
+          {
+            "$ref": "#/components/errors/API_VERSION_NOT_SUPPORTED"
+          },
+          {
+            "$ref": "#/components/errors/UNKNOWN_ERROR"
+          }
+        ]
+      },
+      {
+        "name": "wallet_deploymentData",
+        "summary": "Request from the current wallet the data required to deploy the account at the current address",
+        "description": "When wallet is locked, return error DEPLOYMENT_DATA_NOT_AVAILABLE. When Dapp is not approved, return error DEPLOYMENT_DATA_NOT_AVAILABLE. When wallet is connected and unlocked, return values.",
+        "params": [
+          {
+            "name": "api_version",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/API_VERSION"
+            }
+          }
+        ],
+        "result": {
+          "name": "result",
+          "schema": {
+            "$ref": "#/components/schemas/ACCOUNT_DEPLOYMENT_DATA"
+          }
+        },
+        "errors": [
+          {
+            "$ref": "#/components/errors/ACCOUNT_ALREADY_DEPLOYED"
+          },
+          {
+            "$ref": "#/components/errors/DEPLOYMENT_DATA_NOT_AVAILABLE"
+          },
+          {
+            "$ref": "#/components/errors/API_VERSION_NOT_SUPPORTED"
+          },
+          {
+            "$ref": "#/components/errors/UNKNOWN_ERROR"
+          }
+        ]
+      },
+      {
+        "name": "wallet_switchStarknetChain",
+        "summary": "Change the current network of the wallet, a permission request will be displayed on the wallet UI.",
+        "description": "When wallet is locked, open wallet-unlock UI. When Dapp is not approved, display Dapp-approve UI. When wallet is connected and unlocked, display switch-chain UI.",
+        "params": [
+          {
+            "name": "chainId",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/CHAIN_ID"
+            }
+          },
+          {
+            "name": "silent_mode",
+            "summary": "If true, the wallet will not show the wallet-unlock UI in case of a locked wallet, nor the Dapp-approve UI in case of a non-allowed Dapp, and will return an error CHAIN_ID_NOT_SUPPORTED",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "api_version",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/API_VERSION"
+            }
+          }
+        ],
+        "result": {
+          "name": "response",
+          "summary": "If wallet agrees to change network, return true. If the current network is selected, return true. If network is not added to wallet, return false",
+          "required": true,
+          "schema": {
+            "type": "boolean"
+          }
+        },
+        "errors": [
+          {
+            "$ref": "#/components/errors/UNLISTED_NETWORK"
+          },
+          {
+            "$ref": "#/components/errors/USER_REFUSED_OP"
+          },
+          {
+            "$ref": "#/components/errors/API_VERSION_NOT_SUPPORTED"
+          },
+          {
+            "$ref": "#/components/errors/CHAIN_ID_NOT_SUPPORTED"
+          },
+          {
+            "$ref": "#/components/errors/UNKNOWN_ERROR"
+          }
+        ]
+      },
+      {
+        "name": "wallet_watchAsset",
+        "summary": "Add a token in the list of assets displayed by the wallet, the wallet will show an approval UI",
+        "description": "When wallet is locked, open wallet-unlock UI. When Dapp is not approved, display Dapp-approve UI. When wallet is connected and unlocked, display watch-asset UI.",
+        "params": [
+          {
+            "name": "Asset to add",
+            "description": "Information needed to add asset",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/ASSET"
+            }
+          },
+          {
+            "name": "api_version",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/API_VERSION"
+            }
+          }
+        ],
+        "result": {
+          "name": "response",
+          "summary": "If adding a token is agreed, or if token is already displayed, return true",
+          "required": true,
+          "schema": {
+            "type": "boolean"
+          }
+        },
+        "errors": [
+          {
+            "$ref": "#/components/errors/NOT_ERC20"
+          },
+          {
+            "$ref": "#/components/errors/INVALID_REQUEST_PAYLOAD"
+          },
+          {
+            "$ref": "#/components/errors/USER_REFUSED_OP"
+          },
+          {
+            "$ref": "#/components/errors/API_VERSION_NOT_SUPPORTED"
+          },
+          {
+            "$ref": "#/components/errors/UNKNOWN_ERROR"
+          }
+        ]
+      },
+      {
+        "name": "wallet_addStarknetChain",
+        "summary": "Add a new network in the list of networks of the wallet, a permission request will be displayed on the wallet UI.",
+        "description": "When wallet is locked, open wallet-unlock UI. When Dapp is not approved, display Dapp-approve UI. When wallet is connected and unlocked, display add-chain UI.",
+        "params": [
+          {
+            "name": "Starknet Chain to add",
+            "description": "Information for the chain to add to the wallet",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/STARKNET_CHAIN"
+            }
+          },
+          {
+            "name": "api_version",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/API_VERSION"
+            }
+          }
+        ],
+        "result": {
+          "name": "response",
+          "summary": "If user agreed, and network added successfully, or if network already listed, return true",
+          "required": true,
+          "schema": {
+            "type": "boolean"
+          }
+        },
+        "errors": [
+          {
+            "$ref": "#/components/errors/INVALID_REQUEST_PAYLOAD"
+          },
+          {
+            "$ref": "#/components/errors/USER_REFUSED_OP"
+          },
+          {
+            "$ref": "#/components/errors/API_VERSION_NOT_SUPPORTED"
+          },
+          {
+            "$ref": "#/components/errors/UNKNOWN_ERROR"
+          }
+        ]
+      },
+      {
+        "name": "wallet_addInvokeTransaction",
+        "summary": "Submit a new transaction to be added to the chain",
+        "description": "When wallet is locked, open wallet-unlock UI. When Dapp is not approved, display Dapp-approve UI. When wallet is connected and unlocked, display invoke-tx UI.",
+        "params": [
+          {
+            "name": "invoke_transaction",
+            "description": "A list of calls to invoke in an invoke transaction",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/INVOKE_CALL"
+              }
+            }
+          },
+          {
+            "name": "api_version",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/API_VERSION"
+            }
+          }
+        ],
+        "result": {
+          "name": "result",
+          "description": "The result of the transaction submission",
+          "schema": {
+            "type": "object",
+            "properties": {
+              "transaction_hash": {
+                "title": "Transaction Hash",
+                "$ref": "#/components/schemas/PADDED_TXN_HASH"
+              }
+            },
+            "required": ["transaction_hash"]
+          }
+        },
+        "errors": [
+          {
+            "$ref": "#/components/errors/INVALID_REQUEST_PAYLOAD"
+          },
+          {
+            "$ref": "#/components/errors/USER_REFUSED_OP"
+          },
+          {
+            "$ref": "#/components/errors/API_VERSION_NOT_SUPPORTED"
+          },
+          {
+            "$ref": "#/components/errors/UNKNOWN_ERROR"
+          }
+        ]
+      },
+      {
+        "name": "wallet_addDeclareTransaction",
+        "summary": "Submit a declare transaction",
+        "description": "When wallet is locked, open wallet-unlock UI. When Dapp is not approved, display Dapp-approve UI. When wallet is connected and unlocked, display declare-tx UI.",
+        "params": [
+          {
+            "name": "declare_transaction",
+            "description": "The information needed to declare a new class",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/DECLARE_TXN"
+            }
+          },
+          {
+            "name": "api_version",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/API_VERSION"
+            }
+          }
+        ],
+        "result": {
+          "name": "result",
+          "description": "The result of the transaction submission",
+          "schema": {
+            "type": "object",
+            "properties": {
+              "transaction_hash": {
+                "title": "The hash of the declare transaction",
+                "$ref": "#/components/schemas/PADDED_TXN_HASH"
+              },
+              "class_hash": {
+                "title": "The hash of the declared class",
+                "$ref": "#/components/schemas/PADDED_FELT"
+              }
+            },
+            "required": ["transaction_hash", "class_hash"]
+          }
+        },
+        "errors": [
+          {
+            "$ref": "#/components/errors/INVALID_REQUEST_PAYLOAD"
+          },
+          {
+            "$ref": "#/components/errors/USER_REFUSED_OP"
+          },
+          {
+            "$ref": "#/components/errors/API_VERSION_NOT_SUPPORTED"
+          },
+          {
+            "$ref": "#/components/errors/UNKNOWN_ERROR"
+          }
+        ]
+      },
+      {
+        "name": "wallet_signTypedData",
+        "summary": "Sign typed data using the wallet",
+        "description": "When wallet is locked, open wallet-unlock UI. When Dapp is not approved, display Dapp-approve UI. When wallet is connected and unlocked, display sign-typed-data UI.",
+        "params": [
+          {
+            "name": "typed_data",
+            "description": "The typed data to sign",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/TYPED_DATA"
+            }
+          },
+          {
+            "name": "api_version",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/API_VERSION"
+            }
+          }
+        ],
+        "result": {
+          "name": "response",
+          "summary": "The signature over the typed data",
+          "required": true,
+          "schema": {
+            "$ref": "#/components/schemas/SIGNATURE"
+          }
+        },
+        "errors": [
+          {
+            "$ref": "#/components/errors/INVALID_REQUEST_PAYLOAD"
+          },
+          {
+            "$ref": "#/components/errors/USER_REFUSED_OP"
+          },
+          {
+            "$ref": "#/components/errors/API_VERSION_NOT_SUPPORTED"
+          },
+          {
+            "$ref": "#/components/errors/UNKNOWN_ERROR"
+          }
+        ]
+      }
+    ],
+    "components": {
+      "contentDescriptors": {},
+      "schemas": {
+        "PADDED_TXN_HASH": {
+          "title": "Padded Transaction Hash",
+          "description": "The transaction hash, as assigned in Starknet, padded to 64 hex digits",
+          "$ref": "#/components/schemas/PADDED_FELT"
+        },
+        "ADDRESS": {
+          "title": "Address",
+          "$ref": "#/components/schemas/FELT"
+        },
+        "TOKEN_SYMBOL": {
+          "title": "ERC20 Token Symbol",
+          "description": "The symbol of the token",
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 6,
+          "pattern": "^[A-Za-z0-9]{1,6}$"
+        },
+        "SPEC_VERSION": {
+          "title": "Starknet Spec Version",
+          "description": "A Starknet RPC spec version, only two numbers are provided",
+          "type": "string",
+          "pattern": "^[0-9]+\\.[0-9]+$"
+        },
+        "API_VERSION": {
+          "title": "Wallet API version",
+          "description": "The version of wallet API expected by the request. If not specified, the latest is assumed",
+          "type": "string",
+          "pattern": "^[0-9]+\\.[0-9]+$"
+        },
+        "PERMISSION": {
+          "title": "Wallet permission",
+          "type": "string",
+          "enum": ["accounts"],
+          "description": "Optional wallet permissions"
+        },
+        "ASSET": {
+          "title": "Starknet Token",
+          "description": "Details of an onchain Starknet ERC20 token",
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": ["ERC20"]
+            },
+            "options": {
+              "type": "object",
+              "properties": {
+                "address": {
+                  "title": "Token Address",
+                  "$ref": "#/components/schemas/ADDRESS"
+                },
+                "symbol": {
+                  "title": "Token Symbol",
+                  "$ref": "#/components/schemas/TOKEN_SYMBOL"
+                },
+                "decimals": {
+                  "type": "number",
+                  "minimum": 0
+                },
+                "image": {
+                  "type": "string",
+                  "format": "uri"
+                },
+                "name": {
+                  "type": "string"
+                }
+              },
+              "required": ["address"]
+            }
+          },
+          "required": ["type", "options"]
+        },
+        "CHAIN_ID": {
+          "title": "Chain id",
+          "description": "Starknet chain id, given in hex representation.",
+          "type": "string",
+          "pattern": "^0x[a-fA-F0-9]+$"
+        },
+        "STARKNET_CHAIN_ID": {
+          "title": "Starknet Chain id",
+          "description": "Only officially supported Starknet IDs",
+          "allOf": [
+            {
+              "type": "string",
+              "enum": ["0x534e5f4d41494e", "0x534e5f5345504f4c4941"]
+            },
+            {
+              "$ref": "#/components/schemas/CHAIN_ID"
+            }
+          ]
+        },
+        "ACCOUNT_DEPLOYMENT_DATA": {
+          "title": "Account Deployment Data",
+          "description": "Data required to deploy an account at and address",
+          "type": "object",
+          "properties": {
+            "address": {
+              "title": "Address",
+              "description": "The expected address to be deployed, used to double check",
+              "$ref": "#/components/schemas/ADDRESS"
+            },
+            "class_hash": {
+              "title": "Class hash",
+              "description": "The hash of the deployed contract's class",
+              "$ref": "#/components/schemas/FELT"
+            },
+            "salt": {
+              "title": "Class hash",
+              "description": "The hash of the deployed contract's class",
+              "$ref": "#/components/schemas/FELT"
+            },
+            "calldata": {
+              "type": "array",
+              "description": "The parameters passed to the constructor",
+              "title": "Constructor calldata",
+              "items": {
+                "$ref": "#/components/schemas/FELT"
+              }
+            },
+            "sigdata": {
+              "title": "Signature Data",
+              "type": "array",
+              "description": "Optional array of felts to be added to the signature",
+              "items": {
+                "$ref": "#/components/schemas/FELT"
+              }
+            },
+            "version": {
+              "title": "Contract Version",
+              "description": "The Cairo version of the contract 0 or 1",
+              "type": "integer",
+              "enum": [0, 1]
+            }
+          },
+          "required": ["address", "class_hash", "salt", "calldata", "version"]
+        },
+        "INVOKE_CALL": {
+          "title": "Invoke transaction",
+          "description": "initiates a transaction from a given account",
+          "type": "object",
+          "properties": {
+            "contract_address": {
+              "title": "The contract address to interact with",
+              "$ref": "#/components/schemas/ADDRESS"
+            },
+            "entry_point": {
+              "title": "Contract entry point",
+              "description": "A string correlating the selector name of the contract, e.g. 'transfer'",
+              "type": "string"
+            },
+            "calldata": {
+              "type": "array",
+              "title": "calldata",
+              "description": "Calldata to be passed to the entrypoint",
+              "items": {
+                "$ref": "#/components/schemas/FELT"
+              }
+            }
+          },
+          "required": ["contract_address", "entry_point"]
+        },
+        "DECLARE_TXN": {
+          "title": "Declare Transaction",
+          "description": "Declare Contract Transaction",
+          "type": "object",
+          "properties": {
+            "compiled_class_hash": {
+              "title": "Compiled class hash",
+              "description": "The hash of the Cairo assembly resulting from the Sierra compilation",
+              "$ref": "#/components/schemas/FELT"
+            },
+            "class_hash": {
+              "title": "Class hash",
+              "description": "The hash of the declared class",
+              "$ref": "#/components/schemas/FELT"
+            },
+            "contract_class": {
+              "title": "Contract class",
+              "description": "The class to be declared",
+              "$ref": "#/components/schemas/CONTRACT_CLASS"
+            }
+          },
+          "required": ["compiled_class_hash", "contract_class"]
+        },
+        "STARKNET_CHAIN": {
+          "title": "Starknet Chain",
+          "type": "object",
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "chain_id": {
+              "title": "Starknet Chain Id",
+              "$ref": "#/components/schemas/CHAIN_ID"
+            },
+            "chain_name": {
+              "type": "string"
+            },
+            "rpc_urls": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "uri"
+              },
+              "minItems": 1,
+              "uniqueItems": true
+            },
+            "block_explorer_url": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "uri"
+              },
+              "minItems": 1,
+              "uniqueItems": true
+            },
+            "native_currency": {
+              "title": "Native Currency",
+              "$ref": "#/components/schemas/ASSET"
+            },
+            "icon_urls": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "format": "uri"
+              },
+              "minItems": 1,
+              "uniqueItems": true
+            }
+          },
+          "required": ["id", "chain_id", "chain_name"]
+        },
+        "STARKNET_MERKLE_TYPE": {
+          "title": "Starknet Merkle Type",
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string",
+              "enum": ["merkletree"]
+            },
+            "contains": {
+              "type": "string"
+            }
+          },
+          "required": ["name", "type", "contains"]
+        },
+        "STARKNET_ENUM_TYPE": {
+          "title": "Starknet Enum Type",
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string",
+              "enum": ["enum"]
+            },
+            "contains": {
+              "type": "string"
+            }
+          },
+          "required": ["name", "type", "contains"]
+        },
+        "STARKNET_TYPE": {
+          "title": "Starknet Type",
+          "description": "A single type, as part of a struct. The `type` field can be any of the EIP-712 supported types",
+          "schema": {
+            "anyOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "name": { "type": "string" },
+                  "type": { "type": "string" }
+                },
+                "required": ["name", "type"]
+              },
+              {
+                "$ref": "#/components/schemas/STARKNET_MERKLE_TYPE"
+              },
+              {
+                "$ref": "#/components/schemas/STARKNET_ENUM_TYPE"
+              }
+            ]
+          }
+        },
+        "TYPED_DATA": {
+          "title": "Typed Data",
+          "type": "object",
+          "properties": {
+            "types": {
+              "description": "Defines the types of the typed data object",
+              "type": "object",
+              "additionalProperties": {
+                "type": "array",
+                "itmes": {
+                  "$ref": "#/components/schemas/STARKNET_TYPE"
+                }
+              }
+            },
+            "primaryType": {
+              "type": "string",
+              "description": "primaryType represents the top-level type of the object in the message"
+            },
+            "domain": {
+              "description": "The EIP712 domain struct. Any of these fields are optional, but it must contain at least one field",
+              "$ref": "#/components/schemas/STARKNET_DOMAIN"
+            },
+            "message": {
+              "type": "object",
+              "description": "The message to be signed"
+            }
+          },
+          "required": ["types", "primaryType", "domain", "message"]
+        },
+        "STARKNET_DOMAIN": {
+          "title": "Starknet Domain",
+          "type": "object",
+          "minProperties": 1,
+          "properties": {
+            "name": { "type": "string" },
+            "version": { "type": "string" },
+            "chainId": {
+              "anyOf": [{ "type": "string" }, { "type": "number" }]
+            },
+            "revision": {
+              "oneOf": [
+                {
+                  "type": "string",
+                  "enum": ["2"]
+                },
+                {
+                  "type": "number",
+                  "enum": [0, 1]
+                }
+              ]
+            }
+          }
+        },
+        "PADDED_FELT": {
+          "type": "string",
+          "title": "Padded felt",
+          "description": "A padded felt represented as 62 hex digits, 3 bits, and 5 leading zero bits.",
+          "pattern": "^0x(0[0-8]{1}[a-fA-F0-9]{62}$)"
+        },
+        "CONTRACT_CLASS": {
+          "$ref": "./api/starknet_api_openrpc.json#/components/schemas/CONTRACT_CLASS"
+        },
+        "SIGNATURE": {
+          "$ref": "./api/starknet_api_openrpc.json#/components/schemas/SIGNATURE"
+        },
+        "FELT": {
+          "$ref": "./api/starknet_api_openrpc.json#/components/schemas/FELT"
+        }
+      },
+      "errors": {
+        "NOT_ERC20": {
+          "code": 111,
+          "message": "An error occurred (NOT_ERC20)"
+        },
+        "UNLISTED_NETWORK": {
+          "code": 112,
+          "message": "An error occurred (UNLISTED_NETWORK)"
+        },
+        "USER_REFUSED_OP": {
+          "code": 113,
+          "message": "An error occurred (USER_REFUSED_OP)",
+          "description": "The user refused the operation in the wallet"
+        },
+        "INVALID_REQUEST_PAYLOAD": {
+          "code": 114,
+          "message": "An error occurred (INVALID_REQUEST_PAYLOAD)"
+        },
+        "ACCOUNT_ALREADY_DEPLOYED": {
+          "code": 115,
+          "message": "An error occurred (ACCOUNT_ALREADY_DEPLOYED)"
+        },
+        "DEPLOYMENT_DATA_NOT_AVAILABLE": {
+          "code": 116,
+          "message": "An error occurred (DEPLOYMENT_DATA_NOT_AVAILABLE)",
+          "description": "The deployment data is not available or no supported"
+        },
+        "CHAIN_ID_NOT_SUPPORTED": {
+          "code": 117,
+          "message": "An error occurred (CHAIN_ID_NOT_SUPPORTED)",
+          "description": "The requested chain ID is not supported by the wallet"
+        },
+        "API_VERSION_NOT_SUPPORTED": {
+          "code": 162,
+          "message": "An error occurred (API_VERSION_NOT_SUPPORTED)",
+          "data": "string"
+        },
+        "UNKNOWN_ERROR": {
+          "code": 163,
+          "message": "An error occurred (UNKNOWN_ERROR)",
+          "data": "string"
+        }
+      }
+    }
+  }


### PR DESCRIPTION

This PR introduces a mechanism to validate wallet accounts against on-chain status after loading them from persisted storage (Hive).

Issue: #433 

## Changes:
- `PersistedState` Mixin: Added an `onStateLoaded` asynchronous hook method. This allows Notifiers using the mixin to perform custom validation or migration logic on the state loaded from Hive before it is applied.
- Wallets Provider:
    - Implemented `onStateLoaded` to iterate through loaded wallets and accounts.
    - Calls WalletService.isAccountValid for each account to check its on-chain validity.
    - Filters out wallets/accounts that fail the on-chain validation.
    - Checks if the previously selected wallet/account (`state.selected`) is still present after validation. If not (because it was filtered out), the selection is reset to null to prevent errors when accessing selectedAccount.
    - Returns null from onStateLoaded if no valid wallets remain after validation, preventing the potentially invalid persisted state from being applied.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced the `wallet_provider` Dart package, enabling Dart and Flutter apps to interact with Starknet wallets using the Starknet Wallet API.
  - Provides a strongly-typed API for wallet operations, including account management, network switching, transaction submission, asset management, and typed data signing.
  - Comprehensive data models for wallet interactions, assets, transactions, permissions, errors, and contract classes with JSON serialization.
  - Includes example usage, documentation, and OpenRPC specifications for wallet, node write, trace, WebSocket, and contract ABI APIs.

- **Bug Fixes**
  - Improved validation and migration of persisted wallet state, ensuring only valid accounts and wallets are loaded.

- **Documentation**
  - Added detailed README, changelog, implementation notes, and OpenRPC schema files for API reference.

- **Tests**
  - Added test suites covering wallet provider methods and basic package setup validation.

- **Chores**
  - Added configuration files for analysis, code generation, tool versions, and package management.
  - Included MIT license for open-source usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->