### PR TITLE
feat: add seedphrase validation

### DIFF
--- a/packages/wallet_kit/lib/services/wallet_service.dart
+++ b/packages/wallet_kit/lib/services/wallet_service.dart
@@ -86,9 +86,8 @@ class WalletService {
     required Account account,
     required String walletId,
   }) async {
-    final privateKey = await secureStore.getSecret(
-      key: privateKeyKey(walletId, account.id),
-    );
+    final privateKey =
+        await secureStore.getSecret(key: privateKeyKey(walletId, account.id));
     if (privateKey == null) {
       throw Exception("Private key not found");
     }
@@ -97,19 +96,26 @@ class WalletService {
       chainId: WalletKit().chainId,
       provider: WalletKit().provider,
       signer: s.StarkAccountSigner(
-        signer: s.StarkSigner(privateKey: s.Felt.fromHexString(privateKey)),
+        signer: s.StarkSigner(
+          privateKey: s.Felt.fromHexString(privateKey),
+        ),
       ),
       supportedTxVersion: s.AccountSupportedTxVersion.v1,
     );
   }
 
-  static Future<bool> isAccountValid({required Account account}) async {
+  static Future<bool> isAccountValid({
+    required Account account,
+  }) async {
     final provider = WalletKit().provider;
     final accountClassHash = (await provider.getClassHashAt(
       contractAddress: s.Felt.fromHexString(account.address),
       blockId: BlockId.latest,
     ))
-        .when(result: (result) => result, error: ((error) => s.Felt.zero));
+        .when(
+      result: (result) => result,
+      error: ((error) => s.Felt.zero),
+    );
     return accountClassHash != s.Felt.zero;
   }
 
@@ -128,11 +134,16 @@ class WalletService {
       String seedPhrase = input['seedPhrase'];
       int derivationIndex = input['derivationIndex'];
 
-      return s.derivePrivateKey(mnemonic: seedPhrase, index: derivationIndex);
+      return s.derivePrivateKey(
+        mnemonic: seedPhrase,
+        index: derivationIndex,
+      );
     }, computationInput);
   }
 
-  static Future<s.Felt> computeAddress({required s.Felt privateKey}) async {
+  static Future<s.Felt> computeAddress({
+    required s.Felt privateKey,
+  }) async {
     final address = s.Contract.computeAddress(
       classHash: WalletKit().accountClassHash,
       calldata: [s.StarkSigner(privateKey: privateKey).publicKey],
@@ -140,21 +151,18 @@ class WalletService {
     );
     return address;
   }
-
   static Future<bool> deployAccount({
     required SecureStore secureStore,
     required Account account,
   }) async {
     final privateKey = await secureStore.getSecret(
-      key: privateKeyKey(account.walletId, account.id),
-    );
+        key: privateKeyKey(account.walletId, account.id));
     if (privateKey == null) {
       throw Exception("Private key not found");
     }
 
     s.StarkAccountSigner? signer = s.StarkAccountSigner(
-      signer: s.StarkSigner(privateKey: s.Felt.fromHexString(privateKey)),
-    );
+        signer: s.StarkSigner(privateKey: s.Felt.fromHexString(privateKey)));
 
     final provider = WalletKit().provider;
 
@@ -200,9 +208,8 @@ Future<String> sendEth({
   //     .getPrivateKey(id: account.id.toString(), password: password);
   final privateKey = s.Felt.fromHexString("0x1");
 
-  s.StarkAccountSigner? signer = s.StarkAccountSigner(
-    signer: s.StarkSigner(privateKey: privateKey),
-  );
+  s.StarkAccountSigner? signer =
+      s.StarkAccountSigner(signer: s.StarkSigner(privateKey: privateKey));
 
   final provider = WalletKit().provider;
   final chainId = WalletKit().chainId;
@@ -217,7 +224,9 @@ Future<String> sendEth({
   final txHash = await fundingAccount.send(
     recipient: recipientAddress,
     amount: s.Uint256(
-      low: s.Felt(BigInt.from(amount * 1e18)),
+      low: s.Felt(
+        BigInt.from(amount * 1e18),
+      ),
       high: s.Felt.zero,
     ),
   );

--- a/packages/wallet_kit/lib/services/wallet_service.dart
+++ b/packages/wallet_kit/lib/services/wallet_service.dart
@@ -108,7 +108,8 @@ class WalletService {
     final accountClassHash = (await provider.getClassHashAt(
       contractAddress: s.Felt.fromHexString(account.address),
       blockId: BlockId.latest,
-    )).when(result: (result) => result, error: ((error) => s.Felt.zero));
+    ))
+        .when(result: (result) => result, error: ((error) => s.Felt.zero));
     return accountClassHash != s.Felt.zero;
   }
 

--- a/packages/wallet_kit/lib/services/wallet_service.dart
+++ b/packages/wallet_kit/lib/services/wallet_service.dart
@@ -151,6 +151,7 @@ class WalletService {
     );
     return address;
   }
+  
   static Future<bool> deployAccount({
     required SecureStore secureStore,
     required Account account,

--- a/packages/wallet_kit/lib/services/wallet_service.dart
+++ b/packages/wallet_kit/lib/services/wallet_service.dart
@@ -151,7 +151,7 @@ class WalletService {
     );
     return address;
   }
-  
+
   static Future<bool> deployAccount({
     required SecureStore secureStore,
     required Account account,

--- a/packages/wallet_kit/lib/ui/button.dart
+++ b/packages/wallet_kit/lib/ui/button.dart
@@ -6,14 +6,12 @@ class PrimaryButton extends StatelessWidget {
     Key? key,
     required this.label,
     this.onPressed,
-    this.labelStyle,
     this.isLoading = false,
   }) : super(key: key);
 
   final String label;
   final VoidCallback? onPressed;
   final bool isLoading;
-  final TextStyle? labelStyle;
 
   @override
   Widget build(BuildContext context) {
@@ -29,7 +27,7 @@ class PrimaryButton extends StatelessWidget {
                   strokeWidth: 2,
                 ),
               )
-            : Text(label, style: labelStyle),
+            : Text(label),
       ),
     );
   }

--- a/packages/wallet_kit/lib/ui/button.dart
+++ b/packages/wallet_kit/lib/ui/button.dart
@@ -25,7 +25,9 @@ class PrimaryButton extends StatelessWidget {
             ? const SizedBox(
                 width: 16,
                 height: 16,
-                child: CircularProgressIndicator(strokeWidth: 2),
+                child: CircularProgressIndicator(
+                  strokeWidth: 2,
+                ),
               )
             : Text(label, style: labelStyle),
       ),
@@ -55,7 +57,9 @@ class SecondaryButton extends StatelessWidget {
             ? const SizedBox(
                 width: 16,
                 height: 16,
-                child: CircularProgressIndicator(strokeWidth: 2),
+                child: CircularProgressIndicator(
+                  strokeWidth: 2,
+                ),
               )
             : Text(label),
       ),

--- a/packages/wallet_kit/lib/ui/button.dart
+++ b/packages/wallet_kit/lib/ui/button.dart
@@ -6,12 +6,14 @@ class PrimaryButton extends StatelessWidget {
     Key? key,
     required this.label,
     this.onPressed,
+    this.labelStyle,
     this.isLoading = false,
   }) : super(key: key);
 
   final String label;
   final VoidCallback? onPressed;
   final bool isLoading;
