### PR TITLE
fix: support JSON RPC error with a string payload as data 

### DIFF
--- a/packages/starknet/lib/src/account.dart
+++ b/packages/starknet/lib/src/account.dart
@@ -1148,8 +1148,7 @@ class OpenzeppelinAccountDerivation implements AccountDerivation {
       },
       error: (error) {
         throw Exception(
-          'Account deploy failed: ${error.code} ${error.message}',
-        );
+            'Account deploy failed: ${error.code} ${error.message} ${error.errorData}');
       },
     );
     return deployTxHash;

--- a/packages/starknet/lib/src/account.dart
+++ b/packages/starknet/lib/src/account.dart
@@ -1147,8 +1147,8 @@ class OpenzeppelinAccountDerivation implements AccountDerivation {
         return result.transactionHash;
       },
       error: (error) {
-        throw Exception(
-            'Account deploy failed: ${error.code} ${error.message} ${error.errorData}');
+        throw Exception('Account deploy failed: ${error.code} ${error.message}'
+            '${error.errorData != null ? ' ${error.errorData}' : ''}');
       },
     );
     return deployTxHash;

--- a/packages/starknet_provider/lib/src/model/json_rpc_api_error.dart
+++ b/packages/starknet_provider/lib/src/model/json_rpc_api_error.dart
@@ -163,7 +163,7 @@ enum JsonRpcApiErrorCode {
   INVALID_QUERY,
   @JsonValue(-32603)
   INTERNAL_SEQUENCER,
-  @JsonValue(-32604)
+  @JsonValue(-32604) // Last known error value - 1 for unknown error
   UNKNOWN,
 }
 

--- a/packages/starknet_provider/lib/src/model/json_rpc_api_error.dart
+++ b/packages/starknet_provider/lib/src/model/json_rpc_api_error.dart
@@ -7,37 +7,51 @@ part 'json_rpc_api_error.g.dart';
 
 // Add this JsonConverter to handle JsonRpcApiErrorData serialization
 class JsonRpcApiErrorDataConverter
