### PR TITLE
fix(wallet_kit): add missing expandable for wallet list

### DIFF
--- a/packages/wallet_kit/lib/widgets/wallet_list.dart
+++ b/packages/wallet_kit/lib/widgets/wallet_list.dart
@@ -306,20 +306,22 @@ class _WalletCellHeader extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ListTile(
-      leading: WalletTypeIcon(type: accountType),
-      title: Text(name, style: Theme.of(context).textTheme.titleMedium),
-      subtitle: Text(
-        '$accountsCount account${accountsCount > 1 ? 's' : ''}',
-        style: Theme.of(context).textTheme.bodyMedium,
-      ),
-      trailing: ExpandableIcon(
-        theme: ExpandableThemeData(
-          expandIcon: Icons.keyboard_arrow_down_rounded,
-          collapseIcon: Icons.keyboard_arrow_up_rounded,
-          iconSize: Theme.of(context).iconTheme.size,
-          iconColor: Theme.of(context).iconTheme.color,
-          useInkWell: false,
+    return ExpandableButton(
+      child: ListTile(
+        leading: WalletTypeIcon(type: accountType),
+        title: Text(name, style: Theme.of(context).textTheme.titleMedium),
+        subtitle: Text(
+          '$accountsCount account${accountsCount > 1 ? 's' : ''}',
+          style: Theme.of(context).textTheme.bodyMedium,
+        ),
+        trailing: ExpandableIcon(
+          theme: ExpandableThemeData(
+            expandIcon: Icons.keyboard_arrow_down_rounded,
+            collapseIcon: Icons.keyboard_arrow_up_rounded,
+            iconSize: Theme.of(context).iconTheme.size,
+            iconColor: Theme.of(context).iconTheme.color,
+            useInkWell: false,
+          ),
         ),
       ),
     );


### PR DESCRIPTION
Closes #541 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the expand/collapse interaction by allowing users to tap anywhere on the wallet list tile, not just the icon, to toggle expansion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->