+  final TextStyle? labelStyle;
 
   @override
   Widget build(BuildContext context) {
@@ -23,11 +25,9 @@ class PrimaryButton extends StatelessWidget {
             ? const SizedBox(
                 width: 16,
                 height: 16,
-                child: CircularProgressIndicator(
-                  strokeWidth: 2,
-                ),
+                child: CircularProgressIndicator(strokeWidth: 2),
               )
-            : Text(label),
+            : Text(label, style: labelStyle),
       ),
     );
   }
@@ -55,9 +55,7 @@ class SecondaryButton extends StatelessWidget {
             ? const SizedBox(
                 width: 16,
                 height: 16,
-                child: CircularProgressIndicator(
-                  strokeWidth: 2,
-                ),
+                child: CircularProgressIndicator(strokeWidth: 2),
               )
             : Text(label),
       ),

--- a/packages/wallet_kit/lib/wallet_screens/recover_wallet_screen.dart
+++ b/packages/wallet_kit/lib/wallet_screens/recover_wallet_screen.dart
@@ -19,6 +19,32 @@ class RecoverWalletScreen extends HookConsumerWidget {
         seedPhrase.value == '' ? 0 : seedPhrase.value.trim().split(' ').length;
     final isButtonEnabled = wordsCount == seedPhraseWordsCount;
     final walletType = useState(WalletType.openZeppelin);
+    final seedValid = useState(true);
+
+    void handleSeedPhraseChanged(String value) {
+      seedPhrase.value = value;
+      if (!seedValid.value) {
+        seedValid.value = true;
+      }
+    }
+
+    void handleContinuePressed() {
+      final isValid = ref
+          .read(walletsProvider.notifier)
+          .validateSeedPhrase(seedPhrase: seedPhrase.value);
+      if (isValid) {
+        Navigator.of(context).push(
+          MaterialPageRoute(
+            builder: (context) => ProtectWalletScreen(
+              seedPhrase: seedPhrase.value,
+              walletType: walletType.value,
+            ),
+          ),
+        );
+      } else {
+        seedValid.value = false;
+      }
+    }
 
     return Layout2(
       sideMargin: sideMargin,
@@ -28,7 +54,7 @@ class RecoverWalletScreen extends HookConsumerWidget {
         ),
         TextInput(
           hintText: 'Enter your seed phrase',
-          onChanged: (value) => seedPhrase.value = value,
+          onChanged: handleSeedPhraseChanged,
         ),
         SizedBox(
           width: double.infinity,
@@ -73,19 +99,11 @@ class RecoverWalletScreen extends HookConsumerWidget {
         ),
         const Spacer(),
         PrimaryButton(
-            onPressed: isButtonEnabled
-                ? () {
-                    Navigator.of(context).push(
-                      MaterialPageRoute(
-                        builder: (context) => ProtectWalletScreen(
-                          seedPhrase: seedPhrase.value,
-                          walletType: walletType.value,
-                        ),
-                      ),
-                    );
-                  }
-                : null,
-            label: 'Continue'),
+          onPressed: isButtonEnabled ? handleContinuePressed : null,
+          label: seedValid.value ? 'Continue' : 'Invalid Seed Phrase',
+          labelStyle: TextStyle(
+              color: seedValid.value ? Colors.blueAccent : Colors.red),
+        ),
       ],
     );
   }