-    implements JsonConverter<JsonRpcApiErrorData?, Map<String, dynamic>?> {
+    implements JsonConverter<JsonRpcApiErrorData?, dynamic> {
   const JsonRpcApiErrorDataConverter();
 
   @override
-  JsonRpcApiErrorData? fromJson(Map<String, dynamic>? json) {
+  JsonRpcApiErrorData? fromJson(dynamic json) {
+    // This method will be called by the standard freezed deserializer
+    // But we can't use it effectively without the error code context
+    // The actual conversion happens in fromJsonWithCode below
+    return null;
+  }
+
+  JsonRpcApiErrorData? fromJsonWithCode(
+      dynamic json, JsonRpcApiErrorCode errorCode) {
     if (json == null) return null;
-    return JsonRpcApiErrorData.fromJson(json);
+
+    switch (errorCode) {
+      // from api_openrpc
+      case JsonRpcApiErrorCode.CONTRACT_ERROR:
+        return JsonRpcApiErrorData.contractError(
+          data: ContractErrorData.fromJson(json),
+        );
+      case JsonRpcApiErrorCode.TRANSACTION_EXECUTION_ERROR:
+        return JsonRpcApiErrorData.transactionExecutionError(
+          data: TransactionExecutionErrorData.fromJson(json),
+        );
+      // from write_api
+      case JsonRpcApiErrorCode.VALIDATION_FAILURE:
+      case JsonRpcApiErrorCode.UNEXPECTED_ERROR:
+        return JsonRpcApiErrorData.stringData(
+            json is String ? json : json.toString());
+      default:
+        return JsonRpcApiErrorData.stringData(
+            json is String ? json : json.toString());
+    }
   }
 
   @override
-  Map<String, dynamic>? toJson(JsonRpcApiErrorData? data) {
+  dynamic toJson(JsonRpcApiErrorData? data) {
     if (data == null) return null;
     return data.when(
       contractError: (contractData) => contractData.toJson(),
       transactionExecutionError: (txExecData) => txExecData.toJson(),
+      stringData: (data) => data,
     );
   }
-}
-
-@freezed
-class JsonRpcApiError with _$JsonRpcApiError {
-  const factory JsonRpcApiError({
-    required JsonRpcApiErrorCode code,
-    required String message,
-    @JsonKey(name: 'data')
-    @JsonRpcApiErrorDataConverter() // Apply the converter here
-    JsonRpcApiErrorData? errorData,
-  }) = _JsonRpcApiError;
-
-  factory JsonRpcApiError.fromJson(Map<String, Object?> json) =>
-      _$JsonRpcApiErrorFromJson(json);
 }
 
 @freezed
@@ -73,19 +87,10 @@ class JsonRpcApiErrorData with _$JsonRpcApiErrorData {
     required TransactionExecutionErrorData data,
   }) = TransactionExecutionError;
 
-  factory JsonRpcApiErrorData.fromJson(Map<String, Object?> json) {
-    // When the JSON contains a "revert_error" key, we assume the error is a contract error.
-    // This includes CONTRACT_NOT_FOUND errors (error code 20), for which the revert error
-    // message (e.g., "Contract not found") is parsed into a ContractErrorData.
-    // Otherwise, the error is treated as a transaction execution error.
-    if (json.containsKey('revert_error')) {
-      return JsonRpcApiErrorData.contractError(
-          data: ContractErrorData.fromJson(json));
-    } else {
-      return JsonRpcApiErrorData.transactionExecutionError(
-          data: TransactionExecutionErrorData.fromJson(json));
-    }
-  }
+  const factory JsonRpcApiErrorData.stringData(String message) = StringError;
+
+  factory JsonRpcApiErrorData.fromJson(Map<String, Object?> json) =>
+      _$JsonRpcApiErrorDataFromJson(json);
 }
 
 // TODO: should be generated from JSON-RPC API specs
@@ -158,4 +163,42 @@ enum JsonRpcApiErrorCode {
   INVALID_QUERY,
   @JsonValue(-32603)
   INTERNAL_SEQUENCER,
+  @JsonValue(-32604)
+  UNKNOWN,
+}
+
+@freezed
+class JsonRpcApiError with _$JsonRpcApiError {
+  const factory JsonRpcApiError({
+    required JsonRpcApiErrorCode code,
+    required String message,
+    @JsonKey(name: 'data')
+    @JsonRpcApiErrorDataConverter() // Apply the converter here
+    JsonRpcApiErrorData? errorData,
+  }) = _JsonRpcApiError;
+
+  factory JsonRpcApiError.fromJson(Map<String, Object?> json) =>
+      JsonRpcApiError.fromJsonInternal(json);
+
+  factory JsonRpcApiError.fromJsonInternal(Map<String, Object?> json) {
+    // Parse error code first
+    final codeValue = json['code'];
+    final errorCode = (codeValue is int)
+        ? _$JsonRpcApiErrorCodeEnumMap.keys.firstWhere(
+            (k) => _$JsonRpcApiErrorCodeEnumMap[k] == codeValue,
+            orElse: () => JsonRpcApiErrorCode.UNKNOWN)
+        : JsonRpcApiErrorCode.UNKNOWN;
+
+    // Create a base error object with standard freezed deserialization
+    final baseError = _$JsonRpcApiErrorFromJson(json).copyWith(code: errorCode);
+
+    // Get the data field (could be any type)
+    final data = json['data'];
+    if (data != null) {
+      final converter = const JsonRpcApiErrorDataConverter();
+      final errorData = converter.fromJsonWithCode(data, errorCode);
+      return baseError.copyWith(errorData: errorData);
+    }
+    return baseError;
+  }
 }

--- a/packages/starknet_provider/lib/src/model/json_rpc_api_error.freezed.dart
+++ b/packages/starknet_provider/lib/src/model/json_rpc_api_error.freezed.dart
@@ -14,232 +14,6 @@ T _$identity<T>(T value) => value;
 final _privateConstructorUsedError = UnsupportedError(
     'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
 
-JsonRpcApiError _$JsonRpcApiErrorFromJson(Map<String, dynamic> json) {
-  return _JsonRpcApiError.fromJson(json);
-}
-
-/// @nodoc
-mixin _$JsonRpcApiError {
-  JsonRpcApiErrorCode get code => throw _privateConstructorUsedError;
-  String get message => throw _privateConstructorUsedError;
-  @JsonKey(name: 'data')
-  @JsonRpcApiErrorDataConverter()
-  JsonRpcApiErrorData? get errorData => throw _privateConstructorUsedError;
-
-  /// Serializes this JsonRpcApiError to a JSON map.
-  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
-
-  /// Create a copy of JsonRpcApiError
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  $JsonRpcApiErrorCopyWith<JsonRpcApiError> get copyWith =>
-      throw _privateConstructorUsedError;
-}
-
-/// @nodoc
-abstract class $JsonRpcApiErrorCopyWith<$Res> {
-  factory $JsonRpcApiErrorCopyWith(
-          JsonRpcApiError value, $Res Function(JsonRpcApiError) then) =
-      _$JsonRpcApiErrorCopyWithImpl<$Res, JsonRpcApiError>;
-  @useResult
-  $Res call(
-      {JsonRpcApiErrorCode code,
-      String message,
-      @JsonKey(name: 'data')
-      @JsonRpcApiErrorDataConverter()
-      JsonRpcApiErrorData? errorData});
-
-  $JsonRpcApiErrorDataCopyWith<$Res>? get errorData;
-}
-
-/// @nodoc
-class _$JsonRpcApiErrorCopyWithImpl<$Res, $Val extends JsonRpcApiError>
-    implements $JsonRpcApiErrorCopyWith<$Res> {
-  _$JsonRpcApiErrorCopyWithImpl(this._value, this._then);
-
-  // ignore: unused_field
-  final $Val _value;
-  // ignore: unused_field
-  final $Res Function($Val) _then;
-
-  /// Create a copy of JsonRpcApiError
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? code = null,
-    Object? message = null,
-    Object? errorData = freezed,
-  }) {
-    return _then(_value.copyWith(
-      code: null == code
-          ? _value.code
-          : code // ignore: cast_nullable_to_non_nullable
-              as JsonRpcApiErrorCode,
-      message: null == message
-          ? _value.message
-          : message // ignore: cast_nullable_to_non_nullable
-              as String,
-      errorData: freezed == errorData
-          ? _value.errorData
-          : errorData // ignore: cast_nullable_to_non_nullable
-              as JsonRpcApiErrorData?,
-    ) as $Val);
-  }
-
-  /// Create a copy of JsonRpcApiError
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @pragma('vm:prefer-inline')
-  $JsonRpcApiErrorDataCopyWith<$Res>? get errorData {
-    if (_value.errorData == null) {
-      return null;
-    }
-
-    return $JsonRpcApiErrorDataCopyWith<$Res>(_value.errorData!, (value) {
-      return _then(_value.copyWith(errorData: value) as $Val);
-    });
-  }
-}
-
-/// @nodoc
-abstract class _$$JsonRpcApiErrorImplCopyWith<$Res>
-    implements $JsonRpcApiErrorCopyWith<$Res> {
-  factory _$$JsonRpcApiErrorImplCopyWith(_$JsonRpcApiErrorImpl value,
-          $Res Function(_$JsonRpcApiErrorImpl) then) =
-      __$$JsonRpcApiErrorImplCopyWithImpl<$Res>;
-  @override
-  @useResult
-  $Res call(
-      {JsonRpcApiErrorCode code,
-      String message,
-      @JsonKey(name: 'data')
-      @JsonRpcApiErrorDataConverter()
-      JsonRpcApiErrorData? errorData});
-
-  @override
-  $JsonRpcApiErrorDataCopyWith<$Res>? get errorData;
-}
-
-/// @nodoc
-class __$$JsonRpcApiErrorImplCopyWithImpl<$Res>
-    extends _$JsonRpcApiErrorCopyWithImpl<$Res, _$JsonRpcApiErrorImpl>
-    implements _$$JsonRpcApiErrorImplCopyWith<$Res> {
-  __$$JsonRpcApiErrorImplCopyWithImpl(
-      _$JsonRpcApiErrorImpl _value, $Res Function(_$JsonRpcApiErrorImpl) _then)
-      : super(_value, _then);
-
-  /// Create a copy of JsonRpcApiError
-  /// with the given fields replaced by the non-null parameter values.
-  @pragma('vm:prefer-inline')
-  @override
-  $Res call({
-    Object? code = null,
-    Object? message = null,
-    Object? errorData = freezed,
-  }) {
-    return _then(_$JsonRpcApiErrorImpl(
-      code: null == code
-          ? _value.code
-          : code // ignore: cast_nullable_to_non_nullable
-              as JsonRpcApiErrorCode,
-      message: null == message
-          ? _value.message
-          : message // ignore: cast_nullable_to_non_nullable
-              as String,
-      errorData: freezed == errorData
-          ? _value.errorData
-          : errorData // ignore: cast_nullable_to_non_nullable
-              as JsonRpcApiErrorData?,
-    ));
-  }
-}
-
-/// @nodoc
-@JsonSerializable()
-class _$JsonRpcApiErrorImpl implements _JsonRpcApiError {
-  const _$JsonRpcApiErrorImpl(
-      {required this.code,
-      required this.message,
-      @JsonKey(name: 'data') @JsonRpcApiErrorDataConverter() this.errorData});
-
-  factory _$JsonRpcApiErrorImpl.fromJson(Map<String, dynamic> json) =>
-      _$$JsonRpcApiErrorImplFromJson(json);
-
-  @override
-  final JsonRpcApiErrorCode code;
-  @override
-  final String message;
-  @override
-  @JsonKey(name: 'data')
-  @JsonRpcApiErrorDataConverter()
-  final JsonRpcApiErrorData? errorData;
-
-  @override
-  String toString() {
-    return 'JsonRpcApiError(code: $code, message: $message, errorData: $errorData)';
-  }
-
-  @override
-  bool operator ==(Object other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$JsonRpcApiErrorImpl &&
-            (identical(other.code, code) || other.code == code) &&
-            (identical(other.message, message) || other.message == message) &&
-            (identical(other.errorData, errorData) ||
-                other.errorData == errorData));
-  }
-
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  int get hashCode => Object.hash(runtimeType, code, message, errorData);
-
-  /// Create a copy of JsonRpcApiError
-  /// with the given fields replaced by the non-null parameter values.
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  @override
-  @pragma('vm:prefer-inline')
-  _$$JsonRpcApiErrorImplCopyWith<_$JsonRpcApiErrorImpl> get copyWith =>
-      __$$JsonRpcApiErrorImplCopyWithImpl<_$JsonRpcApiErrorImpl>(
-          this, _$identity);
-
-  @override
-  Map<String, dynamic> toJson() {
-    return _$$JsonRpcApiErrorImplToJson(
-      this,
-    );
-  }
-}
-
-abstract class _JsonRpcApiError implements JsonRpcApiError {
-  const factory _JsonRpcApiError(
-      {required final JsonRpcApiErrorCode code,
-      required final String message,
-      @JsonKey(name: 'data')
-      @JsonRpcApiErrorDataConverter()
-      final JsonRpcApiErrorData? errorData}) = _$JsonRpcApiErrorImpl;
-
-  factory _JsonRpcApiError.fromJson(Map<String, dynamic> json) =
-      _$JsonRpcApiErrorImpl.fromJson;
-
-  @override
-  JsonRpcApiErrorCode get code;
-  @override
-  String get message;
-  @override
-  @JsonKey(name: 'data')
-  @JsonRpcApiErrorDataConverter()
-  JsonRpcApiErrorData? get errorData;
-
-  /// Create a copy of JsonRpcApiError
-  /// with the given fields replaced by the non-null parameter values.
-  @override
-  @JsonKey(includeFromJson: false, includeToJson: false)
-  _$$JsonRpcApiErrorImplCopyWith<_$JsonRpcApiErrorImpl> get copyWith =>
-      throw _privateConstructorUsedError;
-}
-
 ContractErrorData _$ContractErrorDataFromJson(Map<String, dynamic> json) {
   return _ContractErrorData.fromJson(json);
 }
