### PR TITLE
fix: use WalletKit chainId and provider instead of hardcoded

### DIFF
--- a/packages/wallet_kit/lib/wallet_state/wallet_provider.dart
+++ b/packages/wallet_kit/lib/wallet_state/wallet_provider.dart
@@ -187,8 +187,8 @@ class Wallets extends _$Wallets with PersistedState<WalletsState> {
     }
     return s.Account(
       accountAddress: s.Felt.fromHexString(account.address),
-      chainId: s.Felt.fromString('KATANA'),
-      provider: sp.JsonRpcProvider.devnet,
+      chainId: WalletKit().chainId,
+      provider: WalletKit().provider,
       signer: s.StarkAccountSigner(
         signer: s.StarkSigner(
           privateKey: s.Felt.fromHexString(privateKey),


### PR DESCRIPTION
**Summary of Changes:**
- The construction of the `s.Account` object in `wallet_kit/lib/wallet_state/wallet_provider.dart` was refactored.
- Previously, the `chainId` and `provider` fields were hardcoded to specific values (`'KATANA'` and `sp.JsonRpcProvider.devnet`).
- Now, both `chainId` and `provider` are dynamically sourced from the environment via `WalletKit().chainId` and `WalletKit().provider`.
- This change makes the account setup flexible and environment-aware, allowing the app to adapt to different networks and providers based on runtime configuration.

- Closes #522 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account creation to use the currently configured network and provider, ensuring better compatibility with different environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->