### PR TITLE
feat: add `sensStrk` and `execute` to Wallet provider

### DIFF
--- a/packages/wallet_kit/lib/ui/theme.dart
+++ b/packages/wallet_kit/lib/ui/theme.dart
@@ -39,7 +39,7 @@ final walletThemeData = ThemeData(
   bottomSheetTheme: BottomSheetThemeData(
     backgroundColor: colorScheme.surface,
   ),
-  iconTheme: IconThemeData(color: colorScheme.onSurfaceVariant),
+  iconTheme: IconThemeData(color: colorScheme.onSurfaceVariant, size: 24),
 );
 
 // Spacing

--- a/packages/wallet_kit/lib/wallet_state/wallet_provider.dart
+++ b/packages/wallet_kit/lib/wallet_state/wallet_provider.dart
@@ -271,13 +271,18 @@ class Wallets extends _$Wallets with PersistedState<WalletsState> {
     bool strk = false,
   }) async {
     try {
-      await WalletService.send(
+      final success = await WalletService.send(
         secureStore: secureStore,
         account: account,
         recipientAddress: recipientAddress,
         amount: amount,
         strk: strk,
       );
+      if (success) {
+        await (strk
+            ? refreshStrkBalance(account.walletId, account.id)
+            : refreshEthBalance(account.walletId, account.id));
+      }
     } catch (e) {
       ref.read(walletErrorNotifierProvider.notifier).reportError(
             WalletError.accountError(

--- a/packages/wallet_kit/lib/wallet_state/wallet_provider.dart
+++ b/packages/wallet_kit/lib/wallet_state/wallet_provider.dart
@@ -263,6 +263,82 @@ class Wallets extends _$Wallets with PersistedState<WalletsState> {
     state = state.copyWith(wallets: {}, selected: null);
   }
 
+  _send({
+    required SecureStore secureStore,
+    required Account account,
+    required s.Felt recipientAddress,
+    required double amount,
+    bool strk = false,
+  }) async {
+    try {
+      await WalletService.send(
+        secureStore: secureStore,
+        account: account,
+        recipientAddress: recipientAddress,
+        amount: amount,
+        strk: strk,
+      );
+    } catch (e) {
+      ref.read(walletErrorNotifierProvider.notifier).reportError(
+            WalletError.accountError(
+              message: 'Failed to send ERC20',
+              exception: e,
+            ),
+          );
+    }
+  }
+
+  sendEth({
+    required SecureStore secureStore,
+    required Account account,
+    required s.Felt recipientAddress,
+    required double amount,
+  }) async {
+    await _send(
+      secureStore: secureStore,
+      account: account,
+      recipientAddress: recipientAddress,
+      amount: amount,
+      strk: false,
+    );
+  }
+
+  sendStrk({
+    required SecureStore secureStore,
+    required Account account,
+    required s.Felt recipientAddress,
+    required double amount,
+  }) async {
+    await _send(
+      secureStore: secureStore,
+      account: account,
+      recipientAddress: recipientAddress,
+      amount: amount,
+      strk: true,
+    );
+  }
+
+  execute({
+    required SecureStore secureStore,
+    required Account account,
+    required List<sp.FunctionCall> calls,
+  }) async {
+    try {
+      await WalletService.execute(
+        secureStore: secureStore,
+        account: account,
+        calls: calls,
+      );
+    } catch (e) {
+      ref.read(walletErrorNotifierProvider.notifier).reportError(
+            WalletError.accountError(
+              message: 'Failed to execute calls',
+              exception: e,
+            ),
+          );
+    }
+  }
+
   Future<void> refreshAccount(String walletId, int accountId) async {
     if (_isRefreshing) return;
     _isRefreshing = true;

--- a/packages/wallet_kit/lib/wallet_state/wallet_provider.g.dart
+++ b/packages/wallet_kit/lib/wallet_state/wallet_provider.g.dart
@@ -6,7 +6,7 @@ part of 'wallet_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$walletsHash() => r'47db6e9cbe8905bf1705aa1a2dfc85278e5f977f';
+String _$walletsHash() => r'6adf4a4bdedd7d4e9fb36439204905052e23815d';
 
 /// See also [Wallets].
 @ProviderFor(Wallets)

--- a/packages/wallet_kit/lib/wallet_state/wallet_provider.g.dart
+++ b/packages/wallet_kit/lib/wallet_state/wallet_provider.g.dart
@@ -6,7 +6,7 @@ part of 'wallet_provider.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$walletsHash() => r'f07c78a5cc4df8081453948c02eb2ef183a20607';
+String _$walletsHash() => r'47db6e9cbe8905bf1705aa1a2dfc85278e5f977f';
 
 /// See also [Wallets].
 @ProviderFor(Wallets)

--- a/packages/wallet_kit/lib/widgets/send_eth_button.dart
+++ b/packages/wallet_kit/lib/widgets/send_eth_button.dart
@@ -2,9 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:starknet/starknet.dart' as s;
 
-import '../services/index.dart';
 import '../ui/index.dart';
-import '../wallet_screens/index.dart';
 import '../wallet_state/index.dart';
 
 final recipientAddress = s.Felt.fromHexString(
@@ -28,15 +26,15 @@ class SendEthButton extends HookConsumerWidget {
       label: 'Send',
       onPressed: selectedAccount.isDeployed
           ? () async {
-              final password = await showPasswordModal(context);
-              if (password == null) {
-                throw Exception('Password is required');
-              }
-              await sendEth(
-                  account: selectedAccount,
-                  password: password,
-                  recipientAddress: recipientAddress,
-                  amount: 0.001);
+              final secureStore = await ref
+                  .read(walletsProvider.notifier)
+                  .getSecureStoreForWallet(context: context);
+              await ref.read(walletsProvider.notifier).sendEth(
+                    secureStore: secureStore,
+                    account: selectedAccount,
+                    recipientAddress: recipientAddress,
+                    amount: 0.001,
+                  );
             }
           : null,
     );


### PR DESCRIPTION
`execute` allow an account to make a muticall transaction

- add missing icon size in default theme
- fix `sendEth` button


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Send ETH and STRK directly from the wallet.
  - Execute multiple contract calls in a single action.

- Refactor
  - Replaced password prompts with a secure storage flow when sending funds.
  - Centralized transfer and execution logic with improved error handling.

- UI/Style
  - Standardized icon size for consistent appearance.

- Chores
  - Updated generated provider metadata (no user-facing impact).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->