@@ -594,14 +368,32 @@ abstract class _TransactionExecutionErrorData
       get copyWith => throw _privateConstructorUsedError;
 }
 
+JsonRpcApiErrorData _$JsonRpcApiErrorDataFromJson(Map<String, dynamic> json) {
+  switch (json['starkNetRuntimeTypeToRemove']) {
+    case 'contractError':
+      return ContractError.fromJson(json);
+    case 'transactionExecutionError':
+      return TransactionExecutionError.fromJson(json);
+    case 'stringData':
+      return StringError.fromJson(json);
+
+    default:
+      throw CheckedFromJsonException(
+          json,
+          'starkNetRuntimeTypeToRemove',
+          'JsonRpcApiErrorData',
+          'Invalid union type "${json['starkNetRuntimeTypeToRemove']}"!');
+  }
+}
+
 /// @nodoc
 mixin _$JsonRpcApiErrorData {
-  Object get data => throw _privateConstructorUsedError;
   @optionalTypeArgs
   TResult when<TResult extends Object?>({
     required TResult Function(ContractErrorData data) contractError,
     required TResult Function(TransactionExecutionErrorData data)
         transactionExecutionError,
+    required TResult Function(String message) stringData,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
@@ -609,6 +401,7 @@ mixin _$JsonRpcApiErrorData {
     TResult? Function(ContractErrorData data)? contractError,
     TResult? Function(TransactionExecutionErrorData data)?
         transactionExecutionError,
+    TResult? Function(String message)? stringData,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
@@ -616,6 +409,7 @@ mixin _$JsonRpcApiErrorData {
     TResult Function(ContractErrorData data)? contractError,
     TResult Function(TransactionExecutionErrorData data)?
         transactionExecutionError,
+    TResult Function(String message)? stringData,
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
@@ -624,6 +418,7 @@ mixin _$JsonRpcApiErrorData {
     required TResult Function(ContractError value) contractError,
     required TResult Function(TransactionExecutionError value)
         transactionExecutionError,
+    required TResult Function(StringError value) stringData,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
@@ -631,6 +426,7 @@ mixin _$JsonRpcApiErrorData {
     TResult? Function(ContractError value)? contractError,
     TResult? Function(TransactionExecutionError value)?
         transactionExecutionError,
+    TResult? Function(StringError value)? stringData,
   }) =>
       throw _privateConstructorUsedError;
   @optionalTypeArgs
@@ -638,9 +434,13 @@ mixin _$JsonRpcApiErrorData {
     TResult Function(ContractError value)? contractError,
     TResult Function(TransactionExecutionError value)?
         transactionExecutionError,
+    TResult Function(StringError value)? stringData,
     required TResult orElse(),
   }) =>
       throw _privateConstructorUsedError;
+
+  /// Serializes this JsonRpcApiErrorData to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
 }
 
 /// @nodoc
@@ -710,12 +510,19 @@ class __$$ContractErrorImplCopyWithImpl<$Res>
 }
 
 /// @nodoc
-
+@JsonSerializable()
 class _$ContractErrorImpl implements ContractError {
-  const _$ContractErrorImpl({required this.data});
+  const _$ContractErrorImpl({required this.data, final String? $type})
+      : $type = $type ?? 'contractError';
+
+  factory _$ContractErrorImpl.fromJson(Map<String, dynamic> json) =>
+      _$$ContractErrorImplFromJson(json);
 
   @override
   final ContractErrorData data;
+
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
+  final String $type;
 
   @override
   String toString() {
@@ -730,6 +537,7 @@ class _$ContractErrorImpl implements ContractError {
             (identical(other.data, data) || other.data == data));
   }
 
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, data);
 
@@ -747,6 +555,7 @@ class _$ContractErrorImpl implements ContractError {
     required TResult Function(ContractErrorData data) contractError,
     required TResult Function(TransactionExecutionErrorData data)
         transactionExecutionError,
+    required TResult Function(String message) stringData,
   }) {
     return contractError(data);
   }
@@ -757,6 +566,7 @@ class _$ContractErrorImpl implements ContractError {
     TResult? Function(ContractErrorData data)? contractError,
     TResult? Function(TransactionExecutionErrorData data)?
         transactionExecutionError,
+    TResult? Function(String message)? stringData,
   }) {
     return contractError?.call(data);
   }
