### PR TITLE
fix(starknet_provider): remove uneeded asdf configuration file

### DIFF
--- a/packages/starknet_provider/.tool-versions
+++ b/packages/starknet_provider/.tool-versions
@@ -1,1 +1,0 @@
-starknet-devnet 0.1.2


### PR DESCRIPTION
All packages should use the same version for `starknet-devnet`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed the version specification for starknet-devnet from the configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->