### PR TITLE
docs: add missing `melos devnet:setup` step

### DIFF
--- a/docs/how-to-contribute.mdx
+++ b/docs/how-to-contribute.mdx
@@ -68,7 +68,14 @@ Start the devnet in one terminal:
 melos devnet:start
 ```
 
-Then run the tests in another terminal:
+In another terminal, run the following command to declare and deploy some contracts to the devnet:
+
+```sh
+source .env.devnet # Load the env variables
+melos devnet:setup
+```
+
+Then run the tests:
 
 ```sh
 melos test


### PR DESCRIPTION
In order to locally run `melos test`, it's required to run `melos devnet:setup` to declare Argent class.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified and expanded instructions for running tests by adding explicit steps for declaring and deploying contracts before test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->