@@ -767,6 +577,7 @@ class _$ContractErrorImpl implements ContractError {
     TResult Function(ContractErrorData data)? contractError,
     TResult Function(TransactionExecutionErrorData data)?
         transactionExecutionError,
+    TResult Function(String message)? stringData,
     required TResult orElse(),
   }) {
     if (contractError != null) {
@@ -781,6 +592,7 @@ class _$ContractErrorImpl implements ContractError {
     required TResult Function(ContractError value) contractError,
     required TResult Function(TransactionExecutionError value)
         transactionExecutionError,
+    required TResult Function(StringError value) stringData,
   }) {
     return contractError(this);
   }
@@ -791,6 +603,7 @@ class _$ContractErrorImpl implements ContractError {
     TResult? Function(ContractError value)? contractError,
     TResult? Function(TransactionExecutionError value)?
         transactionExecutionError,
+    TResult? Function(StringError value)? stringData,
   }) {
     return contractError?.call(this);
   }
@@ -801,6 +614,7 @@ class _$ContractErrorImpl implements ContractError {
     TResult Function(ContractError value)? contractError,
     TResult Function(TransactionExecutionError value)?
         transactionExecutionError,
+    TResult Function(StringError value)? stringData,
     required TResult orElse(),
   }) {
     if (contractError != null) {
@@ -808,13 +622,22 @@ class _$ContractErrorImpl implements ContractError {
     }
     return orElse();
   }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$ContractErrorImplToJson(
+      this,
+    );
+  }
 }
 
 abstract class ContractError implements JsonRpcApiErrorData {
   const factory ContractError({required final ContractErrorData data}) =
       _$ContractErrorImpl;
 
-  @override
+  factory ContractError.fromJson(Map<String, dynamic> json) =
+      _$ContractErrorImpl.fromJson;
+
   ContractErrorData get data;
 
   /// Create a copy of JsonRpcApiErrorData
@@ -873,12 +696,20 @@ class __$$TransactionExecutionErrorImplCopyWithImpl<$Res>
 }
 
 /// @nodoc