--- a/packages/wallet_kit/lib/wallet_screens/recover_wallet_screen.dart
+++ b/packages/wallet_kit/lib/wallet_screens/recover_wallet_screen.dart
@@ -19,8 +19,8 @@ class RecoverWalletScreen extends HookConsumerWidget {
         seedPhrase.value == '' ? 0 : seedPhrase.value.trim().split(' ').length;
     final isButtonEnabled = wordsCount == seedPhraseWordsCount;
     final isSeedPhraseValid = ref
-          .read(walletsProvider.notifier)
-          .validateSeedPhrase(seedPhrase: seedPhrase.value);
+        .read(walletsProvider.notifier)
+        .validateSeedPhrase(seedPhrase: seedPhrase.value);
 
     final walletType = useState(WalletType.openZeppelin);
 

--- a/packages/wallet_kit/lib/wallet_screens/recover_wallet_screen.dart
+++ b/packages/wallet_kit/lib/wallet_screens/recover_wallet_screen.dart
@@ -18,33 +18,11 @@ class RecoverWalletScreen extends HookConsumerWidget {
     final wordsCount =
         seedPhrase.value == '' ? 0 : seedPhrase.value.trim().split(' ').length;
     final isButtonEnabled = wordsCount == seedPhraseWordsCount;
-    final walletType = useState(WalletType.openZeppelin);
-    final seedValid = useState(true);
-
-    void handleSeedPhraseChanged(String value) {
-      seedPhrase.value = value;
-      if (!seedValid.value) {
-        seedValid.value = true;
-      }
-    }
-
-    void handleContinuePressed() {
-      final isValid = ref
+    final isSeedPhraseValid = ref
           .read(walletsProvider.notifier)
           .validateSeedPhrase(seedPhrase: seedPhrase.value);
-      if (isValid) {
-        Navigator.of(context).push(
-          MaterialPageRoute(
-            builder: (context) => ProtectWalletScreen(
-              seedPhrase: seedPhrase.value,
-              walletType: walletType.value,
-            ),
-          ),
-        );
-      } else {
-        seedValid.value = false;
-      }
-    }
+
+    final walletType = useState(WalletType.openZeppelin);
 
     return Layout2(
       sideMargin: sideMargin,
@@ -54,7 +32,7 @@ class RecoverWalletScreen extends HookConsumerWidget {
         ),
         TextInput(
           hintText: 'Enter your seed phrase',
-          onChanged: handleSeedPhraseChanged,
+          onChanged: (value) => seedPhrase.value = value,
         ),
         SizedBox(
           width: double.infinity,
@@ -99,11 +77,19 @@ class RecoverWalletScreen extends HookConsumerWidget {
         ),
         const Spacer(),
         PrimaryButton(
-          onPressed: isButtonEnabled ? handleContinuePressed : null,
-          label: seedValid.value ? 'Continue' : 'Invalid Seed Phrase',
-          labelStyle: TextStyle(
-              color: seedValid.value ? Colors.blueAccent : Colors.red),
-        ),
+            onPressed: isButtonEnabled && isSeedPhraseValid
+                ? () {
+                    Navigator.of(context).push(
+                      MaterialPageRoute(
+                        builder: (context) => ProtectWalletScreen(
+                          seedPhrase: seedPhrase.value,
+                          walletType: walletType.value,
+                        ),
+                      ),
+                    );
+                  }
+                : null,
+            label: 'Continue'),
       ],
     );
   }

--- a/packages/wallet_kit/lib/wallet_state/wallet_provider.dart
+++ b/packages/wallet_kit/lib/wallet_state/wallet_provider.dart
@@ -83,6 +83,12 @@ class Wallets extends _$Wallets with PersistedState<WalletsState> {
     );
   }
 
+  bool validateSeedPhrase({
+    required String seedPhrase,
+  }) {
+    return WalletService.validateSeedPhrase(seedPhrase: seedPhrase);
+  }
+
   addWallet({
     required SecureStore secureStore,
     String? seedPhrase,


### PR DESCRIPTION
closes #525

- Added seed phrase validation against BIP32 standards on recovery flow.

- Updated UI to show clear, user-friendly error messaging when an invalid seed phrase is detected.


https://github.com/user-attachments/assets/e376abe0-8f38-4507-97f8-ed520e0615ac



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added validation for seed phrases during wallet recovery, ensuring only valid phrases can proceed to the next step.

* **Bug Fixes**
  * The primary action button on the wallet recovery screen is now enabled only when both the seed phrase word count and validity are correct, improving user guidance and preventing invalid submissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->