### PR TITLE
feat: Wallet_kit should check if account is deployed at startup

### DIFF
--- a/packages/wallet_kit/lib/utils/persisted_notifier_state.dart
+++ b/packages/wallet_kit/lib/utils/persisted_notifier_state.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:easy_debounce/easy_debounce.dart';
 import 'package:hive/hive.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:wallet_kit/utils/debug_print.dart';
 
 mixin PersistedState<T extends PersistableState> on AutoDisposeNotifier<T> {
   String get boxName;
@@ -14,13 +15,30 @@ mixin PersistedState<T extends PersistableState> on AutoDisposeNotifier<T> {
     persistState();
   }
 
+  /// Hook called after state is loaded from persistence but before it's set.
+  /// Override this to perform validation or migration logic.
+  /// Return `null` to prevent the loaded state from being applied.
+  Future<T?> onStateLoaded(T loadedState) async {
+    return loadedState;
+  }
+
   loadPersistedState() async {
     final box = await Hive.openBox<String>(boxName);
     final jsonString = box.get(boxName);
     if (jsonString == null) {
-      return null;
+      return;
     }
-    state = fromJson(jsonDecode(jsonString));
+    try {
+      T loadedState = fromJson(jsonDecode(jsonString));
+      T? validatedState = await onStateLoaded(loadedState);
+
+      if (validatedState != null) {
+        super.state = validatedState;
+      }
+    } catch (e, stackTrace) {
+      debugPrint(
+          "Error loading or validating persisted state for $boxName: $e\n$stackTrace");
+    }
   }
 
   persistState() async {

--- a/packages/wallet_kit/lib/utils/persisted_notifier_state.dart
+++ b/packages/wallet_kit/lib/utils/persisted_notifier_state.dart
@@ -3,7 +3,7 @@ import 'dart:convert';
 import 'package:easy_debounce/easy_debounce.dart';
 import 'package:hive/hive.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
-import 'package:wallet_kit/utils/debug_print.dart';
+import 'debug_print.dart';
 
 mixin PersistedState<T extends PersistableState> on AutoDisposeNotifier<T> {
   String get boxName;


### PR DESCRIPTION
This PR suggests to fix issue #433 

## Changes:
- `PersistedState` Mixin: Added an `onStateLoaded` asynchronous hook method. This allows Notifiers using the mixin to perform custom validation or migration logic on the state loaded from Hive before it is applied.
- Wallets Provider:
    - Implemented `onStateLoaded` to iterate through loaded wallets and accounts.
    - Calls WalletService.isAccountValid for each account to check its on-chain validity.
    - Filters out wallets/accounts that fail the on-chain validation.
    - Checks if the previously selected wallet/account (`state.selected`) is still present after validation. If not (because it was filtered out), the selection is reset to null to prevent errors when accessing selectedAccount.
    - Returns null from onStateLoaded if no valid wallets remain after validation, preventing the potentially invalid persisted state from being applied.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved state loading for wallets by validating accounts on-chain during app startup or state restoration. Invalid accounts and wallets are automatically filtered out, and selections are updated to reflect only valid options.
- **Bug Fixes**
	- Enhanced error handling and validation when loading saved wallet data, reducing the risk of applying invalid or outdated wallet information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->