-
+@JsonSerializable()
 class _$TransactionExecutionErrorImpl implements TransactionExecutionError {
-  const _$TransactionExecutionErrorImpl({required this.data});
+  const _$TransactionExecutionErrorImpl(
+      {required this.data, final String? $type})
+      : $type = $type ?? 'transactionExecutionError';
+
+  factory _$TransactionExecutionErrorImpl.fromJson(Map<String, dynamic> json) =>
+      _$$TransactionExecutionErrorImplFromJson(json);
 
   @override
   final TransactionExecutionErrorData data;
+
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
+  final String $type;
 
   @override
   String toString() {
@@ -893,6 +724,7 @@ class _$TransactionExecutionErrorImpl implements TransactionExecutionError {
             (identical(other.data, data) || other.data == data));
   }
 
+  @JsonKey(includeFromJson: false, includeToJson: false)
   @override
   int get hashCode => Object.hash(runtimeType, data);
 
@@ -911,6 +743,7 @@ class _$TransactionExecutionErrorImpl implements TransactionExecutionError {
     required TResult Function(ContractErrorData data) contractError,
     required TResult Function(TransactionExecutionErrorData data)
         transactionExecutionError,
+    required TResult Function(String message) stringData,
   }) {
     return transactionExecutionError(data);
   }
@@ -921,6 +754,7 @@ class _$TransactionExecutionErrorImpl implements TransactionExecutionError {
     TResult? Function(ContractErrorData data)? contractError,
     TResult? Function(TransactionExecutionErrorData data)?
         transactionExecutionError,
+    TResult? Function(String message)? stringData,
   }) {
     return transactionExecutionError?.call(data);
   }
@@ -931,6 +765,7 @@ class _$TransactionExecutionErrorImpl implements TransactionExecutionError {
     TResult Function(ContractErrorData data)? contractError,
     TResult Function(TransactionExecutionErrorData data)?
         transactionExecutionError,
+    TResult Function(String message)? stringData,
     required TResult orElse(),
   }) {
     if (transactionExecutionError != null) {
@@ -945,6 +780,7 @@ class _$TransactionExecutionErrorImpl implements TransactionExecutionError {
     required TResult Function(ContractError value) contractError,
     required TResult Function(TransactionExecutionError value)
         transactionExecutionError,
+    required TResult Function(StringError value) stringData,
   }) {
     return transactionExecutionError(this);
   }
@@ -955,6 +791,7 @@ class _$TransactionExecutionErrorImpl implements TransactionExecutionError {
     TResult? Function(ContractError value)? contractError,
     TResult? Function(TransactionExecutionError value)?
         transactionExecutionError,
+    TResult? Function(StringError value)? stringData,
   }) {
     return transactionExecutionError?.call(this);
   }
@@ -965,12 +802,20 @@ class _$TransactionExecutionErrorImpl implements TransactionExecutionError {
     TResult Function(ContractError value)? contractError,
     TResult Function(TransactionExecutionError value)?
         transactionExecutionError,
+    TResult Function(StringError value)? stringData,
     required TResult orElse(),
   }) {
     if (transactionExecutionError != null) {
       return transactionExecutionError(this);
     }
     return orElse();
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$TransactionExecutionErrorImplToJson(
+      this,
+    );
   }
 }
 
@@ -979,7 +824,9 @@ abstract class TransactionExecutionError implements JsonRpcApiErrorData {
           {required final TransactionExecutionErrorData data}) =
       _$TransactionExecutionErrorImpl;
 
-  @override
+  factory TransactionExecutionError.fromJson(Map<String, dynamic> json) =
+      _$TransactionExecutionErrorImpl.fromJson;
+
   TransactionExecutionErrorData get data;
 
   /// Create a copy of JsonRpcApiErrorData
@@ -987,4 +834,400 @@ abstract class TransactionExecutionError implements JsonRpcApiErrorData {
   @JsonKey(includeFromJson: false, includeToJson: false)
   _$$TransactionExecutionErrorImplCopyWith<_$TransactionExecutionErrorImpl>
       get copyWith => throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class _$$StringErrorImplCopyWith<$Res> {
+  factory _$$StringErrorImplCopyWith(
+          _$StringErrorImpl value, $Res Function(_$StringErrorImpl) then) =
+      __$$StringErrorImplCopyWithImpl<$Res>;
+  @useResult
+  $Res call({String message});
+}
+
+/// @nodoc
+class __$$StringErrorImplCopyWithImpl<$Res>
+    extends _$JsonRpcApiErrorDataCopyWithImpl<$Res, _$StringErrorImpl>
+    implements _$$StringErrorImplCopyWith<$Res> {
+  __$$StringErrorImplCopyWithImpl(
+      _$StringErrorImpl _value, $Res Function(_$StringErrorImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of JsonRpcApiErrorData
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? message = null,
+  }) {
+    return _then(_$StringErrorImpl(
+      null == message
+          ? _value.message
+          : message // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$StringErrorImpl implements StringError {
+  const _$StringErrorImpl(this.message, {final String? $type})
+      : $type = $type ?? 'stringData';
+
+  factory _$StringErrorImpl.fromJson(Map<String, dynamic> json) =>
+      _$$StringErrorImplFromJson(json);
+
+  @override
+  final String message;
+
+  @JsonKey(name: 'starkNetRuntimeTypeToRemove')
+  final String $type;
+
+  @override
+  String toString() {
+    return 'JsonRpcApiErrorData.stringData(message: $message)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$StringErrorImpl &&
+            (identical(other.message, message) || other.message == message));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, message);
+
+  /// Create a copy of JsonRpcApiErrorData
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$StringErrorImplCopyWith<_$StringErrorImpl> get copyWith =>
+      __$$StringErrorImplCopyWithImpl<_$StringErrorImpl>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  TResult when<TResult extends Object?>({
+    required TResult Function(ContractErrorData data) contractError,
+    required TResult Function(TransactionExecutionErrorData data)
+        transactionExecutionError,
+    required TResult Function(String message) stringData,
+  }) {
+    return stringData(message);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? whenOrNull<TResult extends Object?>({
+    TResult? Function(ContractErrorData data)? contractError,
+    TResult? Function(TransactionExecutionErrorData data)?
+        transactionExecutionError,
+    TResult? Function(String message)? stringData,
+  }) {
+    return stringData?.call(message);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeWhen<TResult extends Object?>({
+    TResult Function(ContractErrorData data)? contractError,
+    TResult Function(TransactionExecutionErrorData data)?
+        transactionExecutionError,
+    TResult Function(String message)? stringData,
+    required TResult orElse(),
+  }) {
+    if (stringData != null) {
+      return stringData(message);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult map<TResult extends Object?>({
+    required TResult Function(ContractError value) contractError,
+    required TResult Function(TransactionExecutionError value)
+        transactionExecutionError,
+    required TResult Function(StringError value) stringData,
+  }) {
+    return stringData(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult? mapOrNull<TResult extends Object?>({
+    TResult? Function(ContractError value)? contractError,
+    TResult? Function(TransactionExecutionError value)?
+        transactionExecutionError,
+    TResult? Function(StringError value)? stringData,
+  }) {
+    return stringData?.call(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  TResult maybeMap<TResult extends Object?>({
+    TResult Function(ContractError value)? contractError,
+    TResult Function(TransactionExecutionError value)?
+        transactionExecutionError,
+    TResult Function(StringError value)? stringData,
+    required TResult orElse(),
+  }) {
+    if (stringData != null) {
+      return stringData(this);
+    }
+    return orElse();
+  }
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$StringErrorImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class StringError implements JsonRpcApiErrorData {
+  const factory StringError(final String message) = _$StringErrorImpl;
+
+  factory StringError.fromJson(Map<String, dynamic> json) =
+      _$StringErrorImpl.fromJson;
+
+  String get message;
+
+  /// Create a copy of JsonRpcApiErrorData
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$StringErrorImplCopyWith<_$StringErrorImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+JsonRpcApiError _$JsonRpcApiErrorFromJson(Map<String, dynamic> json) {
+  return _JsonRpcApiError.fromJson(json);
+}
+
+/// @nodoc
+mixin _$JsonRpcApiError {
+  JsonRpcApiErrorCode get code => throw _privateConstructorUsedError;
+  String get message => throw _privateConstructorUsedError;
+  @JsonKey(name: 'data')
+  @JsonRpcApiErrorDataConverter()
+  JsonRpcApiErrorData? get errorData => throw _privateConstructorUsedError;
+
+  /// Serializes this JsonRpcApiError to a JSON map.
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+
+  /// Create a copy of JsonRpcApiError
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  $JsonRpcApiErrorCopyWith<JsonRpcApiError> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $JsonRpcApiErrorCopyWith<$Res> {
+  factory $JsonRpcApiErrorCopyWith(
+          JsonRpcApiError value, $Res Function(JsonRpcApiError) then) =
+      _$JsonRpcApiErrorCopyWithImpl<$Res, JsonRpcApiError>;
+  @useResult
+  $Res call(
+      {JsonRpcApiErrorCode code,
+      String message,
+      @JsonKey(name: 'data')
+      @JsonRpcApiErrorDataConverter()
+      JsonRpcApiErrorData? errorData});
+
+  $JsonRpcApiErrorDataCopyWith<$Res>? get errorData;
+}
+
+/// @nodoc
+class _$JsonRpcApiErrorCopyWithImpl<$Res, $Val extends JsonRpcApiError>
+    implements $JsonRpcApiErrorCopyWith<$Res> {
+  _$JsonRpcApiErrorCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  /// Create a copy of JsonRpcApiError
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? code = null,
+    Object? message = null,
+    Object? errorData = freezed,
+  }) {
+    return _then(_value.copyWith(
+      code: null == code
+          ? _value.code
+          : code // ignore: cast_nullable_to_non_nullable
+              as JsonRpcApiErrorCode,
+      message: null == message
+          ? _value.message
+          : message // ignore: cast_nullable_to_non_nullable
+              as String,
+      errorData: freezed == errorData
+          ? _value.errorData
+          : errorData // ignore: cast_nullable_to_non_nullable
+              as JsonRpcApiErrorData?,
+    ) as $Val);
+  }
+
+  /// Create a copy of JsonRpcApiError
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @pragma('vm:prefer-inline')
+  $JsonRpcApiErrorDataCopyWith<$Res>? get errorData {
+    if (_value.errorData == null) {
+      return null;
+    }
+
+    return $JsonRpcApiErrorDataCopyWith<$Res>(_value.errorData!, (value) {
+      return _then(_value.copyWith(errorData: value) as $Val);
+    });
+  }
+}
+
+/// @nodoc
+abstract class _$$JsonRpcApiErrorImplCopyWith<$Res>
+    implements $JsonRpcApiErrorCopyWith<$Res> {
+  factory _$$JsonRpcApiErrorImplCopyWith(_$JsonRpcApiErrorImpl value,
+          $Res Function(_$JsonRpcApiErrorImpl) then) =
+      __$$JsonRpcApiErrorImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {JsonRpcApiErrorCode code,
+      String message,
+      @JsonKey(name: 'data')
+      @JsonRpcApiErrorDataConverter()
+      JsonRpcApiErrorData? errorData});
+
+  @override
+  $JsonRpcApiErrorDataCopyWith<$Res>? get errorData;
+}
+
+/// @nodoc
+class __$$JsonRpcApiErrorImplCopyWithImpl<$Res>
+    extends _$JsonRpcApiErrorCopyWithImpl<$Res, _$JsonRpcApiErrorImpl>
+    implements _$$JsonRpcApiErrorImplCopyWith<$Res> {
+  __$$JsonRpcApiErrorImplCopyWithImpl(
+      _$JsonRpcApiErrorImpl _value, $Res Function(_$JsonRpcApiErrorImpl) _then)
+      : super(_value, _then);
+
+  /// Create a copy of JsonRpcApiError
+  /// with the given fields replaced by the non-null parameter values.
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? code = null,
+    Object? message = null,
+    Object? errorData = freezed,
+  }) {
+    return _then(_$JsonRpcApiErrorImpl(
+      code: null == code
+          ? _value.code
+          : code // ignore: cast_nullable_to_non_nullable
+              as JsonRpcApiErrorCode,
+      message: null == message
+          ? _value.message
+          : message // ignore: cast_nullable_to_non_nullable
+              as String,
+      errorData: freezed == errorData
+          ? _value.errorData
+          : errorData // ignore: cast_nullable_to_non_nullable
+              as JsonRpcApiErrorData?,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$JsonRpcApiErrorImpl implements _JsonRpcApiError {
+  const _$JsonRpcApiErrorImpl(
+      {required this.code,
+      required this.message,
+      @JsonKey(name: 'data') @JsonRpcApiErrorDataConverter() this.errorData});
+
+  factory _$JsonRpcApiErrorImpl.fromJson(Map<String, dynamic> json) =>
+      _$$JsonRpcApiErrorImplFromJson(json);
+
+  @override
+  final JsonRpcApiErrorCode code;
+  @override
+  final String message;
+  @override
+  @JsonKey(name: 'data')
+  @JsonRpcApiErrorDataConverter()
+  final JsonRpcApiErrorData? errorData;
+
+  @override
+  String toString() {
+    return 'JsonRpcApiError(code: $code, message: $message, errorData: $errorData)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$JsonRpcApiErrorImpl &&
+            (identical(other.code, code) || other.code == code) &&
+            (identical(other.message, message) || other.message == message) &&
+            (identical(other.errorData, errorData) ||
+                other.errorData == errorData));
+  }
+
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  int get hashCode => Object.hash(runtimeType, code, message, errorData);
+
+  /// Create a copy of JsonRpcApiError
+  /// with the given fields replaced by the non-null parameter values.
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$JsonRpcApiErrorImplCopyWith<_$JsonRpcApiErrorImpl> get copyWith =>
+      __$$JsonRpcApiErrorImplCopyWithImpl<_$JsonRpcApiErrorImpl>(
+          this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$JsonRpcApiErrorImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _JsonRpcApiError implements JsonRpcApiError {
+  const factory _JsonRpcApiError(
+      {required final JsonRpcApiErrorCode code,
+      required final String message,
+      @JsonKey(name: 'data')
+      @JsonRpcApiErrorDataConverter()
+      final JsonRpcApiErrorData? errorData}) = _$JsonRpcApiErrorImpl;
+
+  factory _JsonRpcApiError.fromJson(Map<String, dynamic> json) =
+      _$JsonRpcApiErrorImpl.fromJson;
+
+  @override
+  JsonRpcApiErrorCode get code;
+  @override
+  String get message;
+  @override
+  @JsonKey(name: 'data')
+  @JsonRpcApiErrorDataConverter()
+  JsonRpcApiErrorData? get errorData;
+
+  /// Create a copy of JsonRpcApiError
+  /// with the given fields replaced by the non-null parameter values.
+  @override
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  _$$JsonRpcApiErrorImplCopyWith<_$JsonRpcApiErrorImpl> get copyWith =>
+      throw _privateConstructorUsedError;
 }

--- a/packages/starknet_provider/lib/src/model/json_rpc_api_error.g.dart
+++ b/packages/starknet_provider/lib/src/model/json_rpc_api_error.g.dart
@@ -6,13 +6,77 @@ part of 'json_rpc_api_error.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
+_$ContractErrorDataImpl _$$ContractErrorDataImplFromJson(
+        Map<String, dynamic> json) =>
+    _$ContractErrorDataImpl(
+      revertError: json['revert_error'] as String,
+    );
+
+Map<String, dynamic> _$$ContractErrorDataImplToJson(
+        _$ContractErrorDataImpl instance) =>
+    <String, dynamic>{
+      'revert_error': instance.revertError,
+    };
+
+_$TransactionExecutionErrorDataImpl
+    _$$TransactionExecutionErrorDataImplFromJson(Map<String, dynamic> json) =>
+        _$TransactionExecutionErrorDataImpl(
+          transactionIndex: (json['transaction_index'] as num).toInt(),
+          executionError: json['execution_error'] as String,
+        );
+
+Map<String, dynamic> _$$TransactionExecutionErrorDataImplToJson(
+        _$TransactionExecutionErrorDataImpl instance) =>
+    <String, dynamic>{
+      'transaction_index': instance.transactionIndex,
+      'execution_error': instance.executionError,
+    };
+
+_$ContractErrorImpl _$$ContractErrorImplFromJson(Map<String, dynamic> json) =>
+    _$ContractErrorImpl(
+      data: ContractErrorData.fromJson(json['data'] as Map<String, dynamic>),
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
+    );
+
+Map<String, dynamic> _$$ContractErrorImplToJson(_$ContractErrorImpl instance) =>
+    <String, dynamic>{
+      'data': instance.data.toJson(),
+      'starkNetRuntimeTypeToRemove': instance.$type,
+    };
+
+_$TransactionExecutionErrorImpl _$$TransactionExecutionErrorImplFromJson(
+        Map<String, dynamic> json) =>
+    _$TransactionExecutionErrorImpl(
+      data: TransactionExecutionErrorData.fromJson(
+          json['data'] as Map<String, dynamic>),
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
+    );
+
+Map<String, dynamic> _$$TransactionExecutionErrorImplToJson(
+        _$TransactionExecutionErrorImpl instance) =>
+    <String, dynamic>{
+      'data': instance.data.toJson(),
+      'starkNetRuntimeTypeToRemove': instance.$type,
+    };
+
+_$StringErrorImpl _$$StringErrorImplFromJson(Map<String, dynamic> json) =>
+    _$StringErrorImpl(
+      json['message'] as String,
+      $type: json['starkNetRuntimeTypeToRemove'] as String?,
+    );
+
+Map<String, dynamic> _$$StringErrorImplToJson(_$StringErrorImpl instance) =>
+    <String, dynamic>{
+      'message': instance.message,
+      'starkNetRuntimeTypeToRemove': instance.$type,
+    };
+
 _$JsonRpcApiErrorImpl _$$JsonRpcApiErrorImplFromJson(
         Map<String, dynamic> json) =>
     _$JsonRpcApiErrorImpl(
       code: $enumDecode(_$JsonRpcApiErrorCodeEnumMap, json['code']),
       message: json['message'] as String,
-      errorData: const JsonRpcApiErrorDataConverter()
-          .fromJson(json['data'] as Map<String, dynamic>?),
+      errorData: const JsonRpcApiErrorDataConverter().fromJson(json['data']),
     );
 
 Map<String, dynamic> _$$JsonRpcApiErrorImplToJson(
@@ -58,30 +122,5 @@ const _$JsonRpcApiErrorCodeEnumMap = {
   JsonRpcApiErrorCode.METHOD_NOT_FOUND: -32601,
   JsonRpcApiErrorCode.INVALID_QUERY: -32602,
   JsonRpcApiErrorCode.INTERNAL_SEQUENCER: -32603,
+  JsonRpcApiErrorCode.UNKNOWN: -32604,
 };
-
-_$ContractErrorDataImpl _$$ContractErrorDataImplFromJson(
-        Map<String, dynamic> json) =>
-    _$ContractErrorDataImpl(
-      revertError: json['revert_error'] as String,
-    );
-
-Map<String, dynamic> _$$ContractErrorDataImplToJson(
-        _$ContractErrorDataImpl instance) =>
-    <String, dynamic>{
-      'revert_error': instance.revertError,
-    };
-
-_$TransactionExecutionErrorDataImpl
-    _$$TransactionExecutionErrorDataImplFromJson(Map<String, dynamic> json) =>
-        _$TransactionExecutionErrorDataImpl(
-          transactionIndex: (json['transaction_index'] as num).toInt(),
-          executionError: json['execution_error'] as String,
-        );
-
-Map<String, dynamic> _$$TransactionExecutionErrorDataImplToJson(
-        _$TransactionExecutionErrorDataImpl instance) =>
-    <String, dynamic>{
-      'transaction_index': instance.transactionIndex,
-      'execution_error': instance.executionError,
-    };


### PR DESCRIPTION
- Fix parsing of [`VALIDATION_FAILURE`](https://github.com/starkware-libs/starknet-specs/blob/76bdde23c7dae370a3340e40f7ca2ef2520e75b9/api/starknet_write_api.json#L259-L263) and [`UNEXPECTED_ERROR`](https://github.com/starkware-libs/starknet-specs/blob/76bdde23c7dae370a3340e40f7ca2ef2520e75b9/api/starknet_write_api.json#L292-L296)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced error handling for account deployment by providing more detailed error messages.
  - Improved error deserialization for JSON-RPC API errors, including support for unknown error codes and string-based error data.
  - Added new error data type to better represent string error messages in responses.

- **Bug Fixes**
  - More accurate mapping and handling of error data based on error codes, reducing ambiguity in error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->